### PR TITLE
fix:adding new policy and enhancing the noisy policy

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_container_cluster/AC-GC-IS-CC-M-0367.json
+++ b/pkg/policies/opa/rego/gcp/google_container_cluster/AC-GC-IS-CC-M-0367.json
@@ -1,0 +1,10 @@
+{
+    "name": "gkeControlPlanePublicAccess",
+    "file": "gkeControlPlanePublicAccess.rego",
+    "template_args": null,
+    "severity": "Medium",
+    "description": "GKE Control Plane is exposed to few public IP addresses using master-authorized-network-config",
+    "reference_id": "AC-GC-IS-CC-M-0367",
+    "category": "Infrastructure Security",
+    "version": 1
+}

--- a/pkg/policies/opa/rego/gcp/google_container_cluster/gkeControlPlaneNotPublic.rego
+++ b/pkg/policies/opa/rego/gcp/google_container_cluster/gkeControlPlaneNotPublic.rego
@@ -4,4 +4,11 @@ gkeControlPlaneNotPublic[api.id] {
     api := input.google_container_cluster[_]
     pCluster := api.config.private_cluster_config[_]
     pCluster.enable_private_endpoint != true
+    object.get(api.config, "master_authorized_networks_config", "undefined") == ["undefined", []][_]
+}
+
+gkeControlPlaneNotPublic[api.id] {
+    api := input.google_container_cluster[_]
+    object.get(api.config, "private_cluster_config", "undefined") == ["undefined", []][_]
+    object.get(api.config, "master_authorized_networks_config", "undefined") == ["undefined", []][_]
 }

--- a/pkg/policies/opa/rego/gcp/google_container_cluster/gkeControlPlanePublicAccess.rego
+++ b/pkg/policies/opa/rego/gcp/google_container_cluster/gkeControlPlanePublicAccess.rego
@@ -1,0 +1,18 @@
+package accurics
+
+gkeControlPlanePublicAccess[api.id] {
+    api := input.google_container_cluster[_]
+    pCluster := api.config.private_cluster_config[_]
+    pCluster.enable_private_endpoint != true
+    cidr := api.config.master_authorized_networks_config[_].cidr_blocks[_].cidr_block
+    checkScopeIsPublic(cidr)
+}
+
+scopeIsPrivate(scope) {
+    private_ips = ["10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"]
+    net.cidr_contains(private_ips[_], scope)
+}
+
+checkScopeIsPublic(val) {
+    not scopeIsPrivate(val)
+}


### PR DESCRIPTION
fix proposed for #569 includes:
1. Enhancing the existing policy to only throw violation if private_endpoint is not true and master_authorized_networks_config is not used.
2. Included new policy with medium violation provided master_authorized_networks_config CIDR block has a public IP address associated.