### PR TITLE
fixes #405

### DIFF
--- a/pkg/policies/opa/rego/azure/azurerm_storage_container/checkStorageContainerAccess.rego
+++ b/pkg/policies/opa/rego/azure/azurerm_storage_container/checkStorageContainerAccess.rego
@@ -2,5 +2,13 @@ package accurics
 
 {{.prefix}}checkStorageContainerAccess[storage_container.id] {
   storage_container := input.azurerm_storage_container[_]
-  storage_container.config.container_access_type != "private"
+  not checkAccessType(storage_container.config.container_access_type)
+}
+
+checkAccessType(accesstype) {
+  contains(accesstype, "private")
+}
+
+checkAccessType(accesstype) {
+  contains(accesstype, "PRIVATE")
 }


### PR DESCRIPTION
fixes #405 

now using `contains` function to check for `access_type` instead of an exact match to avoid false positives

`terrascan` generates value of `access_type` in this format: `${private}`