### PR TITLE
bugfix: Checks for security group association defined independently from vnet 

### DIFF
--- a/pkg/policies/opa/rego/azure/azurerm_virtual_network/noSecurityGroupAssociated.rego
+++ b/pkg/policies/opa/rego/azure/azurerm_virtual_network/noSecurityGroupAssociated.rego
@@ -5,7 +5,7 @@ package accurics
   vn.type = "azurerm_virtual_network"
   object.get(vn.config, "subnet", "undefined") != "undefined"
   not sgExists(vn.config)
-  
+
   traverse = "subnet[0].security_group"
   retVal := { "Id": vn.id, "ReplaceType": "add", "CodeType": "block", "Traverse": traverse, "Attribute": "subnet.security_group", "AttributeDataType": "string", "Expected": "${azurerm_network_security_group.<security_group_name>.id}", "Actual": "" }
 }
@@ -13,7 +13,10 @@ package accurics
 {{.prefix}}noSecurityGroupAssociated[retVal] {
   vn := input.azurerm_virtual_network[_]
   vn.type = "azurerm_virtual_network"
+
+  object.get(input, "azurerm_subnet", "undefined") == "undefined"
   object.get(vn.config, "subnet", "undefined") == "undefined"
+
   rc = "ewogICJzdWJuZXQiOiB7CiAgICAibmFtZSI6ICJzdWJuZXQzIiwKICAgICJhZGRyZXNzX3ByZWZpeCI6ICI8Y2lkcj4iLAogICAgInNlY3VyaXR5X2dyb3VwIjogIiR7YXp1cmVybV9uZXR3b3JrX3NlY3VyaXR5X2dyb3VwLjxzZWN1cml0eV9ncm91cF9uYW1lPi5pZH0iCiAgfQp9"
   traverse = ""
   retVal := { "Id": vn.id, "ReplaceType": "add", "CodeType": "block", "Traverse": traverse, "Attribute": "subnet", "AttributeDataType": "base64", "Expected": rc, "Actual": null }
@@ -27,4 +30,15 @@ sgExists(cfg) = true {
 sgExists(cfg) = true {
 	subs = cfg.subnet[_]
     object.get(subs, "security_group", "undefined") == "undefined"
+}
+
+{{.prefix}}noSecurityGroupAssociated[subnet.id] {
+  subnet := input.azurerm_subnet[_]
+  subnet_name := subnet.name
+  not checkAssociation(subnet_name)
+}
+
+checkAssociation(arg) {
+	subnet_with_sg := {nsga | nsga := split(input.azurerm_subnet_network_security_group_association[_].config.subnet_id, ".")[1]}
+	subnet_with_sg[arg]
 }


### PR DESCRIPTION
This is a proposed fix for #391

- Added new line which will make the rule to only check for scenarios where the vnet has an associated subnet block.
- Added another rule to throw violation for the scenarios where subnet and security group are associated using 
`azurerm_subnet_network_security_group_association`