### PR TITLE
Allow use of multiple policy types (scan -t x,y or scan -t x -t y)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ for more information on how to use the server endpoints.
 To scan your code for security issues you can run the following
 
 ```sh
-$ terrascan scan -t all
+$ terrascan scan
 ```
 Terrascan will exit 3 if any issues are found.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ for more information on how to use the server endpoints.
 To scan your code for security issues you can run the following
 
 ```sh
-$ terrascan scan -t aws
+$ terrascan scan -t all
 ```
 Terrascan will exit 3 if any issues are found.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,11 +83,22 @@ Use "terrascan [command] --help" for more information about a command.
 The initialization process downloads the latest policies from the [repository](https://github.com/accurics/terrascan) into `~/.terrascan`. The policies are located at `~/.terrascan/pkg/policies/opa/rego` and are fetched when scanning the IaC. This command is implicitly executed if the `scan` command doesn't found policies while executing.
 
 ### Scanning
-The CLI will default to the `scan` command if no other subcommands are used. For example, the below two commands will scan the current directory containing Terraform HCL2 files for supported cloud provider (AWS, GCP, and Azure) resources:
+The CLI will default to scanning all supported cloud providers on Terraform HCL files if the `scan` command is used with no arguments. For example, the below two commands will scan the current directory containing Terraform HCL2 files for supported cloud providers (AWS, GCP, and Azure) resources:
 
 ``` Bash
-$ terrascan -t all
-$ terrascan scan -t all
+$ terrascan scan
+```
+
+Individual cloud providers can be specified using the -t flag as follows:
+
+``` Bash
+$ terrascan scan -t aws
+```
+
+By default Terrascan defaults to scanning Terraform HCL files, you can change the IaC provider using the -i flag. Here's an example of scanning kubernetes yaml files:
+
+``` Bash
+$ terrascan scan -t k8s -i k8s
 ```
 
 The `scan` command support flags to configure: the directory being scanned, scanning of a specific file, IaC provier type, path to policies, and policy type. The full list of flags can be found by typing `terrascan scan -h`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,11 +83,11 @@ Use "terrascan [command] --help" for more information about a command.
 The initialization process downloads the latest policies from the [repository](https://github.com/accurics/terrascan) into `~/.terrascan`. The policies are located at `~/.terrascan/pkg/policies/opa/rego` and are fetched when scanning the IaC. This command is implicitly executed if the `scan` command doesn't found policies while executing.
 
 ### Scanning
-The CLI will default to the `scan` command if no other subcommands are used. For example, the below two commands will scan the current directory containing Terraform HCL2 files for AWS resources:
+The CLI will default to the `scan` command if no other subcommands are used. For example, the below two commands will scan the current directory containing Terraform HCL2 files for supported cloud provider (AWS, GCP, and Azure) resources:
 
 ``` Bash
-$ terrascan -t aws
-$ terrascan scan -t aws
+$ terrascan -t all
+$ terrascan scan -t all
 ```
 
 The `scan` command support flags to configure: the directory being scanned, scanning of a specific file, IaC provier type, path to policies, and policy type. The full list of flags can be found by typing `terrascan scan -h`
@@ -102,14 +102,17 @@ Usage:
   terrascan scan [flags]
 
 Flags:
-      --config-only          will output resource config (should only be used for debugging purposes)
-  -h, --help                 help for scan
-  -d, --iac-dir string       path to a directory containing one or more IaC files (default ".")
-  -f, --iac-file string      path to a single IaC file
-  -i, --iac-type string      iac type (terraform, k8s)
-      --iac-version string   iac version terraform:(v12) k8s:(v1)
-  -p, --policy-path string   policy path directory
-  -t, --policy-type string   <required> policy type (aws, azure, gcp, k8s, github)
+      --config-only               will output resource config (should only be used for debugging purposes)
+  -h, --help                      help for scan
+  -d, --iac-dir string            path to a directory containing one or more IaC files (default ".")
+  -f, --iac-file string           path to a single IaC file
+  -i, --iac-type string           iac type (k8s, terraform)
+      --iac-version string        iac version (k8s: v1, terraform: v12)
+  -p, --policy-path stringArray   policy path directory
+  -t, --policy-type strings       policy type (all, aws, azure, gcp, github, k8s) (default [all])
+  -r, --remote-type string        type of remote backend (git, s3, gcs, http)
+  -u, --remote-url string         url pointing to remote IaC repository
+      --use-colors string         color output (auto, t, f) (default "auto")
 
 Global Flags:
   -c, --config-path string   config file path

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -29,8 +29,9 @@ import (
 )
 
 // Run executes terrascan in CLI mode
-func Run(iacType, iacVersion, cloudType, iacFilePath, iacDirPath, configFile,
-	policyPath, format, remoteType, remoteURL string, configOnly, useColors bool) {
+func Run(iacType, iacVersion string, cloudType []string,
+	iacFilePath, iacDirPath, configFile string, policyPath []string,
+	format, remoteType, remoteURL string, configOnly, useColors bool) {
 
 	// temp dir to download the remote repo
 	tempDir := filepath.Join(os.TempDir(), utils.GenRandomString(6))

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -25,7 +25,7 @@ func TestRun(t *testing.T) {
 		name        string
 		iacType     string
 		iacVersion  string
-		cloudType   string
+		cloudType   []string
 		iacFilePath string
 		iacDirPath  string
 		configFile  string
@@ -36,23 +36,23 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			name:       "normal terraform run",
-			cloudType:  "terraform",
+			cloudType:  []string{"terraform"},
 			iacDirPath: "testdata/run-test",
 		},
 		{
 			name:       "normal k8s run",
-			cloudType:  "k8s",
+			cloudType:  []string{"k8s"},
 			iacDirPath: "testdata/run-test",
 		},
 		{
 			name:        "config-only flag terraform",
-			cloudType:   "terraform",
+			cloudType:   []string{"terraform"},
 			iacFilePath: "testdata/run-test/config-only.tf",
 			configOnly:  true,
 		},
 		{
 			name:        "config-only flag k8s",
-			cloudType:   "k8s",
+			cloudType:   []string{"k8s"},
 			iacFilePath: "testdata/run-test/config-only.yaml",
 			configOnly:  true,
 		},
@@ -60,7 +60,7 @@ func TestRun(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			Run(tt.iacType, tt.iacVersion, tt.cloudType, tt.iacFilePath, tt.iacDirPath, tt.configFile, "", "", "", "", tt.configOnly, false)
+			Run(tt.iacType, tt.iacVersion, tt.cloudType, tt.iacFilePath, tt.iacDirPath, tt.configFile, []string{}, "", "", "", tt.configOnly, false)
 		})
 	}
 }

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -30,10 +30,10 @@ import (
 
 var (
 	// PolicyPath Policy path directory
-	PolicyPath string
+	PolicyPath []string
 
 	// PolicyType Cloud type (aws, azure, gcp, github)
-	PolicyType string
+	PolicyType []string
 
 	// IacType IaC type (terraform)
 	IacType string
@@ -104,17 +104,16 @@ func scan(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	scanCmd.Flags().StringVarP(&PolicyType, "policy-type", "t", "", fmt.Sprintf("<required> policy type (%v)", strings.Join(policy.SupportedPolicyTypes(), ", ")))
+	scanCmd.Flags().StringSliceVarP(&PolicyType, "policy-type", "t", []string{"all"}, fmt.Sprintf("policy type (%s)", strings.Join(policy.SupportedPolicyTypes(true), ", ")))
 	scanCmd.Flags().StringVarP(&IacType, "iac-type", "i", "", fmt.Sprintf("iac type (%v)", strings.Join(iacProvider.SupportedIacProviders(), ", ")))
 	scanCmd.Flags().StringVarP(&IacVersion, "iac-version", "", "", fmt.Sprintf("iac version (%v)", strings.Join(iacProvider.SupportedIacVersions(), ", ")))
 	scanCmd.Flags().StringVarP(&IacFilePath, "iac-file", "f", "", "path to a single IaC file")
 	scanCmd.Flags().StringVarP(&IacDirPath, "iac-dir", "d", ".", "path to a directory containing one or more IaC files")
-	scanCmd.Flags().StringVarP(&PolicyPath, "policy-path", "p", "", "policy path directory")
+	scanCmd.Flags().StringArrayVarP(&PolicyPath, "policy-path", "p", []string{}, "policy path directory")
 	scanCmd.Flags().StringVarP(&RemoteType, "remote-type", "r", "", "type of remote backend (git, s3, gcs, http)")
 	scanCmd.Flags().StringVarP(&RemoteURL, "remote-url", "u", "", "url pointing to remote IaC repository")
 	scanCmd.Flags().BoolVarP(&ConfigOnly, "config-only", "", false, "will output resource config (should only be used for debugging purposes)")
 	// flag passes a string, but we normalize to bool in PreRun
 	scanCmd.Flags().StringVar(&useColors, "use-colors", "auto", "color output (auto, t, f)")
-	scanCmd.MarkFlagRequired("policy-type")
 	RegisterCommand(rootCmd, scanCmd)
 }

--- a/pkg/http-server/file-scan.go
+++ b/pkg/http-server/file-scan.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/accurics/terrascan/pkg/runtime"
 	"github.com/gorilla/mux"
@@ -36,7 +37,7 @@ func (g *APIHandler) scanFile(w http.ResponseWriter, r *http.Request) {
 	var (
 		iacType    = params["iac"]
 		iacVersion = params["iacVersion"]
-		cloudType  = params["cloud"]
+		cloudType  = strings.Split(params["cloud"], ",")
 	)
 
 	// parse multipart form, 10 << 20 specifies maximum upload of 10 MB files
@@ -85,10 +86,10 @@ func (g *APIHandler) scanFile(w http.ResponseWriter, r *http.Request) {
 	var executor *runtime.Executor
 	if g.test {
 		executor, err = runtime.NewExecutor(iacType, iacVersion, cloudType,
-			tempFile.Name(), "", "", "./testdata/testpolicies")
+			tempFile.Name(), "", "", []string{"./testdata/testpolicies"})
 	} else {
 		executor, err = runtime.NewExecutor(iacType, iacVersion, cloudType,
-			tempFile.Name(), "", "", "")
+			tempFile.Name(), "", "", []string{})
 	}
 	if err != nil {
 		zap.S().Error(err)

--- a/pkg/http-server/remote-repo.go
+++ b/pkg/http-server/remote-repo.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/accurics/terrascan/pkg/downloader"
 	"github.com/accurics/terrascan/pkg/runtime"
@@ -48,7 +49,7 @@ func (g *APIHandler) scanRemoteRepo(w http.ResponseWriter, r *http.Request) {
 		// url params
 		iacType    = params["iac"]
 		iacVersion = params["iacVersion"]
-		cloudType  = params["cloud"]
+		cloudType  = strings.Split(params["cloud"], ",")
 	)
 
 	// read request body
@@ -64,10 +65,10 @@ func (g *APIHandler) scanRemoteRepo(w http.ResponseWriter, r *http.Request) {
 	s.d = downloader.NewDownloader()
 	var results interface{}
 	if g.test {
-		results, err = s.ScanRemoteRepo(iacType, iacVersion, cloudType, "./testdata/testpolicies")
+		results, err = s.ScanRemoteRepo(iacType, iacVersion, cloudType, []string{"./testdata/testpolicies"})
 
 	} else {
-		results, err = s.ScanRemoteRepo(iacType, iacVersion, cloudType, "")
+		results, err = s.ScanRemoteRepo(iacType, iacVersion, cloudType, []string{})
 	}
 	if err != nil {
 		apiErrorResponse(w, err.Error(), http.StatusBadRequest)
@@ -89,7 +90,7 @@ func (g *APIHandler) scanRemoteRepo(w http.ResponseWriter, r *http.Request) {
 
 // ScanRemoteRepo is the actual method where a remote repo is downloaded and
 // scanned for violations
-func (s *scanRemoteRepoReq) ScanRemoteRepo(iacType, iacVersion, cloudType, policyPath string) (interface{}, error) {
+func (s *scanRemoteRepoReq) ScanRemoteRepo(iacType, iacVersion string, cloudType []string, policyPath []string) (interface{}, error) {
 
 	// return params
 	var (

--- a/pkg/http-server/remote-repo_test.go
+++ b/pkg/http-server/remote-repo_test.go
@@ -30,7 +30,7 @@ func TestScanRemoteRepo(t *testing.T) {
 		name       string
 		iacType    string
 		iacVersion string
-		cloudType  string
+		cloudType  []string
 		s          *scanRemoteRepoReq
 		wantOutput interface{}
 		wantErr    error
@@ -69,7 +69,7 @@ func TestScanRemoteRepo(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOutput, gotErr := tt.s.ScanRemoteRepo(tt.iacType, tt.iacVersion, tt.cloudType, "")
+			gotOutput, gotErr := tt.s.ScanRemoteRepo(tt.iacType, tt.iacVersion, tt.cloudType, []string{})
 			if !reflect.DeepEqual(gotErr, tt.wantErr) {
 				t.Errorf("error got: '%v', want: '%v'", gotErr, tt.wantErr)
 			}

--- a/pkg/policy/all.go
+++ b/pkg/policy/all.go
@@ -1,0 +1,27 @@
+/*
+    Copyright (C) 2020 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package policy
+
+const (
+	defaultAllIacType    supportedIacType    = "terraform"
+	defaultAllIacVersion supportedIacVersion = "v12"
+)
+
+func init() {
+	// Register all as a cloud provider with terrascan
+	RegisterIndirectCloudProvider("all", defaultAllIacType, defaultAllIacVersion, func() []string { return SupportedPolicyTypes(false) })
+}

--- a/pkg/policy/all_test.go
+++ b/pkg/policy/all_test.go
@@ -22,30 +22,28 @@ import (
 	"testing"
 )
 
-func TestSupportedPolicyTypes(t *testing.T) {
-	t.Run("supported policy types", func(t *testing.T) {
-		var want []string
-		for k := range supportedCloudProvider {
-			want = append(want, string(k))
-		}
+func TestPolicyTypeAllExpandedCorrectly(t *testing.T) {
+	t.Run("policy type all gets right policy names", func(t *testing.T) {
+
+		want := SupportedPolicyTypes(false)
+		got := supportedCloudProvider["all"].policyNames()
+
 		sort.Strings(want)
-		got := SupportedPolicyTypes(true)
+		sort.Strings(got)
+
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got: '%v', want: '%v'", got, want)
 		}
 	})
-}
 
-func TestSupportedNotIndirectPolicyTypes(t *testing.T) {
-	t.Run("supported policy types", func(t *testing.T) {
-		var want []string
-		for k, v := range supportedCloudProvider {
-			if !v.isIndirect {
-				want = append(want, string(k))
-			}
-		}
+	t.Run("policy type all gets right policy paths", func(t *testing.T) {
+
+		want := GetDefaultPolicyPaths(SupportedPolicyTypes(false))
+		got := GetDefaultPolicyPaths([]string{"all"})
+
 		sort.Strings(want)
-		got := SupportedPolicyTypes(false)
+		sort.Strings(got)
+
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got: '%v', want: '%v'", got, want)
 		}

--- a/pkg/policy/cloud-providers.go
+++ b/pkg/policy/cloud-providers.go
@@ -75,7 +75,6 @@ func RegisterIndirectCloudProvider(cloudType supportedCloudType, iacTypeDefault 
 	registerActualCloudProvider(cloudType, iacTypeDefault, iacVersionDefault, true, getPolicyNames)
 }
 
-// IsCloudProviderSupported returns whether a cloud provider is supported in terrascan
 // RegisterCloudProvider registers a cloud provider with terrascan
 func RegisterCloudProvider(cloudType supportedCloudType, iacTypeDefault supportedIacType, iacVersionDefault supportedIacVersion) {
 	registerActualCloudProvider(cloudType, iacTypeDefault, iacVersionDefault, false, func() []string { return []string{basePolicyPath + "/" + string(cloudType)} })

--- a/pkg/policy/cloud-providers_test.go
+++ b/pkg/policy/cloud-providers_test.go
@@ -29,7 +29,23 @@ func TestSupportedPolicyTypes(t *testing.T) {
 			want = append(want, string(k))
 		}
 		sort.Strings(want)
-		got := SupportedPolicyTypes()
+		got := SupportedPolicyTypes(true)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got: '%v', want: '%v'", got, want)
+		}
+	})
+}
+
+func TestSupportediNotIndirectPolicyTypes(t *testing.T) {
+	t.Run("supported policy types", func(t *testing.T) {
+		var want []string
+		for k, v := range supportedCloudProvider {
+			if !v.isIndirect {
+				want = append(want, string(k))
+			}
+		}
+		sort.Strings(want)
+		got := SupportedPolicyTypes(false)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got: '%v', want: '%v'", got, want)
 		}

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -18,6 +18,7 @@ type EngineOutput struct {
 	*results.ViolationStore `json:"results" yaml:"results" xml:"results"`
 }
 
+// EngineOutputFromViolationStore returns an EngineOutput intialized from ViolationStore
 func EngineOutputFromViolationStore(store *results.ViolationStore) EngineOutput {
 	return EngineOutput{
 		xml.Name{},
@@ -25,6 +26,7 @@ func EngineOutputFromViolationStore(store *results.ViolationStore) EngineOutput 
 	}
 }
 
+// AsViolationStore returns EngineOutput as a ViolationStore
 func (me EngineOutput) AsViolationStore() results.ViolationStore {
 	if me.ViolationStore == nil {
 		return results.ViolationStore{}

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -17,3 +17,20 @@ type EngineOutput struct {
 	XMLName                 xml.Name `json:"-" yaml:"-" xml:"results"`
 	*results.ViolationStore `json:"results" yaml:"results" xml:"results"`
 }
+
+func EngineOutputFromViolationStore(store *results.ViolationStore) EngineOutput {
+	return EngineOutput{
+		xml.Name{},
+		store,
+	}
+}
+
+func (me EngineOutput) AsViolationStore() results.ViolationStore {
+	if me.ViolationStore == nil {
+		return results.ViolationStore{}
+	}
+	return results.ViolationStore{
+		Violations: me.Violations,
+		Count:      me.Count,
+	}
+}

--- a/pkg/results/types.go
+++ b/pkg/results/types.go
@@ -45,3 +45,17 @@ type ViolationStore struct {
 	Violations []*Violation   `json:"violations" yaml:"violations" xml:"violations>violation"`
 	Count      ViolationStats `json:"count" yaml:"count" xml:"count"`
 }
+
+// Add adds two ViolationStores
+func (vs ViolationStore) Add(extra ViolationStore) ViolationStore {
+	// Just concatenate the slices, since order shouldn't be important
+	vs.Violations = append(vs.Violations, extra.Violations...)
+
+	// Add the counts
+	vs.Count.LowCount += extra.Count.LowCount
+	vs.Count.MediumCount += extra.Count.MediumCount
+	vs.Count.HighCount += extra.Count.HighCount
+	vs.Count.TotalCount += extra.Count.TotalCount
+
+	return vs
+}

--- a/pkg/runtime/executor_test.go
+++ b/pkg/runtime/executor_test.go
@@ -96,7 +96,7 @@ func TestExecute(t *testing.T) {
 			executor: Executor{
 				dirPath:      "./testdata/testdir",
 				iacProvider:  MockIacProvider{err: nil},
-				policyEngine: MockPolicyEngine{err: nil},
+				policyEngine: []policy.Engine{MockPolicyEngine{err: nil}},
 			},
 			wantErr: nil,
 		},
@@ -113,7 +113,7 @@ func TestExecute(t *testing.T) {
 			executor: Executor{
 				filePath:     "./testdata/testfile",
 				iacProvider:  MockIacProvider{err: nil},
-				policyEngine: MockPolicyEngine{err: nil},
+				policyEngine: []policy.Engine{MockPolicyEngine{err: nil}},
 			},
 			wantErr: nil,
 		},
@@ -122,7 +122,7 @@ func TestExecute(t *testing.T) {
 			executor: Executor{
 				iacProvider:  MockIacProvider{err: nil},
 				notifiers:    []notifications.Notifier{&MockNotifier{err: nil}},
-				policyEngine: MockPolicyEngine{err: nil},
+				policyEngine: []policy.Engine{MockPolicyEngine{err: nil}},
 			},
 			wantErr: nil,
 		},
@@ -131,7 +131,7 @@ func TestExecute(t *testing.T) {
 			executor: Executor{
 				iacProvider:  MockIacProvider{err: nil},
 				notifiers:    []notifications.Notifier{&MockNotifier{err: errMockNotifier}},
-				policyEngine: MockPolicyEngine{err: nil},
+				policyEngine: []policy.Engine{MockPolicyEngine{err: nil}},
 			},
 			wantErr: errMockNotifier,
 		},
@@ -140,7 +140,7 @@ func TestExecute(t *testing.T) {
 			executor: Executor{
 				iacProvider:  MockIacProvider{err: nil},
 				notifiers:    []notifications.Notifier{&MockNotifier{err: nil}},
-				policyEngine: MockPolicyEngine{err: nil},
+				policyEngine: []policy.Engine{MockPolicyEngine{err: nil}},
 			},
 			wantErr: nil,
 		},
@@ -149,7 +149,7 @@ func TestExecute(t *testing.T) {
 			executor: Executor{
 				iacProvider:  MockIacProvider{err: nil},
 				notifiers:    []notifications.Notifier{&MockNotifier{err: nil}},
-				policyEngine: MockPolicyEngine{err: errMockPolicyEngine},
+				policyEngine: []policy.Engine{MockPolicyEngine{err: errMockPolicyEngine}},
 			},
 			wantErr: errMockPolicyEngine,
 		},
@@ -179,10 +179,10 @@ func TestInit(t *testing.T) {
 			executor: Executor{
 				filePath:   "./testdata/testfile",
 				dirPath:    "",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
-				policyPath: "./testdata/testpolicies",
+				policyPath: []string{"./testdata/testpolicies"},
 			},
 			wantErr:         nil,
 			wantIacProvider: &tfv12.TfV12{},
@@ -193,11 +193,11 @@ func TestInit(t *testing.T) {
 			executor: Executor{
 				filePath:   "./testdata/testfile",
 				dirPath:    "",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
 				configFile: "./testdata/webhook.toml",
-				policyPath: "./testdata/testpolicies",
+				policyPath: []string{"./testdata/testpolicies"},
 			},
 			wantErr:         nil,
 			wantIacProvider: &tfv12.TfV12{},
@@ -208,7 +208,7 @@ func TestInit(t *testing.T) {
 			executor: Executor{
 				filePath:   "./testdata/testfile",
 				dirPath:    "",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
 				configFile: "testdata/invalid-notifier.toml",
@@ -222,7 +222,7 @@ func TestInit(t *testing.T) {
 			executor: Executor{
 				filePath:   "./testdata/testfile",
 				dirPath:    "",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
 				configFile: "./testdata/does-not-exist",
@@ -235,11 +235,11 @@ func TestInit(t *testing.T) {
 			executor: Executor{
 				filePath:   "./testdata/testfile",
 				dirPath:    "",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
 				configFile: "./testdata/webhook.toml",
-				policyPath: "./testdata/notthere",
+				policyPath: []string{"./testdata/notthere"},
 			},
 			wantErr:         fmt.Errorf("failed to initialize OPA policy engine"),
 			wantIacProvider: &tfv12.TfV12{},

--- a/pkg/runtime/validate_test.go
+++ b/pkg/runtime/validate_test.go
@@ -33,7 +33,7 @@ func TestValidateInputs(t *testing.T) {
 			executor: Executor{
 				filePath:   "./testdata/testfile",
 				dirPath:    "",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
 			},
@@ -44,7 +44,7 @@ func TestValidateInputs(t *testing.T) {
 			executor: Executor{
 				filePath:   "",
 				dirPath:    "./testdata/testdir",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "v12",
 			},
@@ -77,7 +77,7 @@ func TestValidateInputs(t *testing.T) {
 			executor: Executor{
 				filePath:   "",
 				dirPath:    "./testdata/testdir",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "notthere",
 				iacVersion: "v12",
 			},
@@ -88,7 +88,7 @@ func TestValidateInputs(t *testing.T) {
 			executor: Executor{
 				filePath:   "",
 				dirPath:    "./testdata/testdir",
-				cloudType:  "aws",
+				cloudType:  []string{"aws"},
 				iacType:    "terraform",
 				iacVersion: "notthere",
 			},


### PR DESCRIPTION
Allow scanning with multiple policy types, remove mandatory use of -t option with scan command, default to enabling all policy types