### PR TITLE
Server mode: take file extension from uploaded file

### DIFF
--- a/pkg/http-server/file-scan.go
+++ b/pkg/http-server/file-scan.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 
@@ -62,12 +63,17 @@ func (g *APIHandler) scanFile(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
+	// fileExtension will include the period. (eg ".yaml")
+	fileExtension := path.Ext(handler.Filename)
+
 	zap.S().Debugf("uploaded file: %+v", handler.Filename)
+	zap.S().Debugf("uploaded file extension: %+v", fileExtension)
 	zap.S().Debugf("file size: %+v", handler.Size)
 	zap.S().Debugf("MIME header: %+v", handler.Header)
 
 	// Create a temporary file within temp directory
-	tempFile, err := ioutil.TempFile("", "terrascan-*.tf")
+	tempFileTemplate := fmt.Sprintf("terrascan-*%s", fileExtension)
+	tempFile, err := ioutil.TempFile("", tempFileTemplate)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to create temp file. error: '%v'", err)
 		zap.S().Error(errMsg)

--- a/pkg/http-server/file-scan_test.go
+++ b/pkg/http-server/file-scan_test.go
@@ -219,6 +219,22 @@ func TestUpload(t *testing.T) {
 			invalidShowPassed: true,
 			wantStatus:        http.StatusBadRequest,
 		},
+		{
+			name:       "scan valid kubernetes yaml",
+			path:       "../iac-providers/kubernetes/v1/testdata/yaml-extension2/test_pod.yml",
+			param:      testParamName,
+			iacType:    "k8s",
+			cloudType:  testCloudType,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "scan valid tfplan json",
+			path:       "../iac-providers/tfplan/v1/testdata/valid-tfplan.json",
+			param:      testParamName,
+			iacType:    "tfplan",
+			cloudType:  testCloudType,
+			wantStatus: http.StatusOK,
+		},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
Changes to take temp file extension from uploaded file so we can support more than .tf when in server mode.

Alternately - I was thinking of adding GetDefaultExtension() to each of the iac-providers and then naming the temp file based on the iac type passed. That might be a little more secure, but not by very much. Gimme thoughts...