### PR TITLE
fix xml output

### DIFF
--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -1,6 +1,8 @@
 package policy
 
 import (
+	"encoding/xml"
+
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
 	"github.com/accurics/terrascan/pkg/results"
 )
@@ -12,5 +14,6 @@ type EngineInput struct {
 
 // EngineOutput Contains data output from the engine
 type EngineOutput struct {
-	*results.ViolationStore `json:"results" yaml:"results" xml:"results,attr"`
+	XMLName                 xml.Name `json:"-" yaml:"-" xml:"results"`
+	*results.ViolationStore `json:"results" yaml:"results" xml:"results"`
 }

--- a/pkg/results/types.go
+++ b/pkg/results/types.go
@@ -42,6 +42,6 @@ type ViolationStats struct {
 
 // ViolationStore Storage area for violation data
 type ViolationStore struct {
-	Violations []*Violation   `json:"violations" yaml:"violations" xml:"violations,attr"`
-	Count      ViolationStats `json:"count" yaml:"count" xml:"count,attr"`
+	Violations []*Violation   `json:"violations" yaml:"violations" xml:"violations>violation"`
+	Count      ViolationStats `json:"count" yaml:"count" xml:"count"`
 }


### PR DESCRIPTION
Fixes #290 

This fix creates an xml output:
``` xml
<results>
  <violations>
    <violation rule_name="cloudfrontNoLogging" description="Ensure that your AWS Cloudfront distributions have the Logging feature enabled in order to track all viewer requests for the content delivered through the Content Delivery Network (CDN)." rule_id="AWS.CloudFront.Logging.Medium.0567" severity="MEDIUM" category="Logging" resource_name="s3-distribution-TLS-v1" resource_type="aws_cloudfront_distribution" file="aws_cloudfront_distribution.tf" line="7"></violation>
    <violation rule_name="cloudfrontNoSecureCiphers" description="Secure ciphers are not used in CloudFront distribution" rule_id="AWS.CloudFront.EncryptionandKeyManagement.High.0408" severity="HIGH" category="Encryption and Key Management" resource_name="s3-distribution-TLS-v1" resource_type="aws_cloudfront_distribution" file="aws_cloudfront_distribution.tf" line="7"></violation>
    <violation rule_name="cloudfrontNoHTTPSTraffic" description="Use encrypted connection between CloudFront and origin server" rule_id="AWS.CloudFront.EncryptionandKeyManagement.High.0407" severity="HIGH" category="Encryption and Key Management" resource_name="s3-distribution-TLS-v1" resource_type="aws_cloudfront_distribution" file="aws_cloudfront_distribution.tf" line="7"></violation>
    <violation rule_name="cloudfrontNoHTTPSTraffic" description="Use encrypted connection between CloudFront and origin server" rule_id="AWS.CloudFront.EncryptionandKeyManagement.High.0407" severity="HIGH" category="Encryption and Key Management" resource_name="s3-distribution-TLS-v1" resource_type="aws_cloudfront_distribution" file="aws_cloudfront_distribution.tf" line="7"></violation>
    <violation rule_name="cloudfrontNoGeoRestriction" description="Ensure that geo restriction is enabled for your Amazon CloudFront CDN distribution to whitelist or blacklist a country in order to allow or restrict users in specific locations from accessing web application content." rule_id="AWS.CloudFront.Network Security.Low.0568" severity="LOW" category="Network Security" resource_name="s3-distribution-TLS-v1" resource_type="aws_cloudfront_distribution" file="aws_cloudfront_distribution.tf" line="7"></violation>
  </violations>
  <count low="1" medium="1" high="3" total="5"></count>
</results>
```