### PR TITLE
fix - k8s resources config data has absolute source paths for resources

### DIFF
--- a/pkg/iac-providers/kubernetes/v1/load-dir.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir.go
@@ -43,10 +43,34 @@ func (k *K8sV1) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error)
 			}
 
 			for key := range configData {
+				// the source path formed for each resources is absolute, which should be relative
+				resourceConfigs := configData[key]
+				updateSourcePaths(absRootDir, resourceConfigs)
+
 				allResourcesConfig[key] = append(allResourcesConfig[key], configData[key]...)
 			}
 		}
 	}
 
 	return allResourcesConfig, nil
+}
+
+// updateSourcePaths modifies the source path of each resource from absolute to relative path
+func updateSourcePaths(absRootDir string, resourceConfigs []output.ResourceConfig) {
+	for i := range resourceConfigs {
+		r := &resourceConfigs[i]
+		var err error
+
+		oldSource := r.Source
+
+		// update the source path
+		r.Source, err = filepath.Rel(absRootDir, r.Source)
+
+		// though this error should never occur, but, if occurs for some reason, assign the old value of source back
+		if err != nil {
+			r.Source = oldSource
+			zap.S().Debug("error while getting the relative path for", zap.String("IAC file", oldSource), zap.Error(err))
+			continue
+		}
+	}
 }

--- a/pkg/iac-providers/kubernetes/v1/load-dir.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir.go
@@ -45,7 +45,7 @@ func (k *K8sV1) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error)
 			for key := range configData {
 				// the source path formed for each resources is absolute, which should be relative
 				resourceConfigs := configData[key]
-				updateSourcePaths(absRootDir, resourceConfigs)
+				makeSourcePathRelative(absRootDir, resourceConfigs)
 
 				allResourcesConfig[key] = append(allResourcesConfig[key], configData[key]...)
 			}
@@ -55,8 +55,8 @@ func (k *K8sV1) LoadIacDir(absRootDir string) (output.AllResourceConfigs, error)
 	return allResourcesConfig, nil
 }
 
