### PR TITLE
Moving linux builds to static builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Main GoReleaser
-        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm -v $GITHUB_WORKSPACE:/go/src/github.com/jlk/terrascan-release-test -w /go/src/github.com/jlk/terrascan-release-test neilotoole/xcgo bash -c "apt update; apt install -y gcc-multilib; goreleaser release --rm-dist -f .goreleaser.yml"
+        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm -v $GITHUB_WORKSPACE:/go/src/github.com/accurics/terrascan -w /go/src/github.com/accurics/terrascan neilotoole/xcgo bash -c "apt update; apt install -y gcc-multilib; goreleaser release --rm-dist -f .goreleaser.yml"
 # arm64 build disabled for now while we work through some package conflicts between gcc-multilib and gcc-aarch64-linux-gnu
 #      - name: Run GoReleaser for arm64
-#        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm -v $GITHUB_WORKSPACE:/go/src/github.com/jlk/terrascan-release-test -w /go/src/github.com/jlk/terrascan-release-test neilotoole/xcgo bash -c "apt update; apt install -y gcc-aarch64-linux-gnu; rm -rf /go/src/github.com/jlk/terrascan-release-test/dist ; goreleaser release --rm-dist -f .goreleaser-arm64.yml"
+#        run: docker run -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --rm -v $GITHUB_WORKSPACE:/go/src/github.com/accurics/terrascan -w /go/src/github.com/accurics/terrascan neilotoole/xcgo bash -c "apt update; apt install -y gcc-aarch64-linux-gnu; rm -rf /go/src/github.com/accurics/terrascan/dist ; goreleaser release --rm-dist -f .goreleaser-arm64.yml"
 
   # push image to Docker Hub
   push:

--- a/.goreleaser-arm64.yml
+++ b/.goreleaser-arm64.yml
@@ -10,7 +10,7 @@ builds:
   - binary: terrascan
     id: terrascan_linux_arm64
     main: ./cmd/terrascan/main.go
-    ldflags: -s -w
+    ldflags: -s -w -extldflags=-static
     env:
       - CGO_ENABLED=1
       - CC=aarch64-linux-gnu-gcc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
   - binary: terrascan
     id: terrascan_linux_amd64
     main: ./cmd/terrascan/main.go
-    ldflags: -s -w
+    ldflags: -s -w -extldflags=-static
     env:
       - CGO_ENABLED=1
     flags:
@@ -25,7 +25,7 @@ builds:
   - binary: terrascan
     id: terrascan_linux_386
     main: ./cmd/terrascan/main.go
-    ldflags: -s -w
+    ldflags: -s -w -extldflags=-static
     env:
       - CGO_ENABLED=1
     flags:


### PR DESCRIPTION
This will allow the terrascan binaries to run on Alpine Linux. Also cleaning up mount paths used during build process.

Fixes #705 