### PR TITLE
Fix link to rego playground in policies documentation

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -62,7 +62,7 @@ $ terrascan scan -i terraform --config-only -o json
 }
 ```
 
-You can use this `.json` output as the input in the (rego playgound)[https://play.openpolicyagent.org/]. The following policy can be used on the above Terraform to flag if the GitHub repository has been created with `private = false`.
+You can use this `.json` output as the input in the [rego playgound](https://play.openpolicyagent.org/). The following policy can be used on the above Terraform to flag if the GitHub repository has been created with `private = false`.
 
 ```
 package accurics


### PR DESCRIPTION
Fix the syntax of the Markdown link pointing to the rego playground
in the policies documentation.

Resolves #421