### PR TITLE
fix template rendering bug

### DIFF
--- a/pkg/policy/opa/engine.go
+++ b/pkg/policy/opa/engine.go
@@ -185,7 +185,7 @@ func (e *Engine) LoadRegoFiles(policyPath string) error {
 			}
 
 			regoDataList[j].RawRego = templateData.Bytes()
-			e.regoDataMap[regoDataList[j].Metadata.Name] = regoDataList[j]
+			e.regoDataMap[regoDataList[j].Metadata.ReferenceID] = regoDataList[j]
 		}
 	}
 


### PR DESCRIPTION
- templates were only being rendered once per file, rather than once per rule
- thus, the first render for each file would win, and violations could trigger (or be missed) if using a shared template