### PR TITLE
update docker push to push docker images with latest tag

### DIFF
--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -7,6 +7,9 @@ set -o pipefail
 GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
 DOCKER_REPO="accurics/terrascan"
 DOCKERFILE="./build/Dockerfile"
+LATEST_TAG="latest"
 
 # PS: It is a prerequisite to execute 'docker login' before running this script
+docker tag ${DOCKER_REPO}:${GIT_COMMIT} ${DOCKER_REPO}:${LATEST_TAG}
 docker push ${DOCKER_REPO}:${GIT_COMMIT}
+docker push ${DOCKER_REPO}:${LATEST_TAG}


### PR DESCRIPTION
Currently terrascan docker images are tagged with commit ID, the commits made to master should also be tagged as `latest`