### PR TITLE
Add Docker image release tagging on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,20 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # push image to Docker Hub
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Terrascan
+      uses: actions/checkout@v1
+
+    - name: Build Terrascan docker image
+      run: make docker-build
+
+    - name: Login to docker hub
+      run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u accurics --password-stdin
+
+    - name: Push Terrascan latest tag docker image
+      run: make docker-push-latest-tag

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ help:
 	@echo "docker-build\n\tbuild terrascan docker image"
 	@echo "docker-push\n\tpush terrascan docker image"
 	@echo "docker-push-latest\n\tpush terrascan docker image with latest tag"
+	@echo "docker-push-latest-tag\n\tpush terrascan docker image with latest release tag"
 	@echo "gofmt\n\tvalidate gofmt"
 	@echo "golint\n\tvalidate golint"
 	@echo "gomodverify\n\tverify go modules"
@@ -35,7 +36,7 @@ build: clean
 	@echo "binary created at ${BUILD_DIR}/${BINARY_NAME}"
 
 
-# clean build 
+# clean build
 clean:
 	@rm -rf $(BUILD_DIR)
 
@@ -95,3 +96,7 @@ docker-push:
 # push latest terrascan docker image
 docker-push-latest:
 	./scripts/docker-push-latest.sh
+
+# push release tag terrascan docker image
+docker-push-latest-tag:
+	./scripts/docker-push-latest-tag.sh

--- a/scripts/docker-push-latest-tag.sh
+++ b/scripts/docker-push-latest-tag.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+DOCKER_REPO="accurics/terrascan"
+DOCKERFILE="./build/Dockerfile"
+LATEST_TAG=$(git describe --abbrev=0 --tags)
+LATEST_TAG_SHORT=$(echo "${LATEST_TAG//v}")
+
+# PS: It is a prerequisite to execute 'docker login' before running this script
+docker tag ${DOCKER_REPO}:${GIT_COMMIT} ${DOCKER_REPO}:${LATEST_TAG_SHORT}
+docker push ${DOCKER_REPO}:${LATEST_TAG_SHORT}


### PR DESCRIPTION
Add tagging of the Docker image with the release number when creating a
Git tag.

Resolves #398