### PR TITLE
Fixes dead link to old getting started page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 Terrascan documentation is composed of the following major sections:
 
-* [Getting Started](getting-started.md): Tutorial on how to install and quickly get started with Terrascan.
+* [Getting Started](getting-started/quickstart.md): Tutorial on how to install and quickly get started with Terrascan.
 * [Architecture](architecture.md): Explains the pluggable architecture powering Terrascan.
 * [Policies](policies.md): Explains policies, how to write them, and reference for all policies/rules included by default.
 


### PR DESCRIPTION
The index page of the docs has a link to the old getting started page. This PR fixes that. 