### PR TITLE
Remove demo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 [![codecov](https://codecov.io/gh/accurics/terrascan/branch/master/graph/badge.svg)](https://codecov.io/gh/accurics/terrascan)
 [![community](https://img.shields.io/discourse/status?server=https%3A%2F%2Fcommunity.accurics.com)](https://community.accurics.com)
 [![Documentation Status](https://readthedocs.com/projects/accurics-terrascan/badge/?version=latest)](https://docs.accurics.com/projects/accurics-terrascan/en/latest/?badge=latest)
-[![Blimp demo badge](https://blimpup.io/demo-badge.svg?repo=https://github.com/accurics/terrascan.git)](https://blimpup.io/preview-env/?repo=https://github.com/accurics/terrascan.git&composeFiles=deploy/docker-compose.yml&port=terrascan:9010)
-
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
 
@@ -71,58 +69,6 @@ $ cd terrascan
 $ make build
 $ ./bin/terrascan
 ```
-
-### Demoing
-If you want to play around with Terrascan without running it locally, you can
-[boot a personal demo copy
-](https://blimpup.io/preview-env/?repo=https://github.com/accurics/terrascan.git&composeFiles=deploy/docker-compose.yml&port=terrascan:9010)
-from your browser without downloading or setting up anything.
-
-1. Click the [demo
-   link](https://blimpup.io/preview-env/?repo=https://github.com/accurics/terrascan.git&composeFiles=deploy/docker-compose.yml&port=terrascan:9010)
-   to boot this repo in the Blimp cloud.
-
-1. Once the sandbox is booted, get its public URL by clicking "Connect" on the terrascan service on the left.
-
-   The page will 404, but that's OK because we just need the domain name to
-   create our URL that we'll hit with `curl`.
-
-1. Run the following command in your terminal to scan a simple Terraform file.
-   Make sure to replace `<YOUR PUBLIC URL>` with the URL from the previous
-   step.
-
-   ```
-   curl -i -F "file=@-" https://<YOUR PUBLIC URL>/v1/terraform/v12/aws/local/file/scan << EOF
-   variable "my-variable" {
-     default = "default"
-     type    = string
-   }
-   EOF
-   ```
-
-   The full URL will look something like `https://a98c0197112b7a4a96b72ea21ac0802b.blimp.dev/v1/terraform/v12/aws/local/file/scan`.
-
-   The command will output something like this:
-   ```
-   {
-     "ResourceConfig": {},
-     "Violations": {
-       "results": {
-         "violations": [],
-         "count": {
-           "low": 0,
-           "medium": 0,
-           "high": 0,
-           "total": 0
-         }
-       }
-     }
-   }
-   ```
-
-See the [server mode
-docs](https://docs.accurics.com/projects/accurics-terrascan/en/latest/getting-started/#server-mode)
-for more information on how to use the server endpoints.
 
 ## Getting started
 


### PR DESCRIPTION
Unfortunately, we're shutting down Blimp. This commit removes references
to Blimp to prevent broken links when it shuts down.

Thanks for trying out the badge while it was available! Let me know if you have any questions.