### PR TITLE
Changed description of policy file to match port.

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_compute_firewall/accurics.gcp.NS.149.json
+++ b/pkg/policies/opa/rego/gcp/google_compute_firewall/accurics.gcp.NS.149.json
@@ -6,7 +6,7 @@
         "port_number": "3389"
     },
     "severity": "MEDIUM",
-    "description": "Ensure that SSH access is restricted from the internet",
+    "description": "Ensure that RDP access is restricted from the internet",
     "reference_id": "accurics.gcp.NS.149",
     "category": "Infrastructure Security",
     "version": 1


### PR DESCRIPTION
Changing the description of Policy port3389Open to match the Port.
TCP 3389 is not SSH. TCP 3389 is RDP.