### PR TITLE
fixed a bug in checkIpForward

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_compute_instance/accurics.gcp.NS.130.json
+++ b/pkg/policies/opa/rego/gcp/google_compute_instance/accurics.gcp.NS.130.json
@@ -1,7 +1,10 @@
 {
     "name": "checkIpForward",
     "file": "checkIpForward.rego",
-    "template_args": null,
+    "template_args": {
+        "prefix":"",
+        "suffix":""
+    },
     "severity": "MEDIUM",
     "description": "Ensure IP forwarding is not enabled on Instances.",
     "reference_id": "accurics.gcp.NS.130",

--- a/pkg/policies/opa/rego/gcp/google_compute_instance/checkIpForward.rego
+++ b/pkg/policies/opa/rego/gcp/google_compute_instance/checkIpForward.rego
@@ -1,7 +1,8 @@
 package accurics
 
-checkIpForward[api.id]
+{{.prefix}}{{.name}}{{.suffix}}[api.id]
 {
      api := input.google_compute_instance[_]
-     not api.config.can_ip_forward == true
+     api.config.can_ip_forward == true
 }
+


### PR DESCRIPTION
"not api.config.can_ip_forward == true" should be "api.config.can_ip_forward == true"
by default, can_ip_forward is false, so no need to check for existence of the key before
checking if can_ip_forward is true

Fixes #320 