### PR TITLE
Log error in LoadIacDir before continuing

### DIFF
--- a/pkg/iac-providers/kubernetes/v1/load-dir.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir.go
@@ -38,6 +38,7 @@ func (k *K8sV1) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error)
 
 			var configData output.AllResourceConfigs
 			if configData, err = k.LoadIacFile(file); err != nil {
+				zap.S().Debug("error while loading iac files", zap.String("IAC file", file), zap.Error(err))
 				continue
 			}
 


### PR DESCRIPTION
We were ignoring an error here. Ensuring it's logged before continuing.