### PR TITLE
fix - terrascan not able to read modules within a subdirectory

### DIFF
--- a/pkg/iac-providers/terraform/commons/load-dir.go
+++ b/pkg/iac-providers/terraform/commons/load-dir.go
@@ -198,7 +198,7 @@ func processLocalSource(req *hclConfigs.ModuleRequest) string {
 	// path of caller dir, and join the source address of current module request to get the path to module
 
 	// get the caller dir path
-	callDirPath := filepath.Join(req.CallRange.Filename, "..")
+	callDirPath := filepath.Dir(req.CallRange.Filename)
 
 	// join source address to the caller dir
 	return filepath.Join(callDirPath, req.SourceAddr)


### PR DESCRIPTION
modified the logic to get module path for local source.

tested with:
1. source = "git::https://github.com/terraform-aws-modules/terraform-aws-security-group//modules/http-80?ref=v3.18.0"
2. source = "terraform-aws-modules/security-group/aws//modules/http-80"