### PR TITLE
Added source_range 0.0.0.0/0 (any) to avoid rule violations

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_compute_firewall/unrestrictedRdpAccess.rego
+++ b/pkg/policies/opa/rego/gcp/google_compute_firewall/unrestrictedRdpAccess.rego
@@ -4,6 +4,7 @@ unrestrictedRdpAccess[api.id] {
      api := input.google_compute_firewall[_]
      api.config.direction == "INGRESS"
      fire_rule := api.config.allow[_]
+     config.source_ranges[_] == "0.0.0.0/0"
      fire_rule.protocol == "tcp"
      fire_rule.ports[_] == "3389"
 }

--- a/pkg/policies/opa/rego/gcp/google_compute_firewall/unrestrictedRdpAccess.rego
+++ b/pkg/policies/opa/rego/gcp/google_compute_firewall/unrestrictedRdpAccess.rego
@@ -4,7 +4,7 @@ unrestrictedRdpAccess[api.id] {
      api := input.google_compute_firewall[_]
      api.config.direction == "INGRESS"
      fire_rule := api.config.allow[_]
-     config.source_ranges[_] == "0.0.0.0/0"
+     api.config.source_ranges[_] == "0.0.0.0/0"
      fire_rule.protocol == "tcp"
      fire_rule.ports[_] == "3389"
 }


### PR DESCRIPTION
Added source_range 0.0.0.0/0 to unrestrictedRdpAccess.rego because you will get rule violations when you have restricted RDP Access zu your environment with source_range set.

See issue #735