### PR TITLE
add check for unresolved variables

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_launch_configuration/hardCodedShellScript.rego
+++ b/pkg/policies/opa/rego/aws/aws_launch_configuration/hardCodedShellScript.rego
@@ -2,6 +2,7 @@ package accurics
 
 {{.prefix}}hardCodedShellScript[res.id]{
     res = input.aws_instance[_]
+    not startswith(res.config.user_data_base64, "$")
     value = base64NullCheck(res.config.user_data_base64)
     startswith(value, "#!/")
 }


### PR DESCRIPTION
- adds a check for `$` in the beginning of `user_data_base64` to account for unresolved variables
- works as a workaround for base64 decode error caused due to incorrect string
- fixes issue #709 