### PR TITLE
fixes dockerfile build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_FLAGS := -v -ldflags "-w -s"
+ENV_SETTINGS := CGO_ENABLED=0
 
 BUILD_DIR = ./bin
 BINARY_NAME = terrascan
@@ -30,7 +31,7 @@ help:
 build: clean
 	@mkdir -p $(BUILD_DIR) > /dev/null
 	@export GO111MODULE=on
-	go build ${BUILD_FLAGS} -o ${BUILD_DIR}/${BINARY_NAME} cmd/terrascan/main.go
+	${ENV_SETTINGS} go build ${BUILD_FLAGS} -o ${BUILD_DIR}/${BINARY_NAME} cmd/terrascan/main.go
 	@echo "binary created at ${BUILD_DIR}/${BINARY_NAME}"
 
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,9 @@
 # -------- builder stage -------- #
-FROM golang:alpine AS builder
+FROM golang:1.15.5-alpine3.12 AS builder
 
 ARG GOOS_VAL=linux
-ARG GOARCH=amd64
+ARG GOARCH_VAL=amd64
+ARG CGO_ENABLED_VAL=0
 
 WORKDIR $GOPATH/src/terrascan
 
@@ -14,7 +15,7 @@ RUN go mod download
 COPY . .
 
 # build binary
-RUN GOOS=${GOOS_VAL} GOARCH=${GOARCH_VAL} go build -v -ldflags "-w -s" -o /go/bin/terrascan ./cmd/terrascan
+RUN CGO_ENABLED=${CGO_ENABLED_VAL} GOOS=${GOOS_VAL} GOARCH=${GOARCH_VAL} go build -v -ldflags "-w -s" -o /go/bin/terrascan ./cmd/terrascan
 
 
 # -------- prod stage -------- #

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # -------- builder stage -------- #
-FROM golang:1.15.5-alpine3.12 AS builder
+FROM golang:alpine AS builder
 
 ARG GOOS_VAL=linux
 ARG GOARCH_VAL=amd64


### PR DESCRIPTION
- disables CGO to prevent any dependencies from failing the build
- the GOARCH variable was named incorrectly and not being picked up during the docker build
- locked both the alpine and golang versions for the docker build