### PR TITLE
Automatically populate usage with supported IaC providers, versions, and policies

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -17,6 +17,11 @@
 package cli
 
 import (
+	"fmt"
+	"strings"
+
+	iacProvider "github.com/accurics/terrascan/pkg/iac-providers"
+	"github.com/accurics/terrascan/pkg/policy"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -57,8 +62,8 @@ func scan(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	scanCmd.Flags().StringVarP(&PolicyType, "policy-type", "t", "", "<required> policy type (aws, azure, gcp, k8s)")
-	scanCmd.Flags().StringVarP(&IacType, "iac-type", "i", "", "iac type (terraform, k8s)")
+	scanCmd.Flags().StringVarP(&PolicyType, "policy-type", "t", "", fmt.Sprintf("<required> policy type (%v)", strings.Join(policy.SupportedPolicyTypes(), ", ")))
+	scanCmd.Flags().StringVarP(&IacType, "iac-type", "i", "", fmt.Sprintf("iac type (%v)", strings.Join(iacProvider.SupportedIacProviders(), ", ")))
 	scanCmd.Flags().StringVarP(&IacVersion, "iac-version", "", "", "iac version terraform:(v12) k8s:(v1)")
 	scanCmd.Flags().StringVarP(&IacFilePath, "iac-file", "f", "", "path to a single IaC file")
 	scanCmd.Flags().StringVarP(&IacDirPath, "iac-dir", "d", ".", "path to a directory containing one or more IaC files")

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -64,7 +64,7 @@ func scan(cmd *cobra.Command, args []string) {
 func init() {
 	scanCmd.Flags().StringVarP(&PolicyType, "policy-type", "t", "", fmt.Sprintf("<required> policy type (%v)", strings.Join(policy.SupportedPolicyTypes(), ", ")))
 	scanCmd.Flags().StringVarP(&IacType, "iac-type", "i", "", fmt.Sprintf("iac type (%v)", strings.Join(iacProvider.SupportedIacProviders(), ", ")))
-	scanCmd.Flags().StringVarP(&IacVersion, "iac-version", "", "", "iac version terraform:(v12) k8s:(v1)")
+	scanCmd.Flags().StringVarP(&IacVersion, "iac-version", "", "", fmt.Sprintf("iac version (%v)", strings.Join(iacProvider.SupportedIacVersions(), ", ")))
 	scanCmd.Flags().StringVarP(&IacFilePath, "iac-file", "f", "", "path to a single IaC file")
 	scanCmd.Flags().StringVarP(&IacDirPath, "iac-dir", "d", ".", "path to a directory containing one or more IaC files")
 	scanCmd.Flags().StringVarP(&PolicyPath, "policy-path", "p", "", "policy path directory")

--- a/pkg/iac-providers/providers.go
+++ b/pkg/iac-providers/providers.go
@@ -19,6 +19,8 @@ package iacprovider
 import (
 	"fmt"
 	"reflect"
+	"sort"
+	"strings"
 
 	"go.uber.org/zap"
 )
@@ -54,8 +56,24 @@ func IsIacSupported(iacType, iacVersion string) bool {
 // SupportedIacProviders returns list of Iac Providers supported in terrascan
 func SupportedIacProviders() []string {
 	var iacTypes []string
-	for k, _ := range supportedIacProviders {
+	for k := range supportedIacProviders {
 		iacTypes = append(iacTypes, string(k))
 	}
+	sort.Strings(iacTypes)
 	return iacTypes
+}
+
+// SupportedIacVersions retuns a string of Iac providers and corresponding supported versions
+func SupportedIacVersions() []string {
+	var iacVersions []string
+	for iac, versions := range supportedIacProviders {
+		var versionSlice []string
+		for k := range versions {
+			versionSlice = append(versionSlice, string(k))
+		}
+		versionString := strings.Join(versionSlice, ", ")
+		iacVersions = append(iacVersions, fmt.Sprintf("%s: %s", string(iac), versionString))
+	}
+	sort.Strings(iacVersions)
+	return iacVersions
 }

--- a/pkg/iac-providers/providers.go
+++ b/pkg/iac-providers/providers.go
@@ -50,3 +50,12 @@ func IsIacSupported(iacType, iacVersion string) bool {
 	}
 	return true
 }
+
+// SupportedIacProviders returns list of Iac Providers supported in terrascan
+func SupportedIacProviders() []string {
+	var iacTypes []string
+	for k, _ := range supportedIacProviders {
+		iacTypes = append(iacTypes, string(k))
+	}
+	return iacTypes
+}

--- a/pkg/iac-providers/providers_test.go
+++ b/pkg/iac-providers/providers_test.go
@@ -111,3 +111,16 @@ func TestIsIacSupported(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportedIacProviders(t *testing.T) {
+	t.Run("supported iac providers", func(t *testing.T) {
+		var want []string
+		for k := range supportedIacProviders {
+			want = append(want, string(k))
+		}
+		got := SupportedIacProviders()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: '%v', want: '%v'", got, want)
+		}
+	})
+}

--- a/pkg/policy/cloud-providers.go
+++ b/pkg/policy/cloud-providers.go
@@ -17,6 +17,8 @@
 package policy
 
 import (
+	"sort"
+
 	"github.com/accurics/terrascan/pkg/config"
 )
 
@@ -77,5 +79,6 @@ func SupportedPolicyTypes() []string {
 	for k := range supportedCloudProvider {
 		policyTypes = append(policyTypes, string(k))
 	}
+	sort.Strings(policyTypes)
 	return policyTypes
 }

--- a/pkg/policy/cloud-providers.go
+++ b/pkg/policy/cloud-providers.go
@@ -74,7 +74,7 @@ func GetDefaultIacVersion(cloudType string) string {
 // SupportedPolicyTypes returns the list of policies supported in terrascan
 func SupportedPolicyTypes() []string {
 	var policyTypes []string
-	for k, _ := range supportedCloudProvider {
+	for k := range supportedCloudProvider {
 		policyTypes = append(policyTypes, string(k))
 	}
 	return policyTypes

--- a/pkg/policy/cloud-providers.go
+++ b/pkg/policy/cloud-providers.go
@@ -70,3 +70,12 @@ func GetDefaultIacType(cloudType string) string {
 func GetDefaultIacVersion(cloudType string) string {
 	return string(defaultIacVersion[supportedCloudType(cloudType)])
 }
+
+// SupportedPolicyTypes returns the list of policies supported in terrascan
+func SupportedPolicyTypes() []string {
+	var policyTypes []string
+	for k, _ := range supportedCloudProvider {
+		policyTypes = append(policyTypes, string(k))
+	}
+	return policyTypes
+}

--- a/pkg/policy/cloud-providers_test.go
+++ b/pkg/policy/cloud-providers_test.go
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2020 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package policy
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSupportedPolicyTypes(t *testing.T) {
+	t.Run("supported policy types", func(t *testing.T) {
+		var want []string
+		for k := range supportedCloudProvider {
+			want = append(want, string(k))
+		}
+		sort.Strings(want)
+		got := SupportedPolicyTypes()
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: '%v', want: '%v'", got, want)
+		}
+	})
+}


### PR DESCRIPTION
This PR removes the need to manually update the usage whenever a new policy or iac support is added.

Updated usage looks like:
```sh
Terrascan

Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.

Usage:
  terrascan scan [flags]

Flags:
      --config-only          will output resource config (should only be used for debugging purposes)
  -h, --help                 help for scan
  -d, --iac-dir string       path to a directory containing one or more IaC files (default ".")
  -f, --iac-file string      path to a single IaC file
  -i, --iac-type string      iac type (k8s, terraform)
      --iac-version string   iac version (k8s: v1, terraform: v12)
  -p, --policy-path string   policy path directory
  -t, --policy-type string   <required> policy type (aws, azure, gcp, k8s)

Global Flags:
  -c, --config-path string   config file path
  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
  -x, --log-type string      log output type (console, json) (default "console")
  -o, --output string        output type (json, yaml, xml) (default "yaml")
```