-// updateSourcePaths modifies the source path of each resource from absolute to relative path
-func updateSourcePaths(absRootDir string, resourceConfigs []output.ResourceConfig) {
+// makeSourcePathRelative modifies the source path of each resource from absolute to relative path
+func makeSourcePathRelative(absRootDir string, resourceConfigs []output.ResourceConfig) {
 	for i := range resourceConfigs {
 		r := &resourceConfigs[i]
 		var err error

--- a/pkg/iac-providers/kubernetes/v1/load-dir_test.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir_test.go
@@ -92,7 +92,7 @@ func TestLoadIacDir(t *testing.T) {
 
 }
 
-func TestUpdateSourcePaths(t *testing.T) {
+func TestMakeSourcePathRelative(t *testing.T) {
 	dir1, dir2 := "Dir1", "Dir2"
 	sourcePath1 := filepath.Join(dir1, dir2, "filename.yaml")
 	sourcePath2 := filepath.Join(dir1, "someDir", "test.yaml")
@@ -116,7 +116,7 @@ func TestUpdateSourcePaths(t *testing.T) {
 		args                 args
 	}{
 		{
-			name:                 "test1",
+			name:                 "test to verify path becomes relative",
 			expectedSourceValues: []string{filepath.Join(dir2, "filename.yaml"), filepath.Join("someDir", "test.yaml")},
 			args: args{
 				absRootDir:      dir1,
@@ -126,7 +126,7 @@ func TestUpdateSourcePaths(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			updateSourcePaths(tt.args.absRootDir, tt.args.resourceConfigs)
+			makeSourcePathRelative(tt.args.absRootDir, tt.args.resourceConfigs)
 			updatedSourceValues := []string{tt.args.resourceConfigs[0].Source, tt.args.resourceConfigs[1].Source}
 			if !utils.IsSliceEqual(tt.expectedSourceValues, updatedSourceValues) {
 				t.Errorf("expected source values %v, got %v", tt.expectedSourceValues, updatedSourceValues)

--- a/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_human.txt
+++ b/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_human.txt
@@ -1,7 +1,7 @@
 Violation Details -
     
 	Description    :	TLS disabled can affect the confidentiality of the data in transit
-	File           :	/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml
+	File           :	config.yaml
 	Line           :	1
 	Severity       :	HIGH
 	

--- a/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_human_verbose.txt
+++ b/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_human_verbose.txt
@@ -1,7 +1,7 @@
 Violation Details -
     
 	Description    :	TLS disabled can affect the confidentiality of the data in transit
-	File           :	/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml
+	File           :	config.yaml
 	Line           :	1
 	Severity       :	HIGH
 	Rule Name      :	noHttps

--- a/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_json.txt
+++ b/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_json.txt
@@ -9,7 +9,7 @@
         "category": "Network Security",
         "resource_name": "ingress-demo-disallowed",
         "resource_type": "kubernetes_ingress",
-        "file": "/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml",
+        "file": "config.yaml",
         "line": 1
       }
     ],

--- a/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_junit_xml.txt
+++ b/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_junit_xml.txt
@@ -3,7 +3,7 @@
     <properties>
       <property name="Terrascan Version" value="v1.3.3"></property>
     </properties>
-    <testcase classname="/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml" name="[ERROR] resource: &#34;ingress-demo-disallowed&#34; at line: 1, violates: RULE - AC-K8-NS-IN-H-0020" severity="HIGH" category="Network Security">
+    <testcase classname="config.yaml" name="[ERROR] resource: &#34;ingress-demo-disallowed&#34; at line: 1, violates: RULE - AC-K8-NS-IN-H-0020" severity="HIGH" category="Network Security">
       <failure message="Description: TLS disabled can affect the confidentiality of the data in transit, File: /Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml, Line: 1, Severity: HIGH, Rule Name: noHttps, Rule ID: AC-K8-NS-IN-H-0020, Resource Name: ingress-demo-disallowed, Resource Type: kubernetes_ingress, Category: Network Security" type=""></failure>
     </testcase>
   </testsuite>

--- a/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_xml.txt
+++ b/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_xml.txt
@@ -1,7 +1,7 @@
 <results>
   <passed_rules></passed_rules>
   <violations>
-    <violation rule_name="noHttps" description="TLS disabled can affect the confidentiality of the data in transit" rule_id="AC-K8-NS-IN-H-0020" severity="HIGH" category="Network Security" resource_name="ingress-demo-disallowed" resource_type="kubernetes_ingress" file="/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml" line="1"></violation>
+    <violation rule_name="noHttps" description="TLS disabled can affect the confidentiality of the data in transit" rule_id="AC-K8-NS-IN-H-0020" severity="HIGH" category="Network Security" resource_name="ingress-demo-disallowed" resource_type="kubernetes_ingress" file="config.yaml" line="1"></violation>
   </violations>
   <skipped_violations></skipped_violations>
   <scan_summary file_folder="/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation" iac_type="k8s" scanned_at="2021-03-02 15:53:11.130276 +0000 UTC" policies_validated="7" violated_policies="1" low="0" medium="0" high="1"></scan_summary>

--- a/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_yaml.txt
+++ b/test/e2e/scan/golden/k8s_scans/k8s/kubernetes_ingress_violations/kubernetes_ingress_yaml.txt
@@ -7,7 +7,7 @@ results:
           category: Network Security
           resource_name: ingress-demo-disallowed
           resource_type: kubernetes_ingress
-          file: /Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/k8s/kubernetes_ingress_violation/config.yaml
+          file: config.yaml
           line: 1
     skipped_violations: []
     scan_summary:


### PR DESCRIPTION
1. k8s iac - filename should be relative
2. fix failing e2e tests