### PR TITLE
Add support to extract rules to skip from terraform comments

### DIFF
--- a/pkg/iac-providers/output/types.go
+++ b/pkg/iac-providers/output/types.go
@@ -18,12 +18,13 @@ package output
 
 // ResourceConfig describes a resource present in IaC
 type ResourceConfig struct {
-	ID     string      `json:"id"`
-	Name   string      `json:"name"`
-	Source string      `json:"source"`
-	Line   int         `json:"line"`
-	Type   string      `json:"type"`
-	Config interface{} `json:"config"`
+	ID        string      `json:"id"`
+	Name      string      `json:"name"`
+	Source    string      `json:"source"`
+	Line      int         `json:"line"`
+	Type      string      `json:"type"`
+	Config    interface{} `json:"config"`
+	SkipRules []string    `json:"skip_rules"`
 }
 
 // AllResourceConfigs is a list/slice of resource configs present in IaC

--- a/pkg/iac-providers/output/types.go
+++ b/pkg/iac-providers/output/types.go
@@ -18,13 +18,16 @@ package output
 
 // ResourceConfig describes a resource present in IaC
 type ResourceConfig struct {
-	ID        string      `json:"id"`
-	Name      string      `json:"name"`
-	Source    string      `json:"source"`
-	Line      int         `json:"line"`
-	Type      string      `json:"type"`
-	Config    interface{} `json:"config"`
-	SkipRules []string    `json:"skip_rules"`
+	ID     string      `json:"id"`
+	Name   string      `json:"name"`
+	Source string      `json:"source"`
+	Line   int         `json:"line"`
+	Type   string      `json:"type"`
+	Config interface{} `json:"config"`
+	// SkipRules will hold the rules to be skipped for the resource.
+	// Each iac provider should append the rules to be skipped for a resource,
+	// while extracting resource from the iac files
+	SkipRules []string `json:"skip_rules"`
 }
 
 // AllResourceConfigs is a list/slice of resource configs present in IaC

--- a/pkg/iac-providers/terraform/v12/resource.go
+++ b/pkg/iac-providers/terraform/v12/resource.go
@@ -19,18 +19,12 @@ package tfv12
 import (
 	"fmt"
 	"io/ioutil"
-	"regexp"
-	"strings"
 
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
+	"github.com/accurics/terrascan/pkg/utils"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hclConfigs "github.com/hashicorp/terraform/configs"
 	"go.uber.org/zap"
-)
-
-var (
-	skipRulesPattern = regexp.MustCompile(`#ts:skip=\s*(([A-Za-z0-9]+\.?){5})(\s*,\s*([A-Za-z0-9]+\.?){5})*`)
-	skipRulesPrefix  = "#ts:skip="
 )
 
 // CreateResourceConfig creates output.ResourceConfig
@@ -61,34 +55,10 @@ func CreateResourceConfig(managedResource *hclConfigs.Resource) (resourceConfig 
 		Source:    managedResource.DeclRange.Filename,
 		Line:      managedResource.DeclRange.Start.Line,
 		Config:    goOut,
-		SkipRules: getSkipRules(c.rangeSource(hclBody.Range())),
+		SkipRules: utils.GetSkipRules(c.rangeSource(hclBody.Range())),
 	}
 
 	// successful
 	zap.S().Debugf("created resource config for resource '%s', file: '%s'", resourceConfig.Name, resourceConfig.Source)
 	return resourceConfig, nil
-}
-
-// getSkipRules returns a list of rules to be skipped. The rules to be skipped
-// can be set in terraform resource config with the following comma separated pattern:
-// #ts:skip=AWS.S3Bucket.DS.High.1043, AWS.S3Bucket.DS.High.1044
-func getSkipRules(body string) []string {
-
-	var skipRules []string
-
-	// check if any rules comments are present in body
-	if !skipRulesPattern.MatchString(body) {
-		return skipRules
-	}
-
-	// get all skip rule comments
-	comments := skipRulesPattern.FindAllString(body, -1)
-
-	// extract rule ids from comments
-	for _, c := range comments {
-		c = strings.TrimPrefix(c, skipRulesPrefix)
-		c = strings.ReplaceAll(c, ",", " ")
-		skipRules = append(skipRules, strings.Fields(c)...)
-	}
-	return skipRules
 }

