### PR TITLE
IMDSv1 check policy

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_instance/AC-AWS-NS-IN-M-1172.json
+++ b/pkg/policies/opa/rego/aws/aws_instance/AC-AWS-NS-IN-M-1172.json
@@ -1,0 +1,10 @@
+{
+    "name": "ec2UsingIMDSv1",
+    "file": "ec2UsingIMDSv1.rego",
+    "template_args": null,
+    "severity": "MEDIUM",
+    "description": "Ensure there are no ECS instances using IMDSv1",
+    "reference_id": "AC-AWS-NS-IN-M-1172",
+    "category": "Unknown",
+    "version": 1
+}

--- a/pkg/policies/opa/rego/aws/aws_instance/ec2UsingIMDSv1.rego
+++ b/pkg/policies/opa/rego/aws/aws_instance/ec2UsingIMDSv1.rego
@@ -1,0 +1,13 @@
+package accurics
+
+ec2UsingIMDSv1[api.id] {
+  api := input.aws_instance[_]
+  not api.config.metadata_options
+}
+
+ec2UsingIMDSv1[api.id] {
+  api := input.aws_instance[_]
+  value := api.config.metadata_options[_]
+  not value.http_endpoint == "disabled"
+  not value.http_tokens == "required"
+}


### PR DESCRIPTION
IMDSv1 check for EC2 instance. This should not be enabled as this is potentially vulnerable to SSRF attack (IAM Credential disclosure-Final Objective)