### PR TITLE
Update policy example in the documentation

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -62,14 +62,15 @@ $ terrascan scan -i terraform --config-only -o json
 }
 ```
 
-You can use this `.json` output as the input in the (rego playgound)[https://play.openpolicyagent.org/]. The following policy can be used on the above Terraform to flag if the GitHub repository has been created with `private = false`.
+You can use this `.json` output as the input in the (rego playgound)[https://play.openpolicyagent.org/]. The following policy can be used on the above Terraform to flag if the GitHub repository has been created with `private = false` or `visibility = public`, depending on the version used for the GitHub provider.
 
 ```
 package accurics
 
 privateRepoEnabled[api.id] {
-api := input.github_repository[_]
-not api.config.private == true
+    api := input.github_repository[_]
+    not api.config.private == true
+    not api.config.visibility == "private"
 }
 ```
 


### PR DESCRIPTION
Update the policy example in the policies documentation to use the
latest version of the policy definition for the visibility setting of
GitHub repositories.

Resolves #422