--- a/pkg/iac-providers/terraform/v12/resource_test.go
+++ b/pkg/iac-providers/terraform/v12/resource_test.go
@@ -30,6 +30,11 @@ func TestGetSkipRules(t *testing.T) {
 		expected []string
 	}{
 		{
+			name:  "no rules",
+			input: "no rules here",
+			// expected would be an empty slice of strings
+		},
+		{
 			name:     "single rule id",
 			input:    "#ts:skip=AWS.S3Bucket.DS.High.1041",
 			expected: []string{"AWS.S3Bucket.DS.High.1041"},

--- a/pkg/iac-providers/terraform/v12/resource_test.go
+++ b/pkg/iac-providers/terraform/v12/resource_test.go
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2020 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package tfv12
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ---------------------- unit tests -------------------------------- //
+func TestGetSkipRules(t *testing.T) {
+
+	table := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "single rule id",
+			input:    "#ts:skip=AWS.S3Bucket.DS.High.1041",
+			expected: []string{"AWS.S3Bucket.DS.High.1041"},
+		},
+		{
+			name:     "multiple comma separated no space",
+			input:    "#ts:skip=AWS.S3Bucket.DS.High.1041,AWS.S3Bucket.DS.High.1042",
+			expected: []string{"AWS.S3Bucket.DS.High.1041", "AWS.S3Bucket.DS.High.1042"},
+		},
+		{
+			name: "multiple comma separated random space",
+			input: "#ts:skip=  AWS.S3Bucket.DS.High.1041   ,		AWS.S3Bucket.DS.High.1042",
+			expected: []string{"AWS.S3Bucket.DS.High.1041", "AWS.S3Bucket.DS.High.1042"},
+		},
+		{
+			name:     "sample resource config",
+			input:    "{\n     #ts:skip=AWS.S3Bucket.DS.High.1041\n   region        = var.region\n   #ts:skip=AWS.S3Bucket.DS.High.1042 AWS.S3Bucket.DS.High.1043\n   bucket        = local.bucket_name\n   #ts:skip=AWS.S3Bucket.DS.High.1044,AWS.S3Bucket.DS.High.1045\n   force_destroy = true\n   #ts:skip= AWS.S3Bucket.DS.High.1046   ,   AWS.S3Bucket.DS.High.1047\n   acl           = \"public-read\"\n }",
+			expected: []string{"AWS.S3Bucket.DS.High.1041", "AWS.S3Bucket.DS.High.1042", "AWS.S3Bucket.DS.High.1044", "AWS.S3Bucket.DS.High.1045", "AWS.S3Bucket.DS.High.1046", "AWS.S3Bucket.DS.High.1047"},
+		},
+	}
+
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getSkipRules(tt.input)
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("rule ids got: '%v', want: '%v'", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/iac-providers/terraform/v12/testdata/tfjson/config1.json
+++ b/pkg/iac-providers/terraform/v12/testdata/tfjson/config1.json
@@ -38,7 +38,8 @@
         "vpc_security_group_ids": [
           "${aws_security_group.sg_playground.id}"
         ]
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_internet_gateway": [
@@ -53,7 +54,8 @@
           "Environment": "${var.environment_tag}"
         },
         "vpc_id": "${aws_vpc.vpc_playground.id}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_key_pair": [
@@ -66,7 +68,8 @@
       "config": {
         "key_name": "testKey",
         "public_key": "${file(var.public_key_path)}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_route_table": [
@@ -87,7 +90,8 @@
           "Environment": "${var.environment_tag}"
         },
         "vpc_id": "${aws_vpc.vpc_playground.id}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_route_table_association": [
@@ -100,7 +104,8 @@
       "config": {
         "route_table_id": "${aws_route_table.rtb_public_playground.id}",
         "subnet_id": "${aws_subnet.subnet_public_playground.id}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_security_group": [
@@ -144,7 +149,8 @@
           "Environment": "${var.environment_tag}"
         },
         "vpc_id": "${aws_vpc.vpc_playground.id}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_subnet": [
@@ -161,7 +167,8 @@
           "Environment": "${var.environment_tag}"
         },
         "vpc_id": "${aws_vpc.vpc_playground.id}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "aws_vpc": [
@@ -178,7 +185,8 @@
         "tags": {
           "Environment": "${var.environment_tag}"
         }
-      }
+      },
+      "skip_rules": null
     }
   ]
 }

--- a/pkg/iac-providers/terraform/v12/testdata/tfjson/dummyconfig.json
+++ b/pkg/iac-providers/terraform/v12/testdata/tfjson/dummyconfig.json
@@ -14,7 +14,8 @@
           "profile": "${var.profile}",
           "region": "${var.region}"
         }
