### PR TITLE
fixes #376

### DIFF
--- a/pkg/policies/opa/rego/azure/azurerm_kubernetes_cluster/networkPolicyEnabled.rego
+++ b/pkg/policies/opa/rego/azure/azurerm_kubernetes_cluster/networkPolicyEnabled.rego
@@ -1,12 +1,20 @@
 package accurics
 
-networkPolicyEnabled[api.id]{
-    api := input.azurerm_kubernetes_cluster[_]
-    profile := api.config.network_profile[_]
-    profile.network_policy != "azure"
+networkPolicyEnabled[api.id] {
+	api := input.azurerm_kubernetes_cluster[_]
+	profile := api.config.network_profile[_]
+	not checkNetworkPolicy(profile.network_policy)
 }
 
-networkPolicyEnabled[api.id]{
-    api := input.azurerm_kubernetes_cluster[_]
-    object.get(api.config, "network_profile", "undefined") == "undefined"
+networkPolicyEnabled[api.id] {
+	api := input.azurerm_kubernetes_cluster[_]
+	object.get(api.config, "network_profile", "undefined") == "undefined"
+}
+
+checkNetworkPolicy(policy) {
+	policy == "azure"
+}
+
+checkNetworkPolicy(policy) {
+	policy == "calico"
 }


### PR DESCRIPTION
fixes #376 

added function to include checks for `calico` and `azure`

violation will be thrown if `network_policy` is not one of the above mentioned values