### PR TITLE
#394: recognize that empty values for username and password in master…

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_container_cluster/gkeBasicAuthDisabled.rego
+++ b/pkg/policies/opa/rego/gcp/google_container_cluster/gkeBasicAuthDisabled.rego
@@ -2,7 +2,16 @@ package accurics
 
 gkeBasicAuthDisabled[api.id] {
     api := input.google_container_cluster[_]
-    auth := api.config.master_auth[_]
-    auth.username != null
-    auth.password != null
+    auth := api.config.master_auth
+    # If username is not specified, basic auth is disabled
+    auth[_].username != null
+
+    # If username and password are both empty, basic auth is disabled
+    auths := auth[_]
+    not gkeBasicAuthEmptyCreds[ auths ]
+}
+
+gkeBasicAuthEmptyCreds[auth] {
+    auth := input.google_container_cluster[_].config.master_auth[_]
+    [auth.username,auth.password] == ["",""]
 }


### PR DESCRIPTION
Fixes #394: recognize that empty values for username and password in master_auth block will disable basic auth