-      }
+      },
+      "skip_rules": null
     }
   ],
   "type1": [
@@ -39,7 +40,8 @@
         "test1": "hello",
         "test2": 5,
         "test3": "${1 + 2}"
-      }
+      },
+      "skip_rules": null
     }
   ],
   "type2": [
@@ -60,7 +62,8 @@
           "num": "${local.test2 + 5}",
           "thing": "${[for x in local.arr: x * 2]}"
         }
-      }
+      },
+      "skip_rules": null
     }
   ],
   "type3": [
@@ -75,7 +78,8 @@
         "heredoc": "This is a heredoc template.\nIt references ${local.other.3}\n",
         "heredoc2": "\t\tAnother heredoc, that\n\t\tdoesn't remove indentation\n\t\t${local.other.3}\n\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",
         "simple": "${4 - 2}"
-      }
+      },
+      "skip_rules": null
     }
   ]
 }

--- a/pkg/utils/skip_rules.go
+++ b/pkg/utils/skip_rules.go
@@ -1,0 +1,51 @@
+/*
+    Copyright (C) 2020 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	skipRulesPattern = regexp.MustCompile(`#ts:skip=\s*(([A-Za-z0-9]+\.?){5})(\s*,\s*([A-Za-z0-9]+\.?){5})*`)
+	skipRulesPrefix  = "#ts:skip="
+)
+
+// GetSkipRules returns a list of rules to be skipped. The rules to be skipped
+// can be set in terraform resource config with the following comma separated pattern:
+// #ts:skip=AWS.S3Bucket.DS.High.1043, AWS.S3Bucket.DS.High.1044
+func GetSkipRules(body string) []string {
+
+	var skipRules []string
+
+	// check if any rules comments are present in body
+	if !skipRulesPattern.MatchString(body) {
+		return skipRules
+	}
+
+	// get all skip rule comments
+	comments := skipRulesPattern.FindAllString(body, -1)
+
+	// extract rule ids from comments
+	for _, c := range comments {
+		c = strings.TrimPrefix(c, skipRulesPrefix)
+		c = strings.ReplaceAll(c, ",", " ")
+		skipRules = append(skipRules, strings.Fields(c)...)
+	}
+	return skipRules
+}

--- a/pkg/utils/skip_rules_test.go
+++ b/pkg/utils/skip_rules_test.go
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-package tfv12
+package utils
 
 import (
 	"reflect"
@@ -58,7 +58,7 @@ func TestGetSkipRules(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := getSkipRules(tt.input)
+			actual := GetSkipRules(tt.input)
 			if !reflect.DeepEqual(actual, tt.expected) {
 				t.Errorf("rule ids got: '%v', want: '%v'", actual, tt.expected)
 			}

--- a/pkg/writer/json_test.go
+++ b/pkg/writer/json_test.go
@@ -18,7 +18,8 @@ const (
       "config": {
         "bucket": "${module.m3.fullbucketname}",
         "policy": "${module.m2.fullbucketpolicy}"
-      }
+      },
+      "skip_rules": null
     }
   ]
 }`

--- a/pkg/writer/yaml_test.go
+++ b/pkg/writer/yaml_test.go
@@ -66,7 +66,8 @@ const (
       type: aws_s3_bucket
       config:
         bucket: ${module.m3.fullbucketname}
-        policy: ${module.m2.fullbucketpolicy}`
+        policy: ${module.m2.fullbucketpolicy}
+      skiprules: []`
 
 	scanTestOutputYAML = `results:
     violations:


### PR DESCRIPTION
This PR adds support for extracting rule ids to skip policy evaluation. These rules can be set as a comma separated list of rule ids in the comments of terraform resource config in the following pattern:
```hcl
#ts:skip=AWS.S3Bucket.DS.High.1041, AWS.S3Bucket.DS.High.1042
```

Example of a terraform resource config with rules to skip policy evaluation:
```hcl
resource "aws_s3_bucket" "bucket2" {
   #ts:skip=AWS.S3Bucket.DS.High.1041
   region        = var.region
   bucket        = local.bucket_name
   #ts:skip=AWS.S3Bucket.DS.High.1044,AWS.S3Bucket.DS.High.1045
   force_destroy = true
   #ts:skip= AWS.S3Bucket.DS.High.1046   ,   AWS.S3Bucket.DS.High.1047
   acl           = "public-read"
 }
```