### PR TITLE
Moving from goreleaser GH action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Main GoReleaser
+        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm -v $GITHUB_WORKSPACE:/go/src/github.com/jlk/terrascan-release-test -w /go/src/github.com/jlk/terrascan-release-test neilotoole/xcgo bash -c "apt update; apt install -y gcc-multilib; goreleaser release --rm-dist -f .goreleaser.yml"
+# arm64 build disabled for now while we work through some package conflicts between gcc-multilib and gcc-aarch64-linux-gnu
+#      - name: Run GoReleaser for arm64
+#        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm -v $GITHUB_WORKSPACE:/go/src/github.com/jlk/terrascan-release-test -w /go/src/github.com/jlk/terrascan-release-test neilotoole/xcgo bash -c "apt update; apt install -y gcc-aarch64-linux-gnu; rm -rf /go/src/github.com/jlk/terrascan-release-test/dist ; goreleaser release --rm-dist -f .goreleaser-arm64.yml"
 
   # push image to Docker Hub
   push:

--- a/.goreleaser-arm64.yml
+++ b/.goreleaser-arm64.yml
@@ -1,0 +1,42 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - binary: terrascan
+    id: terrascan_linux_arm64
+    main: ./cmd/terrascan/main.go
+    ldflags: -s -w
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+    flags:
+      - -buildmode
+      - exe
+      - -tags
+      - extended
+    goos:
+      - linux
+    goarch:
+      - arm64
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,13 +7,68 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - binary: terrascan
+    id: terrascan_linux_amd64
+    main: ./cmd/terrascan/main.go
+    ldflags: -s -w
+    env:
+      - CGO_ENABLED=1
+    flags:
+      - -buildmode
+      - exe
+      - -tags
+      - extended
     goos:
       - linux
-      - windows
-      - darwin
+    goarch:
+      - amd64
+  - binary: terrascan
+    id: terrascan_linux_386
     main: ./cmd/terrascan/main.go
+    ldflags: -s -w
+    env:
+      - CGO_ENABLED=1
+    flags:
+      - -buildmode
+      - exe
+      - -tags
+      - extended
+    goos:
+      - linux
+    goarch:
+      - 386
+  - binary: terrascan
+    id: terrascan_darwin
+    main: ./cmd/terrascan/main.go
+    ldflags: -s -w
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+    flags:
+      - -buildmode
+      - exe
+      - -tags
+      - extended
+    goos:
+      - darwin
+    goarch:
+      - amd64
+  - binary: terrascan
+    id: terrascan_windows
+    main: ./cmd/terrascan/main.go
+    ldflags: -s -w
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+    flags:
+      - -buildmode
+      - exe
+      - -tags
+      - extended
+    goos:
+      - windows
+    goarch:
+      - amd64
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
The goreleaser GH action doesn't support cgo because the cross-platform build aspects get quite complex. So, instead we make our build pipeline more complex to support cgo + cross platform builds...

This has been tested out on a private fork, and results in a GH release with artifacts for...

* Linux i386
* Linux amd64
* Darwin amd64
* Windows amd64

Fixes #693 