### PR TITLE
Revert "fixed a bug in checkIpForward"

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_compute_instance/accurics.gcp.NS.130.json
+++ b/pkg/policies/opa/rego/gcp/google_compute_instance/accurics.gcp.NS.130.json
@@ -1,10 +1,7 @@
 {
     "name": "checkIpForward",
     "file": "checkIpForward.rego",
-    "template_args": {
-        "prefix":"",
-        "suffix":""
-    },
+    "template_args": null,
     "severity": "MEDIUM",
     "description": "Ensure IP forwarding is not enabled on Instances.",
     "reference_id": "accurics.gcp.NS.130",

--- a/pkg/policies/opa/rego/gcp/google_compute_instance/checkIpForward.rego
+++ b/pkg/policies/opa/rego/gcp/google_compute_instance/checkIpForward.rego
@@ -1,8 +1,7 @@
 package accurics
 
-{{.prefix}}{{.name}}{{.suffix}}[api.id]
+checkIpForward[api.id]
 {
      api := input.google_compute_instance[_]
-     api.config.can_ip_forward == true
+     not api.config.can_ip_forward == true
 }
-


### PR DESCRIPTION
Reverts accurics/terrascan#321

The #321 change worked locally, but caused an issue once merged to master

```
$ terrascan scan -t gcp
2020-09-14T14:06:26.303-0400    error   opa/engine.go:206       error compiling rego files{rule 15 0 checkIpForward <nil>} {raw rego 15 0 package accurics

<no value>[api.id]
{
     api := input.google_compute_instance[_]
     api.config.can_ip_forward == true
}

 <nil>} {error 25 0  1 error occurred: checkIpForward:3: rego_parse_error: unexpected lt token
        <no value>[api.id]
        ^}
2020-09-14T14:06:26.303-0400    error   opa/engine.go:242       error compiling rego files{policy path 15 0 /Users/therasec/.terrascan/pkg/policies/opa/rego/gcp <nil>}
2020-09-14T14:06:26.303-0400    error   opa/engine.go:56        failed to initialize OPA policy engine
2020-09-14T14:06:26.303-0400    error   runtime/executor.go:88  failed to create policy engine. error: 'failed to initialize OPA policy engine'
```