### PR TITLE
recognize metadata.generateName

### DIFF
--- a/pkg/iac-providers/kubernetes/v1/normalize.go
+++ b/pkg/iac-providers/kubernetes/v1/normalize.go
@@ -38,9 +38,18 @@ var (
 
 // k8sMetadata is used to pull the name, namespace types and annotations for a given resource
 type k8sMetadata struct {
-	Name        string                 `yaml:"name" json:"name"`
-	Namespace   string                 `yaml:"namespace" json:"namespace"`
-	Annotations map[string]interface{} `yaml:"annotations" json:"annotations"`
+	Name         string                 `yaml:"name" json:"name"`
+	GenerateName string                 `yaml:"generateName,omitempty" json:"generateName,omitempty"`
+	Namespace    string                 `yaml:"namespace" json:"namespace"`
+	Annotations  map[string]interface{} `yaml:"annotations" json:"annotations"`
+}
+
+// NameOrGenerateName gets the metadata's Name member, or if Name is not set then GenerateName (for CRDs, for example)
+func (m k8sMetadata) NameOrGenerateName() string {
+	if len(m.Name) > 0 {
+		return m.Name
+	}
+	return m.GenerateName
 }
 
 // k8sResource is a generic struct to handle all k8s resource types
@@ -109,7 +118,7 @@ func (k *K8sV1) Normalize(doc *utils.IacDocument) (*output.ResourceConfig, error
 	case "ClusterRole":
 		fallthrough
 	case "Namespace":
-		resourceConfig.ID = resourceConfig.Type + "." + resource.Metadata.Name
+		resourceConfig.ID = resourceConfig.Type + "." + resource.Metadata.NameOrGenerateName()
 	default:
 		// namespaced-resources
 		namespace := resource.Metadata.Namespace
@@ -117,7 +126,7 @@ func (k *K8sV1) Normalize(doc *utils.IacDocument) (*output.ResourceConfig, error
 			namespace = "default"
 		}
 
-		resourceConfig.ID = resourceConfig.Type + "." + resource.Metadata.Name + "." + namespace
+		resourceConfig.ID = resourceConfig.Type + "." + resource.Metadata.NameOrGenerateName() + "." + namespace
 	}
 
 	// read and update skip rules, if present
@@ -131,7 +140,7 @@ func (k *K8sV1) Normalize(doc *utils.IacDocument) (*output.ResourceConfig, error
 		return nil, err
 	}
 
-	resourceConfig.Name = resource.Metadata.Name
+	resourceConfig.Name = resource.Metadata.NameOrGenerateName()
 	resourceConfig.Config = configData
 
 	return &resourceConfig, nil

--- a/pkg/iac-providers/kubernetes/v1/normalize_test.go
+++ b/pkg/iac-providers/kubernetes/v1/normalize_test.go
@@ -60,6 +60,17 @@ spec:
   containers:
     - name: myapp-container
       image: busybox`)
+
+	testYAMLDataWithGenerateName = []byte(`apiVersion: v1
+kind: CRD
+metadata:
+  generateName: myapp-pod-prefix-
+  annotations:
+    terrascanSkip: [accurics.kubernetes.IAM.109]
+spec:
+  containers:
+    - name: myapp-container
+      image: busybox`)
 )
 
 func TestK8sV1ExtractResource(t *testing.T) {
@@ -207,6 +218,40 @@ func TestK8sV1Normalize(t *testing.T) {
 							terrascanSkip: []interface{}{testRule},
 						},
 						"name": "myapp-pod",
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"image": "busybox",
+								"name":  "myapp-container",
+							},
+						},
+					},
+				},
+				SkipRules: []string{testRule},
+			},
+		},
+		{
+			name: "valid iac document object with generateName",
+			args: args{
+				&utils.IacDocument{
+					Type: "yaml",
+					Data: testYAMLDataWithGenerateName,
+				},
+			},
+			want: &output.ResourceConfig{
+				ID:   "kubernetes_crd.myapp-pod-prefix-.default",
+				Name: "myapp-pod-prefix-",
+				Line: 0,
+				Type: "kubernetes_crd",
+				Config: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "CRD",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							terrascanSkip: []interface{}{testRule},
+						},
+						"generateName": "myapp-pod-prefix-",
 					},
 					"spec": map[string]interface{}{
 						"containers": []interface{}{


### PR DESCRIPTION
As described at https://kubernetes.io/docs/reference/using-api/api-concepts/#generated-values, the metadata.name may sometimes be generated based on metadata.generateName.  Dynamically generated names are populated with unique values at runtime, meaning that metadata.name might be empty when Terrascan is run.  This change uses the value of metadata.generateName for the name when metadata.name is empty.  This can help, for example, with CRDs that rely on generateName.