### PR TITLE
Fix pod level securityContext support

### DIFF
--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/securityContextCheck.rego
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/securityContextCheck.rego
@@ -27,11 +27,6 @@ package accurics
     checkCorrectAttribute(pod.config.spec)
 }
 
-{{.prefix}}{{.name}}{{.suffix}}[pod.id] {
-    pod := input.kubernetes_pod_security_policy[_]
-    podSecurityCheck(pod.config.spec)
-}
-
 checkCorrectAttribute(spec) {
     container := spec.containers[_]
     containerSecurityCheck(container)
@@ -40,11 +35,6 @@ checkCorrectAttribute(spec) {
 checkCorrectAttribute(spec) {
     container := spec.initContainers[_]
     containerSecurityCheck(container)
-}
-
-checkCorrectAttribute(spec) {
-    secContext := spec.securityContext
-    podSecurityCheck(secContext)
 }
 
 containerSecurityCheck(container) {
@@ -63,14 +53,4 @@ containerSecurityCheck(container) {
 containerSecurityCheck(container) {
 	{{.allowed}}
     not container.{{.param1}}.{{.arg1}}.{{.arg2}}
-}
-
-podSecurityCheck(secContext) {
-	{{.not_allowed}}
-    secContext.{{.param}} == {{.value}}
-}
-
-podSecurityCheck(secContext) {
-	{{.not_allowed}}
-    object.get(secContext, "{{.param}}", "undefined") == "undefined"
 }


### PR DESCRIPTION
This PR includes removing PSP support (deprecated) and functions which checked allowPrivilegeEscaltion and readOnlyRootFilesystem at pod.spec.securityContext as these fields are meant to be at pod.spec.containers.securityContext