### PR TITLE
Enhancement: new set of policies for AWS EC2 instance.

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_instance/AC-AW-IA-IN-H-0442.json
+++ b/pkg/policies/opa/rego/aws/aws_instance/AC-AW-IA-IN-H-0442.json
@@ -1,0 +1,12 @@
+{
+    "name": "overlyPermissiveInstance",
+    "file": "overlyPermissiveInstance.rego",
+    "template_args": {
+        "prefix": ""
+    },
+    "severity": "HIGH",
+    "description": "Ensure that instance launched follows the least privilege principle as this can be related to delivery-exploitation-Installation phases of kill  chain",
+    "reference_id": "AC-AW-IA-LC-H-0442",
+    "category": "Identity and Access Management",
+    "version": 1
+}

--- a/pkg/policies/opa/rego/aws/aws_instance/AC-AW-IS-IN-H-0443.json
+++ b/pkg/policies/opa/rego/aws/aws_instance/AC-AW-IS-IN-H-0443.json
@@ -1,0 +1,12 @@
+{
+    "name": "instanceExposedToInternet",
+    "file": "instanceExposedToInternet.rego",
+    "template_args": {
+        "prefix": ""
+    },
+    "severity": "HIGH",
+    "description": "Security group attached to launch configuration is wide open to internet and this can be related to reconnaissance phase",
+    "reference_id": "AC-AW-IS-LC-H-0443",
+    "category": "Infrastructure Security",
+    "version": 1
+}

--- a/pkg/policies/opa/rego/aws/aws_instance/AC-AWS-NS-IN-M-1172.json
+++ b/pkg/policies/opa/rego/aws/aws_instance/AC-AWS-NS-IN-M-1172.json
@@ -3,7 +3,7 @@
     "file": "ec2UsingIMDSv1.rego",
     "template_args": null,
     "severity": "MEDIUM",
-    "description": "EC2 instances should disable IMDS or require IMDSv2",
+    "description": "EC2 instances should disable IMDS or require IMDSv2 as this can be related to the weaponization phase of kill chain",
     "reference_id": "AC-AWS-NS-IN-M-1172",
     "category": "Network Security",
     "version": 1

--- a/pkg/policies/opa/rego/aws/aws_instance/instanceExposedToInternet.rego
+++ b/pkg/policies/opa/rego/aws/aws_instance/instanceExposedToInternet.rego
@@ -1,0 +1,35 @@
+package accurics
+
+instanceExposedToInternet[ins.id] {
+    ins = input.aws_instance[_]
+    sec_groups := [ sg | sg := split(ins.config.vpc_security_group_ids[_], ".")[1] ]
+    sec_group := sec_groups[_]
+    checkSecurityGroupWideOpen(sec_group)
+
+    sub = ins.config.subnet_id
+    route_table_association = input.aws_route_table_association[_]
+    route_table_association.config.subnet_id == sub
+    route_table := split(route_table_association.config.route_table_id, ".")[1]
+    checkRouteInternet(ins, route_table)
+}
+
+checkSecurityGroupWideOpen(sgName) {
+	security_group := input.aws_security_group[_]
+    sgName == security_group.name
+
+    some i
+    ingress = security_group.config.ingress[i]
+
+    # Checks if the cidr block is not a private IP
+    ingress.cidr_blocks[_] == "0.0.0.0/0"
+
+    ports_open = (ingress.to_port - ingress.from_port)
+    ports_open > 0
+}
+
+checkRouteInternet(instance, arg) {
+    rt = input.aws_route_table[_]
+    rt.name == arg
+    routes = rt.config.route[_]
+    routes.gateway_id != ""
+}

--- a/pkg/policies/opa/rego/aws/aws_instance/overlyPermissiveInstance.rego
+++ b/pkg/policies/opa/rego/aws/aws_instance/overlyPermissiveInstance.rego
@@ -1,0 +1,39 @@
+
+package accurics
+
+overlyPermissiveInstance[res.id] {
+    res = input.aws_instance[_]
+    ins_profile_name := split(res.config.iam_instance_profile, ".")[1]
+    iam_instance_profile := input.aws_iam_instance_profile[_]
+    ins_profile_name == iam_instance_profile.name
+
+    role_name := split(iam_instance_profile.config.role, ".")[1]
+    role_policy_attachment := input.aws_iam_role_policy_attachment[_]
+    role_name == split(role_policy_attachment.config.role, ".")[1]
+    policy_name := split(role_policy_attachment.config.policy_arn, ".")[1]
+
+    iam_policy := input.aws_iam_policy[_]
+    policy_name == iam_policy.name
+    policy := json_unmarshal(iam_policy.config.policy)
+    statement = policy.Statement[_]
+    ac := statement.Action[_]
+    action := split(ac, ":")[0]
+    policyCheck(statement, "*", "Allow", "*")
+}
+
+json_unmarshal(s) = result {
+	s != null
+	result := json.unmarshal(s)
+}
+
+policyCheck(s, a, e ,r) {
+    split(s.Action[_], ":")[1] == a
+    s.Effect == e
+    s.Resource == r
+}
+
+policyCheck(s, a, e ,r) {
+    s.Action[_] == a
+    s.Effect == e
+    s.Resource == r
+}


### PR DESCRIPTION
Two new policies are added for AWS instance (aws_instance).
1. One policy checks whether the security group attached to ec2 instance is wide open to internet and has a route to internet through internet gateway.
2. Other policy checks the permissions of instance profile attached to the ec2 instance.