### PR TITLE
Fix infinite loop on variable resolution

### DIFF
--- a/pkg/iac-providers/terraform/v12/variable-references.go
+++ b/pkg/iac-providers/terraform/v12/variable-references.go
@@ -148,6 +148,10 @@ func (r *RefResolver) ResolveVarRefFromParentModuleCall(varRef string) interface
 	if reflect.TypeOf(val).Kind() == reflect.String {
 		valStr := val.(string)
 		resolvedVal := strings.Replace(varRef, varExpr, valStr, 1)
+		if varRef == resolvedVal {
+			zap.S().Debugf("resolved str variable ref refers to self: '%v'", varRef)
+			return val
+		}
 		zap.S().Debugf("resolved str variable ref: '%v', value: '%v'", varRef, string(resolvedVal))
 		return r.ResolveStrRef(resolvedVal)
 	}

--- a/pkg/iac-providers/terraform/v12/variable-references.go
+++ b/pkg/iac-providers/terraform/v12/variable-references.go
@@ -150,7 +150,7 @@ func (r *RefResolver) ResolveVarRefFromParentModuleCall(varRef string) interface
 		resolvedVal := strings.Replace(varRef, varExpr, valStr, 1)
 		if varRef == resolvedVal {
 			zap.S().Debugf("resolved str variable ref refers to self: '%v'", varRef)
-			return val
+			return varRef
 		}
 		zap.S().Debugf("resolved str variable ref: '%v', value: '%v'", varRef, string(resolvedVal))
 		return r.ResolveStrRef(resolvedVal)

--- a/pkg/iac-providers/terraform/v12/variable-references.go
+++ b/pkg/iac-providers/terraform/v12/variable-references.go
@@ -87,6 +87,10 @@ func (r *RefResolver) ResolveVarRef(varRef string) interface{} {
 			if reflect.TypeOf(val).Kind() == reflect.String {
 				valStr := val.(string)
 				resolvedVal := strings.Replace(varRef, varExpr, valStr, 1)
+				if varRef == resolvedVal {
+					zap.S().Debugf("resolved str variable ref refers to self: '%v'", varRef)
+					return varRef
+				}
 				zap.S().Debugf("resolved str variable ref: '%v', value: '%v'", varRef, resolvedVal)
 				return r.ResolveStrRef(resolvedVal)
 			}


### PR DESCRIPTION
When executing on a terraform HCL IaC, it is possible for a variable to end up resolving to itself because it is undefined at the time of analysis (defined in tfvars or on the command line)

This logic detects when a variable resolves to itself and breaks out of the infinite loop that would be created.

fixes #406