### PR TITLE
Fixes docker latest tag

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -55,5 +55,5 @@ jobs:
       run: make docker-push
 
     - name: Push Terrascan latest docker image
-      if: github.ref == 'refs/heads/master'
+      if: ${{ github.ref == 'refs/heads/master' }}
       run: make docker-push-latest

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -55,5 +55,5 @@ jobs:
       run: make docker-push
 
     - name: Push Terrascan latest docker image
-      if: ${{ github.ref == 'refs/heads/master' }}
+      if: github.ref == 'refs/heads/master'
       run: make docker-push-latest

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Push Terrascan docker image
       run: make docker-push
-    
+
     - name: Push Terrascan latest docker image
-      if: ${{ github.ref == 'ref/head/master' }}
+      if: ${{ github.ref == 'refs/heads/master' }}
       run: make docker-push-latest


### PR DESCRIPTION
This fixes a bug (#294) that's preventing the latest docker image from being pushed to DockerHub. 
