### PR TITLE
Fix CI for latest docker image

### DIFF
--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -39,7 +39,7 @@ jobs:
     needs: validate
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/master'
 
     steps:
     - name: Checkout Terrascan


### PR DESCRIPTION
Docker image on dockerhub tagged with "latest" will only be pushed with changes merged to master. 