### PR TITLE
changes in log level and messages for load iac functions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -913,6 +913,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/pkg/iac-providers/helm/v3/load-dir.go
+++ b/pkg/iac-providers/helm/v3/load-dir.go
@@ -34,10 +34,9 @@ import (
 )
 
 var (
-	errSkipTestDir       = fmt.Errorf("skipping test directory")
-	errNoHelmChartsFound = fmt.Errorf("no helm charts found")
-	errBadChartName      = fmt.Errorf("bad chart name in Chart.yaml")
-	errBadChartVersion   = fmt.Errorf("bad chart version in Chart.yaml")
+	errSkipTestDir     = fmt.Errorf("skipping test directory")
+	errBadChartName    = fmt.Errorf("bad chart name in Chart.yaml")
+	errBadChartVersion = fmt.Errorf("bad chart version in Chart.yaml")
 )
 
 // LoadIacDir loads all helm charts under the specified directory
@@ -48,14 +47,13 @@ func (h *HelmV3) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error
 	// find all Chart.yaml files within the specified directory structure
 	fileMap, err := utils.FindFilesBySuffix(absRootDir, h.getHelmChartFilenames())
 	if err != nil {
-		zap.S().Error("error while searching for helm charts", zap.String("root dir", absRootDir), zap.Error(err))
+		zap.S().Debug("error while searching for helm charts", zap.String("root dir", absRootDir), zap.Error(err))
 		return allResourcesConfig, err
 	}
 
 	if len(fileMap) == 0 {
-		err = errNoHelmChartsFound
-		zap.S().Error("", zap.String("root dir", absRootDir), zap.Error(err))
-		return allResourcesConfig, err
+		zap.S().Debug(zap.String("root dir", absRootDir), zap.Error(err))
+		return allResourcesConfig, fmt.Errorf("no helm charts found in directory %s", absRootDir)
 	}
 
 	// fileDir now contains the chart path
@@ -70,7 +68,7 @@ func (h *HelmV3) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error
 		var chartMap helmChartData
 		iacDocuments, chartMap, err = h.loadChart(chartPath)
 		if err != nil && err != errSkipTestDir {
-			logger.Error("error occurred while loading chart", zap.Error(err))
+			logger.Debug("error occurred while loading chart", zap.Error(err))
 			continue
 		}
 
