### PR TITLE
Modified the Dockerfile to use numeric UID 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /home/terrascan/.ssh /home/terrascan/bin && \
     chown -R terrascan:terrascan /home/terrascan
 
 # run as non root user
-USER terrascan
+USER 101
 
 ENV PATH /go/bin:$PATH
 

--- a/docs/integrations/argocd-integration.md
+++ b/docs/integrations/argocd-integration.md
@@ -341,7 +341,7 @@ RUN addgroup --gid 101 terrascan && \
   chown -R terrascan:terrascan bin && \
   chmod u+x bin/terrascan-remote-scan.sh
 
-USER terrascan
+USER 101
 
 CMD ["sh"]
 ```

--- a/integrations/argocd/Dockerfile
+++ b/integrations/argocd/Dockerfile
@@ -17,6 +17,6 @@ RUN addgroup --gid 101 terrascan && \
     chown -R terrascan:terrascan bin && \
     chmod u+x bin/terrascan-remote-scan.sh
 
-USER terrascan
+USER 101
 
 CMD ["sh"]


### PR DESCRIPTION
#766 
Fix: modified the docker file to use numeric UID.
```
USE 101
``` 
Reason for change:
 
when we set the RunAsNonRoot field of a security context, k8s internal logic checks the container for numeric UID instead of a username, and if it doesnot found any numeric UID it throughs error `container has runAsNonRoot and image has non-numeric user (terrascan), cannot verify user is non-root
`

Tested the changes for Use cases

- Admission controller webhook with plane YAML files
-  Admission controller with Helm
- Admission controller with argoCD

