### PR TITLE
Fix: potential bug added in PR #470

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/mod v0.4.1 // indirect
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
-	golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 // indirect
+	golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	helm.sh/helm/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -1295,6 +1295,8 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 h1:K+NlvTLy0oONtRtkl1jRD9xIhnItbG2PiE7YOdjPb+k=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 h1:BTs2GMGSMWpgtCpv1CE7vkJTv7XcHdcLLnAMu7UbgTY=
+golang.org/x/tools v0.0.0-20210115202250-e0d201561e39/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/policy/all.go
+++ b/pkg/policy/all.go
@@ -18,7 +18,7 @@ package policy
 
 const (
 	defaultAllIacType    supportedIacType    = "terraform"
-	defaultAllIacVersion supportedIacVersion = "v12"
+	defaultAllIacVersion supportedIacVersion = version12
 )
 
 func init() {

--- a/pkg/policy/all.go
+++ b/pkg/policy/all.go
@@ -18,7 +18,7 @@ package policy
 
 const (
 	defaultAllIacType    supportedIacType    = "terraform"
-	defaultAllIacVersion supportedIacVersion = "v14"
+	defaultAllIacVersion supportedIacVersion = "v12"
 )
 
 func init() {

--- a/pkg/policy/aws.go
+++ b/pkg/policy/aws.go
@@ -19,7 +19,7 @@ package policy
 const (
 	aws                  supportedCloudType  = "aws"
 	defaultAWSIacType    supportedIacType    = "terraform"
-	defaultAWSIacVersion supportedIacVersion = "v14"
+	defaultAWSIacVersion supportedIacVersion = version12
 )
 
 func init() {

--- a/pkg/policy/azure.go
+++ b/pkg/policy/azure.go
@@ -19,7 +19,7 @@ package policy
 const (
 	azure                  supportedCloudType  = "azure"
 	defaultAzureIacType    supportedIacType    = "terraform"
-	defaultAzureIacVersion supportedIacVersion = "v12"
+	defaultAzureIacVersion supportedIacVersion = version12
 )
 
 func init() {

--- a/pkg/policy/azure.go
+++ b/pkg/policy/azure.go
@@ -19,7 +19,7 @@ package policy
 const (
 	azure                  supportedCloudType  = "azure"
 	defaultAzureIacType    supportedIacType    = "terraform"
-	defaultAzureIacVersion supportedIacVersion = "v14"
+	defaultAzureIacVersion supportedIacVersion = "v12"
 )
 
 func init() {

--- a/pkg/policy/gcp.go
+++ b/pkg/policy/gcp.go
@@ -19,7 +19,7 @@ package policy
 const (
 	gcp                  supportedCloudType  = "gcp"
 	defaultGCPIacType    supportedIacType    = "terraform"
-	defaultGCPIacVersion supportedIacVersion = "v12"
+	defaultGCPIacVersion supportedIacVersion = version12
 )
 
 func init() {

--- a/pkg/policy/gcp.go
+++ b/pkg/policy/gcp.go
@@ -19,7 +19,7 @@ package policy
 const (
 	gcp                  supportedCloudType  = "gcp"
 	defaultGCPIacType    supportedIacType    = "terraform"
-	defaultGCPIacVersion supportedIacVersion = "v14"
+	defaultGCPIacVersion supportedIacVersion = "v12"
 )
 
 func init() {

--- a/pkg/policy/github.go
+++ b/pkg/policy/github.go
@@ -19,7 +19,7 @@ package policy
 const (
 	github                  supportedCloudType  = "github"
 	defaultGithubIacType    supportedIacType    = "terraform"
-	defaultGithubIacVersion supportedIacVersion = "v14"
+	defaultGithubIacVersion supportedIacVersion = "v12"
 )
 
 func init() {

--- a/pkg/policy/github.go
+++ b/pkg/policy/github.go
@@ -19,7 +19,7 @@ package policy
 const (
 	github                  supportedCloudType  = "github"
 	defaultGithubIacType    supportedIacType    = "terraform"
-	defaultGithubIacVersion supportedIacVersion = "v12"
+	defaultGithubIacVersion supportedIacVersion = version12
 )
 
 func init() {

--- a/pkg/policy/helm.go
+++ b/pkg/policy/helm.go
@@ -19,7 +19,7 @@ package policy
 const (
 	helm                  supportedCloudType  = "k8s"
 	defaultHelmIacType    supportedIacType    = "helm"
-	defaultHelmIacVersion supportedIacVersion = "3"
+	defaultHelmIacVersion supportedIacVersion = version3
 )
 
 func init() {

--- a/pkg/policy/kubernetes.go
+++ b/pkg/policy/kubernetes.go
@@ -19,7 +19,7 @@ package policy
 const (
 	kubernetes                  supportedCloudType  = "k8s"
 	defaultKubernetesIacType    supportedIacType    = "k8s"
-	defaultKubernetesIacVersion supportedIacVersion = "v1"
+	defaultKubernetesIacVersion supportedIacVersion = version1
 )
 
 func init() {

--- a/pkg/policy/kustomize.go
+++ b/pkg/policy/kustomize.go
@@ -2,7 +2,7 @@ package policy
 
 const (
 	defaultKustomizeIacType    supportedIacType    = "kustomize"
-	defaultKustomizeIacVersion supportedIacVersion = "v3"
+	defaultKustomizeIacVersion supportedIacVersion = version3
 )
 
 func init() {

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -7,6 +7,12 @@ import (
 	"github.com/accurics/terrascan/pkg/results"
 )
 
+const (
+	version12 = "v12"
+	version1  = "v1"
+	version3  = "v3"
+)
+
 // EngineInput Contains data used as input to the engine
 type EngineInput struct {
 	InputData *output.AllResourceConfigs


### PR DESCRIPTION
My PR #470  wrongly set the default version for terraform iac to v14 from v12, in the context of policy engine. Everywhere else in the repo, the default version is still v12 for terraform. So this PR will rectify the mistake and eliminate any potential bug caused due to this.