@@ -165,7 +163,7 @@ func (h *HelmV3) renderChart(chartPath string, chartMap helmChartData, templateD
 		var fileData []byte
 		fileData, err := ioutil.ReadFile(filepath.Join(templateDir, *templateFile))
 		if err != nil {
-			logger.Error("unable to read template file", zap.String("file", *templateFile), zap.Error(err))
+			logger.Debug("error while reading template file", zap.String("file", *templateFile), zap.Error(err))
 			return iacDocuments, err
 		}
 
@@ -178,14 +176,14 @@ func (h *HelmV3) renderChart(chartPath string, chartMap helmChartData, templateD
 	// chart name and version are required parameters
 	chartName, ok := chartMap["name"].(string)
 	if !ok {
-		logger.Error("chart name was invalid")
+		logger.Debug("chart name is invalid")
 		return iacDocuments, errBadChartName
 	}
 
 	var chartVersion string
 	chartVersion, ok = chartMap["version"].(string)
 	if !ok {
-		logger.Error("chart version was invalid")
+		logger.Debug("chart version is invalid")
 		return iacDocuments, errBadChartVersion
 	}
 
@@ -203,7 +201,7 @@ func (h *HelmV3) renderChart(chartPath string, chartMap helmChartData, templateD
 
 	v, err := chartutil.ToRenderValues(c, valueMap, options, nil)
 	if err != nil {
-		logger.Error("value rendering failed", zap.Any("values", v), zap.Error(err))
+		logger.Debug("value rendering failed", zap.Any("values", v), zap.Error(err))
 		return iacDocuments, err
 	}
 
@@ -215,7 +213,7 @@ func (h *HelmV3) renderChart(chartPath string, chartMap helmChartData, templateD
 	e.LintMode = true
 	renderData, err = e.Render(c, v)
 	if err != nil {
-		logger.Error("error encountered while rendering chart", zap.String("template dir", templateDir), zap.Error(err))
+		logger.Debug("error encountered while rendering chart", zap.String("template dir", templateDir), zap.Error(err))
 		return iacDocuments, err
 	}
 
@@ -241,12 +239,12 @@ func (h *HelmV3) loadChart(chartPath string) ([]*utils.IacDocument, helmChartDat
 	// load the chart file and values file from the specified chart path
 	chartFileBytes, err := ioutil.ReadFile(chartPath)
 	if err != nil {
-		logger.Error("unable to read", zap.Error(err))
+		logger.Debug("unable to read", zap.Error(err))
 		return iacDocuments, chartMap, err
 	}
 
 	if err = yaml.Unmarshal(chartFileBytes, &chartMap); err != nil {
-		logger.Error("unable to unmarshal values", zap.Error(err))
+		logger.Debug("unable to unmarshal values", zap.Error(err))
 		return iacDocuments, chartMap, err
 	}
 
@@ -255,7 +253,7 @@ func (h *HelmV3) loadChart(chartPath string) ([]*utils.IacDocument, helmChartDat
 	valuesFile := filepath.Join(chartDir, helmValuesFilename)
 	fileInfo, err = os.Stat(valuesFile)
 	if err != nil {
-		logger.Error("unable to stat values.yaml", zap.Error(err))
+		logger.Debug("unable to stat values.yaml", zap.Error(err))
 		return iacDocuments, chartMap, err
 	}
 
@@ -263,13 +261,13 @@ func (h *HelmV3) loadChart(chartPath string) ([]*utils.IacDocument, helmChartDat
 	var valueFileBytes []byte
 	valueFileBytes, err = ioutil.ReadFile(valuesFile)
 	if err != nil {
-		logger.Error("unable to read values.yaml", zap.Error(err))
+		logger.Debug("unable to read values.yaml", zap.Error(err))
 		return iacDocuments, chartMap, err
 	}
 
 	var valueMap map[string]interface{}
 	if err = yaml.Unmarshal(valueFileBytes, &valueMap); err != nil {
-		logger.Error("unable to unmarshal values.yaml", zap.Error(err))
+		logger.Debug("unable to unmarshal values.yaml", zap.Error(err))
 		return iacDocuments, chartMap, err
 	}
 

--- a/pkg/iac-providers/helm/v3/load-dir.go
+++ b/pkg/iac-providers/helm/v3/load-dir.go
@@ -35,8 +35,8 @@ import (
 
 var (
 	errSkipTestDir     = fmt.Errorf("skipping test directory")
-	errBadChartName    = fmt.Errorf("bad chart name in Chart.yaml")
-	errBadChartVersion = fmt.Errorf("bad chart version in Chart.yaml")
+	errBadChartName    = fmt.Errorf("invalid chart name in Chart.yaml")
+	errBadChartVersion = fmt.Errorf("invalid chart version in Chart.yaml")
 )
 
 // LoadIacDir loads all helm charts under the specified directory

--- a/pkg/iac-providers/helm/v3/load-dir_test.go
+++ b/pkg/iac-providers/helm/v3/load-dir_test.go
@@ -35,35 +35,33 @@ func TestLoadIacDir(t *testing.T) {
 		dirPath       string
 		helmv3        HelmV3
 		want          output.AllResourceConfigs
-		wantErr       error
+		wantErr       bool
 		resourceCount int
 	}{
 		{
 			name:          "happy path (credit to madhuakula/kubernetes-goat)",
 			dirPath:       "./testdata/happy-path",
 			helmv3:        HelmV3{},
-			wantErr:       nil,
 			resourceCount: 3,
 		},
 		{
 			name:          "happy path with subchart (credit to madhuakula/kubernetes-goat)",
 			dirPath:       "./testdata/happy-path-with-subchart",
 			helmv3:        HelmV3{},
-			wantErr:       nil,
 			resourceCount: 5,
 		},
 		{
 			name:          "bad directory",
 			dirPath:       "./testdata/bad-dir",
 			helmv3:        HelmV3{},
-			wantErr:       &os.PathError{Err: syscall.ENOENT, Op: "lstat", Path: "./testdata/bad-dir"},
+			wantErr:       true,
 			resourceCount: 0,
 		},
 		{
 			name:          "no helm charts in directory",
 			dirPath:       "./testdata/no-helm-charts",
 			helmv3:        HelmV3{},
-			wantErr:       errNoHelmChartsFound,
+			wantErr:       true,
 			resourceCount: 0,
 		},
 	}
@@ -71,7 +69,7 @@ func TestLoadIacDir(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			resources, gotErr := tt.helmv3.LoadIacDir(tt.dirPath)
-			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			if tt.wantErr && gotErr == nil {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 

--- a/pkg/iac-providers/helm/v3/load-dir_test.go
+++ b/pkg/iac-providers/helm/v3/load-dir_test.go
@@ -35,7 +35,7 @@ func TestLoadIacDir(t *testing.T) {
 		dirPath       string
 		helmv3        HelmV3
 		want          output.AllResourceConfigs
-		wantErr       bool
+		wantErr       error
 		resourceCount int
 	}{
 		{
@@ -54,14 +54,14 @@ func TestLoadIacDir(t *testing.T) {
 			name:          "bad directory",
 			dirPath:       "./testdata/bad-dir",
 			helmv3:        HelmV3{},
-			wantErr:       true,
+			wantErr:       &os.PathError{Err: syscall.ENOENT, Op: "lstat", Path: "./testdata/bad-dir"},
 			resourceCount: 0,
 		},
 		{
 			name:          "no helm charts in directory",
 			dirPath:       "./testdata/no-helm-charts",
 			helmv3:        HelmV3{},
-			wantErr:       true,
+			wantErr:       fmt.Errorf("no helm charts found in directory ./testdata/no-helm-charts"),
 			resourceCount: 0,
 		},
 	}
@@ -69,7 +69,7 @@ func TestLoadIacDir(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			resources, gotErr := tt.helmv3.LoadIacDir(tt.dirPath)
-			if tt.wantErr && gotErr == nil {
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 

--- a/pkg/iac-providers/kubernetes/v1/load-dir.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir.go
@@ -28,7 +28,7 @@ func (k *K8sV1) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error)
 
 	fileMap, err := utils.FindFilesBySuffix(absRootDir, K8sFileExtensions())
 	if err != nil {
-		zap.S().Warn("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
+		zap.S().Debug("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
 		return allResourcesConfig, err
 	}
 

--- a/pkg/iac-providers/kubernetes/v1/load-file.go
+++ b/pkg/iac-providers/kubernetes/v1/load-file.go
@@ -11,25 +11,25 @@ import (
 
 // LoadIacFile loads the k8s file specified
 // Note that a single k8s yaml file may contain multiple resource definitions
-func (k *K8sV1) LoadIacFile(filePath string) (allResourcesConfig output.AllResourceConfigs, err error) {
+func (k *K8sV1) LoadIacFile(absFilePath string) (allResourcesConfig output.AllResourceConfigs, err error) {
 	allResourcesConfig = make(map[string][]output.ResourceConfig)
 
 	var iacDocuments []*utils.IacDocument
 
-	fileExt := k.getFileType(filePath)
+	fileExt := k.getFileType(absFilePath)
 	switch fileExt {
 	case YAMLExtension:
 		fallthrough
 	case YAMLExtension2:
-		iacDocuments, err = utils.LoadYAML(filePath)
+		iacDocuments, err = utils.LoadYAML(absFilePath)
 	case JSONExtension:
-		iacDocuments, err = utils.LoadJSON(filePath)
+		iacDocuments, err = utils.LoadJSON(absFilePath)
 	default:
 		zap.S().Debug("unknown extension found", zap.String("extension", fileExt))
-		return allResourcesConfig, fmt.Errorf("unknown file extension for file %s", filePath)
+		return allResourcesConfig, fmt.Errorf("unknown file extension for file %s", absFilePath)
 	}
 	if err != nil {
-		zap.S().Debug("failed to load file", zap.String("file", filePath))
+		zap.S().Debug("failed to load file", zap.String("file", absFilePath))
 		return allResourcesConfig, err
 	}
 
@@ -37,12 +37,12 @@ func (k *K8sV1) LoadIacFile(filePath string) (allResourcesConfig output.AllResou
 		var config *output.ResourceConfig
 		config, err = k.Normalize(doc)
 		if err != nil {
-			zap.S().Debug("unable to normalize data", zap.Error(err), zap.String("file", filePath))
+			zap.S().Debug("unable to normalize data", zap.Error(err), zap.String("file", absFilePath))
 			continue
 		}
 
 		config.Line = doc.StartLine
-		config.Source = filePath
+		config.Source = absFilePath
 
 		allResourcesConfig[config.Type] = append(allResourcesConfig[config.Type], *config)
 	}

--- a/pkg/iac-providers/kustomize/v3/load-dir.go
+++ b/pkg/iac-providers/kustomize/v3/load-dir.go
@@ -17,9 +17,7 @@ const (
 )
 
 var (
-	errorKustomizeNotFound     = fmt.Errorf("kustomization.y(a)ml file not found in the directory")
-	errorMultipleKustomizeFile = fmt.Errorf("multiple kustomization.y(a)ml found in the directory")
-	errorFromKustomize         = fmt.Errorf("error from kustomization")
+	errorFromKustomize = fmt.Errorf("error from kustomization")
 )
 
 // LoadIacDir loads the kustomize directory and returns the ResourceConfig mapping which is evaluated by the policy engine
@@ -29,20 +27,18 @@ func (k *KustomizeV3) LoadIacDir(absRootDir string) (output.AllResourceConfigs, 
 
 	files, err := utils.FindFilesBySuffixInDir(absRootDir, KustomizeFileNames())
 	if err != nil {
-		zap.S().Error("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
+		zap.S().Debug("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
 		return allResourcesConfig, err
 	}
 
 	if len(files) == 0 {
-		err = errorKustomizeNotFound
-		zap.S().Error("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
-		return allResourcesConfig, err
+		zap.S().Debug("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
+		return allResourcesConfig, fmt.Errorf("kustomization.y(a)ml file not found in the directory %s", absRootDir)
 	}
 
 	if len(files) > 1 {
-		err = errorMultipleKustomizeFile
-		zap.S().Error("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
-		return allResourcesConfig, err
+		zap.S().Debug("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
+		return allResourcesConfig, fmt.Errorf("multiple kustomization.y(a)ml found in the directory %s", absRootDir)
 	}
 
 	kustomizeFileName := *files[0]

--- a/pkg/iac-providers/kustomize/v3/load-dir.go
+++ b/pkg/iac-providers/kustomize/v3/load-dir.go
@@ -45,7 +45,7 @@ func (k *KustomizeV3) LoadIacDir(absRootDir string) (output.AllResourceConfigs, 
 	yamlkustomizeobj, err := utils.ReadYamlFile(filepath.Join(absRootDir, kustomizeFileName))
 
 	if err != nil {
-		err = fmt.Errorf("unable to read the kustomization file in the directory : %v", err)
+		err = fmt.Errorf("unable to read the kustomization file in the directory %s, error: %v", absRootDir, err)
 		zap.S().Error("error while reading the file", kustomizeFileName, zap.Error(err))
 		return allResourcesConfig, err
 	}

--- a/pkg/iac-providers/kustomize/v3/load-dir_test.go
+++ b/pkg/iac-providers/kustomize/v3/load-dir_test.go
@@ -1,17 +1,12 @@
 package kustomizev3
 
 import (
-	"fmt"
-	"os"
 	"reflect"
-	"syscall"
 	"testing"
 
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
 	"github.com/accurics/terrascan/pkg/utils"
 )
-
-var errorReadKustomize = fmt.Errorf("unable to read the kustomization file in the directory : %s", utils.ErrYamlFileEmpty.Error())
 
 func TestLoadIacDir(t *testing.T) {
 
@@ -20,42 +15,38 @@ func TestLoadIacDir(t *testing.T) {
 		dirPath       string
 		kustomize     KustomizeV3
 		want          output.AllResourceConfigs
-		wantErr       error
+		wantErr       bool
 		resourceCount int
 	}{
 		{
 			name:          "invalid dirPath",
 			dirPath:       "not-there",
 			kustomize:     KustomizeV3{},
-			wantErr:       &os.PathError{Err: syscall.ENOENT, Op: "open", Path: "not-there"},
+			wantErr:       true,
 			resourceCount: 0,
 		},
 		{
 			name:          "simple-deployment",
 			dirPath:       "./testdata/simple-deployment",
 			kustomize:     KustomizeV3{},
-			wantErr:       nil,
 			resourceCount: 4,
 		},
 		{
 			name:          "multibases",
 			dirPath:       "./testdata/multibases/base",
 			kustomize:     KustomizeV3{},
-			wantErr:       nil,
 			resourceCount: 2,
 		},
 		{
 			name:          "multibases",
 			dirPath:       "./testdata/multibases/dev",
 			kustomize:     KustomizeV3{},
-			wantErr:       nil,
 			resourceCount: 2,
 		},
 		{
 			name:          "multibases",
 			dirPath:       "./testdata/multibases/prod",
 			kustomize:     KustomizeV3{},
-			wantErr:       nil,
 			resourceCount: 2,
 		},
 
@@ -63,28 +54,26 @@ func TestLoadIacDir(t *testing.T) {
 			name:          "multibases",
 			dirPath:       "./testdata/multibases/stage",
 			kustomize:     KustomizeV3{},
-			wantErr:       nil,
 			resourceCount: 2,
 		},
 		{
 			name:          "multibases",
 			dirPath:       "./testdata/multibases",
 			kustomize:     KustomizeV3{},
-			wantErr:       nil,
 			resourceCount: 4,
 		},
 		{
 			name:          "no-kustomize-directory",
 			dirPath:       "./testdata/no-kustomizefile",
 			kustomize:     KustomizeV3{},
-			wantErr:       errorKustomizeNotFound,
+			wantErr:       true,
 			resourceCount: 0,
 		},
 		{
 			name:          "kustomize-file-empty",
 			dirPath:       "./testdata/kustomize-file-empty",
 			kustomize:     KustomizeV3{},
-			wantErr:       errorReadKustomize,
+			wantErr:       true,
 			resourceCount: 0,
 		},
 	}
@@ -92,7 +81,7 @@ func TestLoadIacDir(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			resourceMap, gotErr := tt.kustomize.LoadIacDir(tt.dirPath)
-			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			if tt.wantErr && gotErr == nil {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 

--- a/pkg/iac-providers/terraform.go
+++ b/pkg/iac-providers/terraform.go
@@ -13,7 +13,7 @@ const (
 	terraformV12            supportedIacVersion = "v12"
 	terraformV13            supportedIacVersion = "v13"
 	terraformV14            supportedIacVersion = "v14"
-	terraformDefaultVersion                     = terraformV12
+	terraformDefaultVersion                     = terraformV14
 )
 
 // register terraform as an IaC provider with terrascan

--- a/pkg/iac-providers/terraform/commons/load-dir.go
+++ b/pkg/iac-providers/terraform/commons/load-dir.go
@@ -68,7 +68,7 @@ func LoadIacDir(absRootDir string) (allResourcesConfig output.AllResourceConfigs
 	// load root config directory
 	rootMod, diags := parser.LoadConfigDir(absRootDir)
 	if diags.HasErrors() {
-		errMessage := fmt.Sprintf("failed to load terraform config dir '%s'. error:\n%+v\n", absRootDir, diags)
+		errMessage := fmt.Sprintf("failed to load terraform config dir '%s'. error from terraform:\n%+v\n", absRootDir, getErrorMessagesFromDiagnostics(diags))
 		zap.S().Debug(errMessage)
 		return allResourcesConfig, fmt.Errorf(errMessage)
 	}

--- a/pkg/iac-providers/terraform/commons/load-dir.go
+++ b/pkg/iac-providers/terraform/commons/load-dir.go
@@ -34,10 +34,6 @@ import (
 )
 
 var (
-	// ErrEmptyTFConfigDir error
-	ErrEmptyTFConfigDir = fmt.Errorf("directory has no terraform files")
-	// ErrLoadConfigDir error
-	ErrLoadConfigDir = fmt.Errorf("failed to load terraform allResourcesConfig dir")
 	// ErrBuildTFConfigDir error
 	ErrBuildTFConfigDir = fmt.Errorf("failed to build terraform allResourcesConfig")
 )
@@ -64,15 +60,17 @@ func LoadIacDir(absRootDir string) (allResourcesConfig output.AllResourceConfigs
 
 	// check if the directory has any tf config files (.tf or .tf.json)
 	if !parser.IsConfigDir(absRootDir) {
-		zap.S().Errorf("directory '%s' has no terraform config files", absRootDir)
-		return allResourcesConfig, ErrEmptyTFConfigDir
+		errMessage := fmt.Sprintf("directory '%s' has no terraform config files", absRootDir)
+		zap.S().Debug(errMessage)
+		return allResourcesConfig, fmt.Errorf(errMessage)
 	}
 
 	// load root config directory
 	rootMod, diags := parser.LoadConfigDir(absRootDir)
 	if diags.HasErrors() {
-		zap.S().Errorf("failed to load terraform config dir '%s'. error:\n%+v\n", absRootDir, diags)
-		return allResourcesConfig, ErrLoadConfigDir
+		errMessage := fmt.Sprintf("failed to load terraform config dir '%s'. error:\n%+v\n", absRootDir, diags)
+		zap.S().Debug(errMessage)
+		return allResourcesConfig, fmt.Errorf(errMessage)
 	}
 
 	// create a new downloader to install remote modules

--- a/pkg/iac-providers/terraform/commons/load-file.go
+++ b/pkg/iac-providers/terraform/commons/load-file.go
@@ -26,11 +26,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	// ErrLoadConfigFile error
-	ErrLoadConfigFile = fmt.Errorf("failed to load config file")
-)
-
 // LoadIacFile parses the given terraform file from the given file path
 func LoadIacFile(absFilePath string) (allResourcesConfig output.AllResourceConfigs, err error) {
 
@@ -39,12 +34,14 @@ func LoadIacFile(absFilePath string) (allResourcesConfig output.AllResourceConfi
 
 	hclFile, diags := parser.LoadConfigFile(absFilePath)
 	if diags != nil {
-		zap.S().Errorf("failed to load config file '%s'. error:\n%v\n", absFilePath, diags)
-		return allResourcesConfig, ErrLoadConfigFile
+		errMessage := fmt.Sprintf("failed to load config file '%s'. error:\n%v\n", absFilePath, diags)
+		zap.S().Debug(errMessage)
+		return allResourcesConfig, fmt.Errorf(errMessage)
 	}
 	if hclFile == nil && diags.HasErrors() {
-		zap.S().Errorf("error occured while loading config file. error:\n%v\n", diags)
-		return allResourcesConfig, ErrLoadConfigFile
+		errMessage := fmt.Sprintf("error occured while loading config file. error:\n%v\n", diags)
+		zap.S().Debug(errMessage)
+		return allResourcesConfig, fmt.Errorf(errMessage)
 	}
 
 	// initialize normalized output

--- a/pkg/iac-providers/terraform/v12/load-dir_test.go
+++ b/pkg/iac-providers/terraform/v12/load-dir_test.go
@@ -18,6 +18,7 @@ package tfv12
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -27,50 +28,60 @@ import (
 )
 
 func TestLoadIacDir(t *testing.T) {
+	testErrorString1 := `failed to load terraform config dir './testdata'. error from terraform:
+testdata/empty.tf:1,21-2,1: Invalid block definition; A block definition must have block content delimited by "{" and "}", starting on the same line as the block header.
+testdata/empty.tf:1,1-5: Unsupported block type; Blocks of type "some" are not expected here.
+`
+	testErrorString2 := `failed to load terraform config dir './testdata/multiple-required-providers'. error from terraform:
+testdata/multiple-required-providers/b.tf:2,3-21: Duplicate required providers configuration; A module may have only one required providers configuration. The required providers were previously configured at testdata/multiple-required-providers/a.tf:2,3-21.
+`
+	testDirPath1 := "not-there"
+	testDirPath2 := "./testdata/testfile"
+	invalidDirErrStringTemplate := "directory '%s' has no terraform config files"
 
 	table := []struct {
 		name    string
 		dirPath string
 		tfv12   TfV12
 		want    output.AllResourceConfigs
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name:    "invalid dirPath",
-			dirPath: "not-there",
+			dirPath: testDirPath1,
 			tfv12:   TfV12{},
-			wantErr: true,
+			wantErr: fmt.Errorf(invalidDirErrStringTemplate, testDirPath1),
 		},
 		{
 			name:    "empty config",
-			dirPath: "./testdata/testfile",
+			dirPath: testDirPath2,
 			tfv12:   TfV12{},
-			wantErr: true,
+			wantErr: fmt.Errorf(invalidDirErrStringTemplate, testDirPath2),
 		},
 		{
 			name:    "incorrect module structure",
 			dirPath: "./testdata/invalid-moduleconfigs",
 			tfv12:   TfV12{},
-			wantErr: true,
+			wantErr: fmt.Errorf("failed to build terraform allResourcesConfig"),
 		},
 		{
 			name:    "load invalid config dir",
 			dirPath: "./testdata",
 			tfv12:   TfV12{},
-			wantErr: true,
+			wantErr: fmt.Errorf(testErrorString1),
 		},
 		{
 			name:    "load invalid config dir",
 			dirPath: "./testdata/multiple-required-providers",
 			tfv12:   TfV12{},
-			wantErr: true,
+			wantErr: fmt.Errorf(testErrorString2),
 		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.tfv12.LoadIacDir(tt.dirPath)
-			if tt.wantErr && gotErr == nil {
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 		})

--- a/pkg/iac-providers/terraform/v12/load-dir_test.go
+++ b/pkg/iac-providers/terraform/v12/load-dir_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
-	"github.com/accurics/terrascan/pkg/iac-providers/terraform/commons"
 	commons_test "github.com/accurics/terrascan/pkg/iac-providers/terraform/commons/test"
 )
 
@@ -34,44 +33,44 @@ func TestLoadIacDir(t *testing.T) {
 		dirPath string
 		tfv12   TfV12
 		want    output.AllResourceConfigs
-		wantErr error
+		wantErr bool
 	}{
 		{
 			name:    "invalid dirPath",
 			dirPath: "not-there",
 			tfv12:   TfV12{},
-			wantErr: commons.ErrEmptyTFConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "empty config",
 			dirPath: "./testdata/testfile",
 			tfv12:   TfV12{},
-			wantErr: commons.ErrEmptyTFConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "incorrect module structure",
 			dirPath: "./testdata/invalid-moduleconfigs",
 			tfv12:   TfV12{},
-			wantErr: commons.ErrBuildTFConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "load invalid config dir",
 			dirPath: "./testdata",
 			tfv12:   TfV12{},
-			wantErr: commons.ErrLoadConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "load invalid config dir",
 			dirPath: "./testdata/multiple-required-providers",
 			tfv12:   TfV12{},
-			wantErr: commons.ErrLoadConfigDir,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.tfv12.LoadIacDir(tt.dirPath)
-			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			if tt.wantErr && gotErr == nil {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 		})

--- a/pkg/iac-providers/terraform/v12/load-file_test.go
+++ b/pkg/iac-providers/terraform/v12/load-file_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
-	"github.com/accurics/terrascan/pkg/iac-providers/terraform/commons"
 )
 
 func TestLoadIacFile(t *testing.T) {
@@ -34,38 +33,37 @@ func TestLoadIacFile(t *testing.T) {
 		filePath string
 		tfv12    TfV12
 		want     output.AllResourceConfigs
-		wantErr  error
+		wantErr  bool
 	}{
 		{
 			name:     "invalid filepath",
 			filePath: "not-there",
 			tfv12:    TfV12{},
-			wantErr:  commons.ErrLoadConfigFile,
+			wantErr:  true,
 		},
 		{
 			name:     "empty config",
 			filePath: "./testdata/testfile",
 			tfv12:    TfV12{},
-			wantErr:  nil,
 		},
 		{
 			name:     "invalid config",
 			filePath: "./testdata/empty.tf",
 			tfv12:    TfV12{},
-			wantErr:  commons.ErrLoadConfigFile,
+			wantErr:  true,
 		},
 		{
 			name:     "destroy-provisioners",
 			filePath: "./testdata/destroy-provisioners/main.tf",
 			tfv12:    TfV12{},
-			wantErr:  commons.ErrLoadConfigFile,
+			wantErr:  true,
 		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.tfv12.LoadIacFile(tt.filePath)
-			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			if tt.wantErr && gotErr == nil {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 		})

--- a/pkg/iac-providers/terraform/v14/load-dir_test.go
+++ b/pkg/iac-providers/terraform/v14/load-dir_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
-	"github.com/accurics/terrascan/pkg/iac-providers/terraform/commons"
 	commons_test "github.com/accurics/terrascan/pkg/iac-providers/terraform/commons/test"
 )
 
@@ -34,38 +33,38 @@ func TestLoadIacDir(t *testing.T) {
 		dirPath string
 		tfv14   TfV14
 		want    output.AllResourceConfigs
-		wantErr error
+		wantErr bool
 	}{
 		{
 			name:    "invalid dirPath",
 			dirPath: "not-there",
 			tfv14:   TfV14{},
-			wantErr: commons.ErrEmptyTFConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "empty config",
 			dirPath: "./testdata/testfile",
 			tfv14:   TfV14{},
-			wantErr: commons.ErrEmptyTFConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "incorrect module structure",
 			dirPath: "./testdata/invalid-moduleconfigs",
 			tfv14:   TfV14{},
-			wantErr: commons.ErrBuildTFConfigDir,
+			wantErr: true,
 		},
 		{
 			name:    "load invalid config dir",
 			dirPath: "./testdata",
 			tfv14:   TfV14{},
-			wantErr: commons.ErrLoadConfigDir,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.tfv14.LoadIacDir(tt.dirPath)
-			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			if tt.wantErr && gotErr == nil {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 		})

--- a/pkg/iac-providers/terraform/v14/load-file_test.go
+++ b/pkg/iac-providers/terraform/v14/load-file_test.go
@@ -19,6 +19,7 @@ package tfv14
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -28,18 +29,26 @@ import (
 
 func TestLoadIacFile(t *testing.T) {
 
+	testErrorString1 := `error occured while loading config file 'not-there'. error:
+<nil>: Failed to read file; The file "not-there" could not be read.
+`
+	testErrorString2 := `failed to load config file './testdata/empty.tf'. error:
+./testdata/empty.tf:1,21-2,1: Invalid block definition; A block definition must have block content delimited by "{" and "}", starting on the same line as the block header.
+./testdata/empty.tf:1,1-5: Unsupported block type; Blocks of type "some" are not expected here.
+`
+
 	table := []struct {
 		name     string
 		filePath string
 		tfv14    TfV14
 		want     output.AllResourceConfigs
-		wantErr  bool
+		wantErr  error
 	}{
 		{
 			name:     "invalid filepath",
 			filePath: "not-there",
 			tfv14:    TfV14{},
-			wantErr:  true,
+			wantErr:  fmt.Errorf(testErrorString1),
 		},
 		{
 			name:     "empty config",
@@ -50,7 +59,7 @@ func TestLoadIacFile(t *testing.T) {
 			name:     "invalid config",
 			filePath: "./testdata/empty.tf",
 			tfv14:    TfV14{},
-			wantErr:  true,
+			wantErr:  fmt.Errorf(testErrorString2),
 		},
 		{
 			name:     "depends_on",
@@ -77,7 +86,7 @@ func TestLoadIacFile(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.tfv14.LoadIacFile(tt.filePath)
-			if tt.wantErr && gotErr == nil {
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 		})

--- a/pkg/iac-providers/terraform/v14/load-file_test.go
+++ b/pkg/iac-providers/terraform/v14/load-file_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/accurics/terrascan/pkg/iac-providers/output"
-	"github.com/accurics/terrascan/pkg/iac-providers/terraform/commons"
 )
 
 func TestLoadIacFile(t *testing.T) {
@@ -34,56 +33,51 @@ func TestLoadIacFile(t *testing.T) {
 		filePath string
 		tfv14    TfV14
 		want     output.AllResourceConfigs
-		wantErr  error
+		wantErr  bool
 	}{
 		{
 			name:     "invalid filepath",
 			filePath: "not-there",
 			tfv14:    TfV14{},
-			wantErr:  commons.ErrLoadConfigFile,
+			wantErr:  true,
 		},
 		{
 			name:     "empty config",
 			filePath: "./testdata/testfile",
 			tfv14:    TfV14{},
-			wantErr:  nil,
 		},
 		{
 			name:     "invalid config",
 			filePath: "./testdata/empty.tf",
 			tfv14:    TfV14{},
-			wantErr:  commons.ErrLoadConfigFile,
+			wantErr:  true,
 		},
 		{
 			name:     "depends_on",
 			filePath: "./testdata/depends_on/main.tf",
 			tfv14:    TfV14{},
-			wantErr:  nil,
 		},
 		{
 			name:     "count",
 			filePath: "./testdata/count/main.tf",
 			tfv14:    TfV14{},
-			wantErr:  nil,
 		},
 		{
 			name:     "for_each",
 			filePath: "./testdata/for_each/main.tf",
 			tfv14:    TfV14{},
-			wantErr:  nil,
 		},
 		{
 			name:     "required_providers",
 			filePath: "./testdata/required-providers/main.tf",
 			tfv14:    TfV14{},
-			wantErr:  nil,
 		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			_, gotErr := tt.tfv14.LoadIacFile(tt.filePath)
-			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			if tt.wantErr && gotErr == nil {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", gotErr, tt.wantErr)
 			}
 		})

--- a/pkg/runtime/validate_test.go
+++ b/pkg/runtime/validate_test.go
@@ -109,6 +109,22 @@ func TestValidateInputs(t *testing.T) {
 			wantErr: errDirNotExists,
 		},
 		{
+			// should error out in validations if -f option is not a file
+			name: "valid directory passed as file path",
+			executor: Executor{
+				filePath: "./testdata/testdir",
+			},
+			wantErr: errNotValidFile,
+		},
+		{
+			// should error out in validations if -d option is not a dir
+			name: "valid directory passed as file path",
+			executor: Executor{
+				dirPath: "./testdata/testdir/testfile",
+			},
+			wantErr: errNotValidDir,
+		},
+		{
 			name: "invalid iac type",
 			executor: Executor{
 				filePath:   "",


### PR DESCRIPTION
1. change default terraform version to v14 from v12
2. modified log levels and changed log messages (few) in load iac functions of all iac providers
3. modified related unit tests
4. added file mode validation in executor for iacDirPath and iacFilePath
