### PR TITLE
fix - improved description for init command in help

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -24,7 +24,7 @@ import (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize Terrascan",
+	Short: "Initializes Terrascan and clones policies from the Terrascan GitHub repository.",
 	Long: `Terrascan
 
 Initializes Terrascan and clones policies from the Terrascan GitHub repository.


### PR DESCRIPTION
Fixed the description based on issue #461.
closes #461

The `make cicd` updated `go.mod` and `go.sum` files. I didn't include the changes in this PR, I don't know whether this is required being my first PR to this repo. 

Thank you