### PR TITLE
Add /go/bin to PATH.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -29,6 +29,8 @@ RUN addgroup --gid 101 terrascan && \
 # run as non root user
 USER terrascan
 
+ENV PATH /go/bin:$PATH
+
 # copy terrascan binary from build
 COPY --from=builder /go/bin/terrascan /go/bin/terrascan
 


### PR DESCRIPTION
Resolves #577 by adding `/go/bin` to the container's PATH.

**Local Test Output**

```
docker run -it --entrypoint /bin/sh accurics/terrascan:6b94411 
/ $ echo $PATH
/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
/ $ terrascan
Terrascan

Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
For more information, please visit https://docs.accurics.com

Usage:
  terrascan [command]

Available Commands:
  help        Help about any command
  init        Initializes Terrascan and clones policies from the Terrascan GitHub repository.
  scan        Detect compliance and security violations across Infrastructure as Code.
  server      Run Terrascan as an API server
  version     Terrascan version

Flags:
  -c, --config-path string   config file path
  -h, --help                 help for terrascan
  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
  -x, --log-type string      log output type (console, json) (default "console")
  -o, --output string        output type (human, json, yaml, xml, junit-xml) (default "human")

Use "terrascan [command] --help" for more information about a command.
```