### PR TITLE
Fixes GCP cos node image policy

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_container_node_pool/cosNodeImageUsed.rego
+++ b/pkg/policies/opa/rego/gcp/google_container_node_pool/cosNodeImageUsed.rego
@@ -3,6 +3,5 @@ package accurics
 cosNodeImageUsed[api.id]{
     api := input.google_container_node_pool[_]
     node := api.config.node_config[_]
-    not startswith(node.image_type, "cos")
+    not startswith(lower(node.image_type), "cos")
 }
-

--- a/pkg/policies/opa/rego/gcp/google_container_node_pool/cosNodeImageUsed.rego
+++ b/pkg/policies/opa/rego/gcp/google_container_node_pool/cosNodeImageUsed.rego
@@ -2,6 +2,7 @@ package accurics
 
 cosNodeImageUsed[api.id]{
     api := input.google_container_node_pool[_]
-    node := api.config.node_config[_] 
-    node.image_type != "cos"
+    node := api.config.node_config[_]
+    not startswith(node.image_type, "cos")
 }
+


### PR DESCRIPTION
Fixes an issue where the `cos_containerd` was being flagged as not compliant with the `accurics.gcp.OPS.114` policy.

Resolves #395