### PR TITLE
Fix exit code on error

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -29,15 +29,18 @@ var initCmd = &cobra.Command{
 
 Initializes Terrascan and clones policies from the Terrascan GitHub repository.
 `,
-	Run: initial,
+	RunE:          initial,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
-func initial(cmd *cobra.Command, args []string) {
+func initial(cmd *cobra.Command, args []string) error {
 	// initialize terrascan
 	if err := initialize.Run(); err != nil {
 		zap.S().Error("failed to initialize terrascan")
-		return
+		return err
 	}
+	return nil
 }
 
 func init() {

--- a/pkg/cli/register.go
+++ b/pkg/cli/register.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"flag"
-	"fmt"
 	"os"
 
 	"github.com/accurics/terrascan/pkg/config"
@@ -29,27 +28,6 @@ import (
 // RegisterCommand Registers a new command under the base command
 func RegisterCommand(baseCommand *cobra.Command, command *cobra.Command) {
 	baseCommand.AddCommand(command)
-}
-
-func subCommands() (commandNames []string) {
-	for _, command := range rootCmd.Commands() {
-		commandNames = append(commandNames, append(command.Aliases, command.Name())...)
-	}
-	return
-}
-
-// setDefaultCommand sets `scan` as default command if no other command is specified
-func setDefaultCommandIfNonePresent() {
-	if len(os.Args) > 1 {
-		potentialCommand := os.Args[1]
-		for _, command := range subCommands() {
-			if command == potentialCommand {
-				return
-			}
-		}
-		os.Args = append([]string{os.Args[0], "scan"}, os.Args[1:]...)
-	}
-
 }
 
 // Execute the entrypoint called by main
@@ -81,9 +59,7 @@ func Execute() {
 		}
 	}
 
-	setDefaultCommandIfNonePresent()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	iacProvider "github.com/accurics/terrascan/pkg/iac-providers"
@@ -36,17 +35,17 @@ var scanCmd = &cobra.Command{
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
 `,
-	PreRun: initial,
-	Run:    scan,
+	PreRunE:       initial,
+	RunE:          scan,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
-func scan(cmd *cobra.Command, args []string) {
+func scan(cmd *cobra.Command, args []string) error {
 	zap.S().Debug("running terrascan in cli mode")
 	scanOptions.configFile = ConfigFile
 	scanOptions.outputType = OutputType
-	if err := scanOptions.Scan(); err != nil {
-		os.Exit(1)
-	}
+	return scanOptions.Scan()
 }
 
 func init() {

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	iacProvider "github.com/accurics/terrascan/pkg/iac-providers"
@@ -43,7 +44,9 @@ func scan(cmd *cobra.Command, args []string) {
 	zap.S().Debug("running terrascan in cli mode")
 	scanOptions.configFile = ConfigFile
 	scanOptions.outputType = OutputType
-	scanOptions.Scan()
+	if err := scanOptions.Scan(); err != nil {
+		os.Exit(1)
+	}
 }
 
 func init() {


### PR DESCRIPTION
- This PR fixes https://github.com/accurics/terrascan/issues/442 (addressed both scan and init commands)
- Removed the code for scan as default command. The function doesn't serve the purpose. Ideally if no commands are specified then help should be printed and if there is a typo in command then cobra prints out useful message with hints. 