### PR TITLE
Add ID Field for K8s Policies' Metadata

### DIFF
--- a/pkg/policies/opa/rego/k8s/kubernetes_ingress/AC-K8-NS-IN-H-0020.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_ingress/AC-K8-NS-IN-H-0020.json
@@ -1,17 +1,17 @@
 {
-  "name": "noHttps",
-  "file": "noHttps.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_ingress",
-  "template_args": {
     "name": "noHttps",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "TLS disabled can affect the confidentiality of the data in transit",
-  "reference_id": "AC-K8-NS-IN-H-0020",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0002"
+    "file": "noHttps.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_ingress",
+    "template_args": {
+        "name": "noHttps",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "TLS disabled can affect the confidentiality of the data in transit",
+    "reference_id": "AC-K8-NS-IN-H-0020",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0002"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_ingress/AC-K8-NS-IN-H-0020.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_ingress/AC-K8-NS-IN-H-0020.json
@@ -1,16 +1,17 @@
 {
+  "name": "noHttps",
+  "file": "noHttps.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_ingress",
+  "template_args": {
     "name": "noHttps",
-    "file": "noHttps.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_ingress",
-    "template_args": {
-        "name": "noHttps",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "HIGH",
-    "description": "TLS disabled can affect the confidentiality of the data in transit",
-    "reference_id": "AC-K8-NS-IN-H-0020",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "TLS disabled can affect the confidentiality of the data in transit",
+  "reference_id": "AC-K8-NS-IN-H-0020",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0002"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_namespace/AC-K8-OE-NS-L-0128.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_namespace/AC-K8-OE-NS-L-0128.json
@@ -1,16 +1,17 @@
 {
+  "name": "noOwnerLabel",
+  "file": "noOwnerLabel.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_namespace",
+  "template_args": {
     "name": "noOwnerLabel",
-    "file": "noOwnerLabel.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_namespace",
-    "template_args": {
-        "name": "noOwnerLabel",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "LOW",
-    "description": "No owner for namespace affects the operations",
-    "reference_id": "AC-K8-OE-NS-L-0128",
-    "category": "Security Best Practices",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "LOW",
+  "description": "No owner for namespace affects the operations",
+  "reference_id": "AC-K8-OE-NS-L-0128",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0013"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_namespace/AC-K8-OE-NS-L-0128.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_namespace/AC-K8-OE-NS-L-0128.json
@@ -1,17 +1,17 @@
 {
-  "name": "noOwnerLabel",
-  "file": "noOwnerLabel.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_namespace",
-  "template_args": {
     "name": "noOwnerLabel",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "LOW",
-  "description": "No owner for namespace affects the operations",
-  "reference_id": "AC-K8-OE-NS-L-0128",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0013"
+    "file": "noOwnerLabel.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_namespace",
+    "template_args": {
+        "name": "noOwnerLabel",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "No owner for namespace affects the operations",
+    "reference_id": "AC-K8-OE-NS-L-0128",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0013"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-CA-PO-H-0165.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-CA-PO-H-0165.json
@@ -1,23 +1,24 @@
 {
+  "name": "privilegeEscalationCheck",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "false",
+    "arg1": "cpu",
+    "arg2": "limits",
     "name": "privilegeEscalationCheck",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "false",
-        "arg1": "cpu",
-        "arg2": "limits",
-        "name": "privilegeEscalationCheck",
-        "not_allowed": "true",
-        "param": "allowPrivilegeEscalation",
-        "param1": "securityContext",
-        "prefix": "",
-        "suffix": "",
-        "value": "true"
-    },
-    "severity": "HIGH",
-    "description": "Containers Should Not Run with AllowPrivilegeEscalation",
-    "reference_id": "AC-K8-CA-PO-H-0165",
-    "category": "Compliance Validation",
-    "version": 1
+    "not_allowed": "true",
+    "param": "allowPrivilegeEscalation",
+    "param1": "securityContext",
+    "prefix": "",
+    "suffix": "",
+    "value": "true"
+  },
+  "severity": "HIGH",
+  "description": "Containers Should Not Run with AllowPrivilegeEscalation",
+  "reference_id": "AC-K8-CA-PO-H-0165",
+  "category": "Compliance Validation",
+  "version": 1,
+  "id": "AC_K8S_0085"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-CA-PO-H-0165.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-CA-PO-H-0165.json
@@ -1,24 +1,24 @@
 {
-  "name": "privilegeEscalationCheck",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "false",
-    "arg1": "cpu",
-    "arg2": "limits",
     "name": "privilegeEscalationCheck",
-    "not_allowed": "true",
-    "param": "allowPrivilegeEscalation",
-    "param1": "securityContext",
-    "prefix": "",
-    "suffix": "",
-    "value": "true"
-  },
-  "severity": "HIGH",
-  "description": "Containers Should Not Run with AllowPrivilegeEscalation",
-  "reference_id": "AC-K8-CA-PO-H-0165",
-  "category": "Compliance Validation",
-  "version": 1,
-  "id": "AC_K8S_0085"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "false",
+        "arg1": "cpu",
+        "arg2": "limits",
+        "name": "privilegeEscalationCheck",
+        "not_allowed": "true",
+        "param": "allowPrivilegeEscalation",
+        "param1": "securityContext",
+        "prefix": "",
+        "suffix": "",
+        "value": "true"
+    },
+    "severity": "HIGH",
+    "description": "Containers Should Not Run with AllowPrivilegeEscalation",
+    "reference_id": "AC-K8-CA-PO-H-0165",
+    "category": "Compliance Validation",
+    "version": 1,
+    "id": "AC_K8S_0085"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0176.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0176.json
@@ -1,17 +1,17 @@
 {
-  "name": "kubeDashboardEnabled",
-  "file": "kubeDashboardEnabled.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "kubeDashboardEnabled",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Ensure Kubernetes Dashboard Is Not Deployed",
-  "reference_id": "AC-K8-DS-PO-M-0176",
-  "category": "Data Protection",
-  "version": 1,
-  "id": "AC_K8S_0067"
+    "file": "kubeDashboardEnabled.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "kubeDashboardEnabled",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Ensure Kubernetes Dashboard Is Not Deployed",
+    "reference_id": "AC-K8-DS-PO-M-0176",
+    "category": "Data Protection",
+    "version": 1,
+    "id": "AC_K8S_0067"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0176.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0176.json
@@ -1,16 +1,17 @@
 {
+  "name": "kubeDashboardEnabled",
+  "file": "kubeDashboardEnabled.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "kubeDashboardEnabled",
-    "file": "kubeDashboardEnabled.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "kubeDashboardEnabled",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Ensure Kubernetes Dashboard Is Not Deployed",
-    "reference_id": "AC-K8-DS-PO-M-0176",
-    "category": "Data Protection",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Ensure Kubernetes Dashboard Is Not Deployed",
+  "reference_id": "AC-K8-DS-PO-M-0176",
+  "category": "Data Protection",
+  "version": 1,
+  "id": "AC_K8S_0067"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0177.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0177.json
@@ -1,17 +1,17 @@
 {
-  "name": "tillerDeployed",
-  "file": "tillerDeployed.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "tillerDeployed",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Ensure That Tiller (Helm V2) Is Not Deployed",
-  "reference_id": "AC-K8-DS-PO-M-0177",
-  "category": "Data Protection",
-  "version": 1,
-  "id": "AC_K8S_0071"
+    "file": "tillerDeployed.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "tillerDeployed",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Ensure That Tiller (Helm V2) Is Not Deployed",
+    "reference_id": "AC-K8-DS-PO-M-0177",
+    "category": "Data Protection",
+    "version": 1,
+    "id": "AC_K8S_0071"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0177.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-DS-PO-M-0177.json
@@ -1,16 +1,17 @@
 {
+  "name": "tillerDeployed",
+  "file": "tillerDeployed.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "tillerDeployed",
-    "file": "tillerDeployed.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "tillerDeployed",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Ensure That Tiller (Helm V2) Is Not Deployed",
-    "reference_id": "AC-K8-DS-PO-M-0177",
-    "category": "Data Protection",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Ensure That Tiller (Helm V2) Is Not Deployed",
+  "reference_id": "AC-K8-DS-PO-M-0177",
+  "category": "Data Protection",
+  "version": 1,
+  "id": "AC_K8S_0071"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0106.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0106.json
@@ -1,16 +1,17 @@
 {
+  "name": "priviledgedContainersEnabled",
+  "file": "priviledgedContainersEnabled.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "priviledgedContainersEnabled",
-    "file": "priviledgedContainersEnabled.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "priviledgedContainersEnabled",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "HIGH",
-    "description": "Minimize the admission of privileged containers",
-    "reference_id": "AC-K8-IA-PO-H-0106",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "HIGH",
+  "description": "Minimize the admission of privileged containers",
+  "reference_id": "AC-K8-IA-PO-H-0106",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0046"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0106.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0106.json
@@ -1,17 +1,17 @@
 {
-  "name": "priviledgedContainersEnabled",
-  "file": "priviledgedContainersEnabled.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "priviledgedContainersEnabled",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "HIGH",
-  "description": "Minimize the admission of privileged containers",
-  "reference_id": "AC-K8-IA-PO-H-0106",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0046"
+    "file": "priviledgedContainersEnabled.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "priviledgedContainersEnabled",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "HIGH",
+    "description": "Minimize the admission of privileged containers",
+    "reference_id": "AC-K8-IA-PO-H-0106",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0046"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0137.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0137.json
@@ -1,17 +1,17 @@
 {
-  "name": "disallowedSysCalls",
-  "file": "disallowedSysCalls.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "disallowedSysCalls",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Allowing the pod to make system level calls provide access to host/node sensitive information",
-  "reference_id": "AC-K8-IA-PO-H-0137",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0074"
+    "file": "disallowedSysCalls.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "disallowedSysCalls",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Allowing the pod to make system level calls provide access to host/node sensitive information",
+    "reference_id": "AC-K8-IA-PO-H-0137",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0074"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0137.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0137.json
@@ -1,16 +1,17 @@
 {
+  "name": "disallowedSysCalls",
+  "file": "disallowedSysCalls.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "disallowedSysCalls",
-    "file": "disallowedSysCalls.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "disallowedSysCalls",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "HIGH",
-    "description": "Allowing the pod to make system level calls provide access to host/node sensitive information",
-    "reference_id": "AC-K8-IA-PO-H-0137",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Allowing the pod to make system level calls provide access to host/node sensitive information",
+  "reference_id": "AC-K8-IA-PO-H-0137",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0074"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0138.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0138.json
@@ -1,16 +1,17 @@
 {
+  "name": "allowedHostPath",
+  "file": "allowedHostPath.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "allowedHostPath",
-    "file": "allowedHostPath.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "allowedHostPath",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "HIGH",
-    "description": "Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem",
-    "reference_id": "AC-K8-IA-PO-H-0138",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "HIGH",
+  "description": "Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem",
+  "reference_id": "AC-K8-IA-PO-H-0138",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0076"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0138.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0138.json
@@ -1,17 +1,17 @@
 {
-  "name": "allowedHostPath",
-  "file": "allowedHostPath.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "allowedHostPath",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "HIGH",
-  "description": "Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem",
-  "reference_id": "AC-K8-IA-PO-H-0138",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0076"
+    "file": "allowedHostPath.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "allowedHostPath",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "HIGH",
+    "description": "Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem",
+    "reference_id": "AC-K8-IA-PO-H-0138",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0076"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0168.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0168.json
@@ -1,23 +1,24 @@
 {
+  "name": "runAsNonRootCheck",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "false",
+    "arg1": "cpu",
+    "arg2": "limits",
     "name": "runAsNonRootCheck",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "false",
-        "arg1": "cpu",
-        "arg2": "limits",
-        "name": "runAsNonRootCheck",
-        "not_allowed": "true",
-        "param": "runAsNonRoot",
-        "param1": "securityContext",
-        "prefix": "",
-        "suffix": "",
-        "value": "false"
-    },
-    "severity": "HIGH",
-    "description": "Minimize Admission of Root Containers",
-    "reference_id": "AC-K8-IA-PO-H-0168",
-    "category": "Identity and Access Management",
-    "version": 1
+    "not_allowed": "true",
+    "param": "runAsNonRoot",
+    "param1": "securityContext",
+    "prefix": "",
+    "suffix": "",
+    "value": "false"
+  },
+  "severity": "HIGH",
+  "description": "Minimize Admission of Root Containers",
+  "reference_id": "AC-K8-IA-PO-H-0168",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0087"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0168.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-H-0168.json
@@ -1,24 +1,24 @@
 {
-  "name": "runAsNonRootCheck",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "false",
-    "arg1": "cpu",
-    "arg2": "limits",
     "name": "runAsNonRootCheck",
-    "not_allowed": "true",
-    "param": "runAsNonRoot",
-    "param1": "securityContext",
-    "prefix": "",
-    "suffix": "",
-    "value": "false"
-  },
-  "severity": "HIGH",
-  "description": "Minimize Admission of Root Containers",
-  "reference_id": "AC-K8-IA-PO-H-0168",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0087"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "false",
+        "arg1": "cpu",
+        "arg2": "limits",
+        "name": "runAsNonRootCheck",
+        "not_allowed": "true",
+        "param": "runAsNonRoot",
+        "param1": "securityContext",
+        "prefix": "",
+        "suffix": "",
+        "value": "false"
+    },
+    "severity": "HIGH",
+    "description": "Minimize Admission of Root Containers",
+    "reference_id": "AC-K8-IA-PO-H-0168",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0087"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0105.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0105.json
@@ -1,17 +1,17 @@
 {
-  "name": "autoMountTokenEnabled",
-  "file": "autoMountTokenEnabled.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "autoMountTokenEnabled",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Ensure that Service Account Tokens are only mounted where necessary",
-  "reference_id": "AC-K8-IA-PO-M-0105",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0045"
+    "file": "autoMountTokenEnabled.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "autoMountTokenEnabled",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Ensure that Service Account Tokens are only mounted where necessary",
+    "reference_id": "AC-K8-IA-PO-M-0105",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0045"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0105.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0105.json
@@ -1,16 +1,17 @@
 {
+  "name": "autoMountTokenEnabled",
+  "file": "autoMountTokenEnabled.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "autoMountTokenEnabled",
-    "file": "autoMountTokenEnabled.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "autoMountTokenEnabled",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Ensure that Service Account Tokens are only mounted where necessary",
-    "reference_id": "AC-K8-IA-PO-M-0105",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Ensure that Service Account Tokens are only mounted where necessary",
+  "reference_id": "AC-K8-IA-PO-M-0105",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0045"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0135.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0135.json
@@ -1,16 +1,17 @@
 {
+  "name": "appArmorProfile",
+  "file": "appArmorProfile.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "appArmorProfile",
-    "file": "appArmorProfile.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "appArmorProfile",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats",
-    "reference_id": "AC-K8-IA-PO-M-0135",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats",
+  "reference_id": "AC-K8-IA-PO-M-0135",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0073"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0135.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0135.json
@@ -1,17 +1,17 @@
 {
-  "name": "appArmorProfile",
-  "file": "appArmorProfile.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "appArmorProfile",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats",
-  "reference_id": "AC-K8-IA-PO-M-0135",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0073"
+    "file": "appArmorProfile.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "appArmorProfile",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats",
+    "reference_id": "AC-K8-IA-PO-M-0135",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0073"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0139.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0139.json
@@ -1,17 +1,17 @@
 {
-  "name": "allowedProcMount",
-  "file": "allowedProcMount.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "allowedProcMount",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s",
-  "reference_id": "AC-K8-IA-PO-M-0139",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0077"
+    "file": "allowedProcMount.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "allowedProcMount",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s",
+    "reference_id": "AC-K8-IA-PO-M-0139",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0077"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0139.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0139.json
@@ -1,16 +1,17 @@
 {
+  "name": "allowedProcMount",
+  "file": "allowedProcMount.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "allowedProcMount",
-    "file": "allowedProcMount.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "allowedProcMount",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s",
-    "reference_id": "AC-K8-IA-PO-M-0139",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s",
+  "reference_id": "AC-K8-IA-PO-M-0139",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0077"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0140.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0140.json
@@ -1,23 +1,24 @@
 {
+  "name": "readOnlyFileSystem",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "false",
+    "arg1": "limits",
+    "arg2": "cpu",
     "name": "readOnlyFileSystem",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "false",
-        "arg1": "limits",
-        "arg2": "cpu",
-        "name": "readOnlyFileSystem",
-        "not_allowed": "true",
-        "param": "readOnlyRootFilesystem",
-        "param1": "securityContext",
-        "prefix": "",
-        "suffix": "",
-        "value": "false"
-    },
-    "severity": "MEDIUM",
-    "description": "Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions",
-    "reference_id": "AC-K8-IA-PO-M-0140",
-    "category": "Identity and Access Management",
-    "version": 1
+    "not_allowed": "true",
+    "param": "readOnlyRootFilesystem",
+    "param1": "securityContext",
+    "prefix": "",
+    "suffix": "",
+    "value": "false"
+  },
+  "severity": "MEDIUM",
+  "description": "Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions",
+  "reference_id": "AC-K8-IA-PO-M-0140",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0078"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0140.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0140.json
@@ -1,24 +1,24 @@
 {
-  "name": "readOnlyFileSystem",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "false",
-    "arg1": "limits",
-    "arg2": "cpu",
     "name": "readOnlyFileSystem",
-    "not_allowed": "true",
-    "param": "readOnlyRootFilesystem",
-    "param1": "securityContext",
-    "prefix": "",
-    "suffix": "",
-    "value": "false"
-  },
-  "severity": "MEDIUM",
-  "description": "Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions",
-  "reference_id": "AC-K8-IA-PO-M-0140",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0078"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "false",
+        "arg1": "limits",
+        "arg2": "cpu",
+        "name": "readOnlyFileSystem",
+        "not_allowed": "true",
+        "param": "readOnlyRootFilesystem",
+        "param1": "securityContext",
+        "prefix": "",
+        "suffix": "",
+        "value": "false"
+    },
+    "severity": "MEDIUM",
+    "description": "Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions",
+    "reference_id": "AC-K8-IA-PO-M-0140",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0078"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0141.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0141.json
@@ -1,16 +1,17 @@
 {
+  "name": "secCompProfile",
+  "file": "secCompProfile.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "secCompProfile",
-    "file": "secCompProfile.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "secCompProfile",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Default seccomp profile not enabled will make the container to make non-essential system calls",
-    "reference_id": "AC-K8-IA-PO-M-0141",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Default seccomp profile not enabled will make the container to make non-essential system calls",
+  "reference_id": "AC-K8-IA-PO-M-0141",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0080"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0141.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0141.json
@@ -1,17 +1,17 @@
 {
-  "name": "secCompProfile",
-  "file": "secCompProfile.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "secCompProfile",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Default seccomp profile not enabled will make the container to make non-essential system calls",
-  "reference_id": "AC-K8-IA-PO-M-0141",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0080"
+    "file": "secCompProfile.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "secCompProfile",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Default seccomp profile not enabled will make the container to make non-essential system calls",
+    "reference_id": "AC-K8-IA-PO-M-0141",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0080"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0143.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0143.json
@@ -1,25 +1,25 @@
 {
-  "name": "allowedVolumes",
-  "file": "allowedVolumes.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "allowedVolumes",
-    "prefix": "",
-    "secure_volumes": [
-      "configMap",
-      "emptyDir",
-      "projected",
-      "secret",
-      "downwardAPI",
-      "persistentVolumeClaim"
-    ],
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host",
-  "reference_id": "AC-K8-IA-PO-M-0143",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0081"
+    "file": "allowedVolumes.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "allowedVolumes",
+        "prefix": "",
+        "secure_volumes": [
+            "configMap",
+            "emptyDir",
+            "projected",
+            "secret",
+            "downwardAPI",
+            "persistentVolumeClaim"
+        ],
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host",
+    "reference_id": "AC-K8-IA-PO-M-0143",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0081"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0143.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0143.json
@@ -1,24 +1,25 @@
 {
+  "name": "allowedVolumes",
+  "file": "allowedVolumes.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "allowedVolumes",
-    "file": "allowedVolumes.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "allowedVolumes",
-        "prefix": "",
-        "secure_volumes": [
-            "configMap",
-            "emptyDir",
-            "projected",
-            "secret",
-            "downwardAPI",
-            "persistentVolumeClaim"
-        ],
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host",
-    "reference_id": "AC-K8-IA-PO-M-0143",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "secure_volumes": [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim"
+    ],
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host",
+  "reference_id": "AC-K8-IA-PO-M-0143",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0081"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0162.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0162.json
@@ -1,19 +1,19 @@
 {
-  "name": "falseHostPID",
-  "file": "specBoolCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "falseHostPID",
-    "param": "hostPID",
-    "prefix": "",
-    "suffix": "",
-    "value": "true"
-  },
-  "severity": "MEDIUM",
-  "description": "Containers Should Not Share Host Process ID Namespace",
-  "reference_id": "AC-K8-IA-PO-M-0162",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0082"
+    "file": "specBoolCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "falseHostPID",
+        "param": "hostPID",
+        "prefix": "",
+        "suffix": "",
+        "value": "true"
+    },
+    "severity": "MEDIUM",
+    "description": "Containers Should Not Share Host Process ID Namespace",
+    "reference_id": "AC-K8-IA-PO-M-0162",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0082"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0162.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PO-M-0162.json
@@ -1,18 +1,19 @@
 {
+  "name": "falseHostPID",
+  "file": "specBoolCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "falseHostPID",
-    "file": "specBoolCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "falseHostPID",
-        "param": "hostPID",
-        "prefix": "",
-        "suffix": "",
-        "value": "true"
-    },
-    "severity": "MEDIUM",
-    "description": "Containers Should Not Share Host Process ID Namespace",
-    "reference_id": "AC-K8-IA-PO-M-0162",
-    "category": "Identity and Access Management",
-    "version": 1
+    "param": "hostPID",
+    "prefix": "",
+    "suffix": "",
+    "value": "true"
+  },
+  "severity": "MEDIUM",
+  "description": "Containers Should Not Share Host Process ID Namespace",
+  "reference_id": "AC-K8-IA-PO-M-0162",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0082"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PS-M-0112.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PS-M-0112.json
@@ -1,17 +1,18 @@
 {
+  "name": "netRawCapabilityUsed",
+  "file": "capabilityUsed.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "attribute": "requiredDropCapabilities",
     "name": "netRawCapabilityUsed",
-    "file": "capabilityUsed.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "attribute": "requiredDropCapabilities",
-        "name": "netRawCapabilityUsed",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Minimize the admission of containers with the NET_RAW capability",
-    "reference_id": "AC-K8-IA-PS-M-0112",
-    "category": "Identity and Access Management",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Minimize the admission of containers with the NET_RAW capability",
+  "reference_id": "AC-K8-IA-PS-M-0112",
+  "category": "Identity and Access Management",
+  "version": 1,
+  "id": "AC_K8S_0048"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PS-M-0112.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-IA-PS-M-0112.json
@@ -1,18 +1,18 @@
 {
-  "name": "netRawCapabilityUsed",
-  "file": "capabilityUsed.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "attribute": "requiredDropCapabilities",
     "name": "netRawCapabilityUsed",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Minimize the admission of containers with the NET_RAW capability",
-  "reference_id": "AC-K8-IA-PS-M-0112",
-  "category": "Identity and Access Management",
-  "version": 1,
-  "id": "AC_K8S_0048"
+    "file": "capabilityUsed.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "attribute": "requiredDropCapabilities",
+        "name": "netRawCapabilityUsed",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Minimize the admission of containers with the NET_RAW capability",
+    "reference_id": "AC-K8-IA-PS-M-0112",
+    "category": "Identity and Access Management",
+    "version": 1,
+    "id": "AC_K8S_0048"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0117.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0117.json
@@ -1,16 +1,17 @@
 {
+  "name": "secretsAsEnvVariables",
+  "file": "secretsAsEnvVariables.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "secretsAsEnvVariables",
-    "file": "secretsAsEnvVariables.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "secretsAsEnvVariables",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "HIGH",
-    "description": "Prefer using secrets as files over secrets as environment variables",
-    "reference_id": "AC-K8-NS-PO-H-0117",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "HIGH",
+  "description": "Prefer using secrets as files over secrets as environment variables",
+  "reference_id": "AC-K8-NS-PO-H-0117",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0051"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0117.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0117.json
@@ -1,17 +1,17 @@
 {
-  "name": "secretsAsEnvVariables",
-  "file": "secretsAsEnvVariables.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "secretsAsEnvVariables",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "HIGH",
-  "description": "Prefer using secrets as files over secrets as environment variables",
-  "reference_id": "AC-K8-NS-PO-H-0117",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0051"
+    "file": "secretsAsEnvVariables.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "secretsAsEnvVariables",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "HIGH",
+    "description": "Prefer using secrets as files over secrets as environment variables",
+    "reference_id": "AC-K8-NS-PO-H-0117",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0051"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0170.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0170.json
@@ -1,16 +1,17 @@
 {
+  "name": "capSysAdminUsed",
+  "file": "capSysAdminUsed.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "capSysAdminUsed",
-    "file": "capSysAdminUsed.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "capSysAdminUsed",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "HIGH",
-    "description": "Do Not Use CAP_SYS_ADMIN Linux Capability",
-    "reference_id": "AC-K8-NS-PO-H-0170",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Do Not Use CAP_SYS_ADMIN Linux Capability",
+  "reference_id": "AC-K8-NS-PO-H-0170",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0075"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0170.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-H-0170.json
@@ -1,17 +1,17 @@
 {
-  "name": "capSysAdminUsed",
-  "file": "capSysAdminUsed.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "capSysAdminUsed",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Do Not Use CAP_SYS_ADMIN Linux Capability",
-  "reference_id": "AC-K8-NS-PO-H-0170",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0075"
+    "file": "capSysAdminUsed.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "capSysAdminUsed",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Do Not Use CAP_SYS_ADMIN Linux Capability",
+    "reference_id": "AC-K8-NS-PO-H-0170",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0075"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0122.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0122.json
@@ -1,16 +1,17 @@
 {
+  "name": "securityContextUsed",
+  "file": "securityContextUsed.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "securityContextUsed",
-    "file": "securityContextUsed.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "securityContextUsed",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Apply Security Context to Your Pods and Containers",
-    "reference_id": "AC-K8-NS-PO-M-0122",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Apply Security Context to Your Pods and Containers",
+  "reference_id": "AC-K8-NS-PO-M-0122",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0064"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0122.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0122.json
@@ -1,17 +1,17 @@
 {
-  "name": "securityContextUsed",
-  "file": "securityContextUsed.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "securityContextUsed",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Apply Security Context to Your Pods and Containers",
-  "reference_id": "AC-K8-NS-PO-M-0122",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0064"
+    "file": "securityContextUsed.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "securityContextUsed",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Apply Security Context to Your Pods and Containers",
+    "reference_id": "AC-K8-NS-PO-M-0122",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0064"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0133.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0133.json
@@ -1,17 +1,17 @@
 {
-  "name": "imageWithoutDigest",
-  "file": "imageWithoutDigest.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "imageWithoutDigest",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Image without digest affects the integrity principle of image security",
-  "reference_id": "AC-K8-NS-PO-M-0133",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0069"
+    "file": "imageWithoutDigest.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "imageWithoutDigest",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Image without digest affects the integrity principle of image security",
+    "reference_id": "AC-K8-NS-PO-M-0133",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0069"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0133.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0133.json
@@ -1,16 +1,17 @@
 {
+  "name": "imageWithoutDigest",
+  "file": "imageWithoutDigest.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "imageWithoutDigest",
-    "file": "imageWithoutDigest.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "imageWithoutDigest",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Image without digest affects the integrity principle of image security",
-    "reference_id": "AC-K8-NS-PO-M-0133",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Image without digest affects the integrity principle of image security",
+  "reference_id": "AC-K8-NS-PO-M-0133",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0069"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0163.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0163.json
@@ -1,18 +1,19 @@
 {
+  "name": "falseHostIPC",
+  "file": "specBoolCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "falseHostIPC",
-    "file": "specBoolCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "falseHostIPC",
-        "param": "hostIPC",
-        "prefix": "",
-        "suffix": "",
-        "value": "true"
-    },
-    "severity": "MEDIUM",
-    "description": "Containers Should Not Share Host IPC Namespace",
-    "reference_id": "AC-K8-NS-PO-M-0163",
-    "category": "Infrastructure Security",
-    "version": 1
+    "param": "hostIPC",
+    "prefix": "",
+    "suffix": "",
+    "value": "true"
+  },
+  "severity": "MEDIUM",
+  "description": "Containers Should Not Share Host IPC Namespace",
+  "reference_id": "AC-K8-NS-PO-M-0163",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0083"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0163.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0163.json
@@ -1,19 +1,19 @@
 {
-  "name": "falseHostIPC",
-  "file": "specBoolCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "falseHostIPC",
-    "param": "hostIPC",
-    "prefix": "",
-    "suffix": "",
-    "value": "true"
-  },
-  "severity": "MEDIUM",
-  "description": "Containers Should Not Share Host IPC Namespace",
-  "reference_id": "AC-K8-NS-PO-M-0163",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0083"
+    "file": "specBoolCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "falseHostIPC",
+        "param": "hostIPC",
+        "prefix": "",
+        "suffix": "",
+        "value": "true"
+    },
+    "severity": "MEDIUM",
+    "description": "Containers Should Not Share Host IPC Namespace",
+    "reference_id": "AC-K8-NS-PO-M-0163",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0083"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0164.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0164.json
@@ -1,18 +1,19 @@
 {
+  "name": "falseHostNetwork",
+  "file": "specBoolCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "falseHostNetwork",
-    "file": "specBoolCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "falseHostNetwork",
-        "param": "hostNetwork",
-        "prefix": "",
-        "suffix": "",
-        "value": "true"
-    },
-    "severity": "MEDIUM",
-    "description": "Containers Should Not Share the Host Network Namespace",
-    "reference_id": "AC-K8-NS-PO-M-0164",
-    "category": "Infrastructure Security",
-    "version": 1
+    "param": "hostNetwork",
+    "prefix": "",
+    "suffix": "",
+    "value": "true"
+  },
+  "severity": "MEDIUM",
+  "description": "Containers Should Not Share the Host Network Namespace",
+  "reference_id": "AC-K8-NS-PO-M-0164",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0084"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0164.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0164.json
@@ -1,19 +1,19 @@
 {
-  "name": "falseHostNetwork",
-  "file": "specBoolCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "falseHostNetwork",
-    "param": "hostNetwork",
-    "prefix": "",
-    "suffix": "",
-    "value": "true"
-  },
-  "severity": "MEDIUM",
-  "description": "Containers Should Not Share the Host Network Namespace",
-  "reference_id": "AC-K8-NS-PO-M-0164",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0084"
+    "file": "specBoolCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "falseHostNetwork",
+        "param": "hostNetwork",
+        "prefix": "",
+        "suffix": "",
+        "value": "true"
+    },
+    "severity": "MEDIUM",
+    "description": "Containers Should Not Share the Host Network Namespace",
+    "reference_id": "AC-K8-NS-PO-M-0164",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0084"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0171.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0171.json
@@ -1,19 +1,20 @@
 {
+  "name": "dontConnectDockerSock",
+  "file": "dockerSockCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "attrib": "spec.volumes[_].hostPath",
     "name": "dontConnectDockerSock",
-    "file": "dockerSockCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "attrib": "spec.volumes[_].hostPath",
-        "name": "dontConnectDockerSock",
-        "param": "path",
-        "prefix": "",
-        "suffix": "",
-        "value": "/var/run/docker"
-    },
-    "severity": "MEDIUM",
-    "description": "Restrict Mounting Docker Socket in a Container",
-    "reference_id": "AC-K8-NS-PO-M-0171",
-    "category": "Infrastructure Security",
-    "version": 1
+    "param": "path",
+    "prefix": "",
+    "suffix": "",
+    "value": "/var/run/docker"
+  },
+  "severity": "MEDIUM",
+  "description": "Restrict Mounting Docker Socket in a Container",
+  "reference_id": "AC-K8-NS-PO-M-0171",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0088"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0171.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0171.json
@@ -1,20 +1,20 @@
 {
-  "name": "dontConnectDockerSock",
-  "file": "dockerSockCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "attrib": "spec.volumes[_].hostPath",
     "name": "dontConnectDockerSock",
-    "param": "path",
-    "prefix": "",
-    "suffix": "",
-    "value": "/var/run/docker"
-  },
-  "severity": "MEDIUM",
-  "description": "Restrict Mounting Docker Socket in a Container",
-  "reference_id": "AC-K8-NS-PO-M-0171",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0088"
+    "file": "dockerSockCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "attrib": "spec.volumes[_].hostPath",
+        "name": "dontConnectDockerSock",
+        "param": "path",
+        "prefix": "",
+        "suffix": "",
+        "value": "/var/run/docker"
+    },
+    "severity": "MEDIUM",
+    "description": "Restrict Mounting Docker Socket in a Container",
+    "reference_id": "AC-K8-NS-PO-M-0171",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0088"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0182.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0182.json
@@ -1,16 +1,17 @@
 {
+  "name": "containersAsHighUID",
+  "file": "containersAsHighUID.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "containersAsHighUID",
-    "file": "containersAsHighUID.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "containersAsHighUID",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Containers Should Run as a High UID to Avoid Host Conflict",
-    "reference_id": "AC-K8-NS-PO-M-0182",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Containers Should Run as a High UID to Avoid Host Conflict",
+  "reference_id": "AC-K8-NS-PO-M-0182",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0079"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0182.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-NS-PO-M-0182.json
@@ -1,17 +1,17 @@
 {
-  "name": "containersAsHighUID",
-  "file": "containersAsHighUID.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "containersAsHighUID",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Containers Should Run as a High UID to Avoid Host Conflict",
-  "reference_id": "AC-K8-NS-PO-M-0182",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0079"
+    "file": "containersAsHighUID.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "containersAsHighUID",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Containers Should Run as a High UID to Avoid Host Conflict",
+    "reference_id": "AC-K8-NS-PO-M-0182",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0079"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0034.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0034.json
@@ -1,22 +1,22 @@
 {
-  "name": "alwaysPullImages",
-  "file": "commandCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "argument": "--enable-admission-plugins",
     "name": "alwaysPullImages",
-    "negation": "",
-    "optional": "",
-    "param": "AlwaysPullImages",
-    "prefix": "",
-    "presence": "not",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "AlwaysPullImages plugin is not set",
-  "reference_id": "AC-K8-OE-PK-M-0034",
-  "category": "Compliance Validation",
-  "version": 1,
-  "id": "AC_K8S_0021"
+    "file": "commandCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "argument": "--enable-admission-plugins",
+        "name": "alwaysPullImages",
+        "negation": "",
+        "optional": "",
+        "param": "AlwaysPullImages",
+        "prefix": "",
+        "presence": "not",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "AlwaysPullImages plugin is not set",
+    "reference_id": "AC-K8-OE-PK-M-0034",
+    "category": "Compliance Validation",
+    "version": 1,
+    "id": "AC_K8S_0021"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0034.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0034.json
@@ -1,21 +1,22 @@
 {
+  "name": "alwaysPullImages",
+  "file": "commandCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "argument": "--enable-admission-plugins",
     "name": "alwaysPullImages",
-    "file": "commandCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "argument": "--enable-admission-plugins",
-        "name": "alwaysPullImages",
-        "negation": "",
-        "optional": "",
-        "param": "AlwaysPullImages",
-        "prefix": "",
-        "presence": "not",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "AlwaysPullImages plugin is not set",
-    "reference_id": "AC-K8-OE-PK-M-0034",
-    "category": "Compliance Validation",
-    "version": 1
+    "negation": "",
+    "optional": "",
+    "param": "AlwaysPullImages",
+    "prefix": "",
+    "presence": "not",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "AlwaysPullImages plugin is not set",
+  "reference_id": "AC-K8-OE-PK-M-0034",
+  "category": "Compliance Validation",
+  "version": 1,
+  "id": "AC_K8S_0021"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0155.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0155.json
@@ -1,24 +1,24 @@
 {
-  "name": "CpuRequestsCheck",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "true",
-    "arg1": "requests",
-    "arg2": "cpu",
     "name": "CpuRequestsCheck",
-    "not_allowed": "false",
-    "param": "requests",
-    "param1": "resources",
-    "prefix": "",
-    "suffix": "",
-    "value": "false"
-  },
-  "severity": "Medium",
-  "description": "CPU Request Not Set in config file.",
-  "reference_id": "AC-K8-OE-PK-M-0155",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0097"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "true",
+        "arg1": "requests",
+        "arg2": "cpu",
+        "name": "CpuRequestsCheck",
+        "not_allowed": "false",
+        "param": "requests",
+        "param1": "resources",
+        "prefix": "",
+        "suffix": "",
+        "value": "false"
+    },
+    "severity": "Medium",
+    "description": "CPU Request Not Set in config file.",
+    "reference_id": "AC-K8-OE-PK-M-0155",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0097"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0155.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0155.json
@@ -1,23 +1,24 @@
 {
+  "name": "CpuRequestsCheck",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "true",
+    "arg1": "requests",
+    "arg2": "cpu",
     "name": "CpuRequestsCheck",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "true",
-        "arg1": "requests",
-        "arg2": "cpu",
-        "name": "CpuRequestsCheck",
-        "not_allowed": "false",
-        "param": "requests",
-        "param1": "resources",
-        "prefix": "",
-        "suffix": "",
-        "value": "false"
-    },
-    "severity": "Medium",
-    "description": "CPU Request Not Set in config file.",
-    "reference_id": "AC-K8-OE-PK-M-0155",
-    "category": "Security Best Practices",
-    "version": 1
+    "not_allowed": "false",
+    "param": "requests",
+    "param1": "resources",
+    "prefix": "",
+    "suffix": "",
+    "value": "false"
+  },
+  "severity": "Medium",
+  "description": "CPU Request Not Set in config file.",
+  "reference_id": "AC-K8-OE-PK-M-0155",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0097"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0156.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0156.json
@@ -1,24 +1,24 @@
 {
-  "name": "CpulimitsCheck",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "true",
-    "arg1": "limits",
-    "arg2": "cpu",
     "name": "CpulimitsCheck",
-    "not_allowed": "false",
-    "param": "limits",
-    "param1": "resources",
-    "prefix": "",
-    "suffix": "",
-    "value": "false"
-  },
-  "severity": "Medium",
-  "description": "CPU Limits Not Set in config file.",
-  "reference_id": "AC-K8-OE-PK-M-0156",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0098"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "true",
+        "arg1": "limits",
+        "arg2": "cpu",
+        "name": "CpulimitsCheck",
+        "not_allowed": "false",
+        "param": "limits",
+        "param1": "resources",
+        "prefix": "",
+        "suffix": "",
+        "value": "false"
+    },
+    "severity": "Medium",
+    "description": "CPU Limits Not Set in config file.",
+    "reference_id": "AC-K8-OE-PK-M-0156",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0098"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0156.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0156.json
@@ -1,23 +1,24 @@
 {
+  "name": "CpulimitsCheck",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "true",
+    "arg1": "limits",
+    "arg2": "cpu",
     "name": "CpulimitsCheck",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "true",
-        "arg1": "limits",
-        "arg2": "cpu",
-        "name": "CpulimitsCheck",
-        "not_allowed": "false",
-        "param": "limits",
-        "param1": "resources",
-        "prefix": "",
-        "suffix": "",
-        "value": "false"
-    },
-    "severity": "Medium",
-    "description": "CPU Limits Not Set in config file.",
-    "reference_id": "AC-K8-OE-PK-M-0156",
-    "category": "Security Best Practices",
-    "version": 1
+    "not_allowed": "false",
+    "param": "limits",
+    "param1": "resources",
+    "prefix": "",
+    "suffix": "",
+    "value": "false"
+  },
+  "severity": "Medium",
+  "description": "CPU Limits Not Set in config file.",
+  "reference_id": "AC-K8-OE-PK-M-0156",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0098"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0157.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0157.json
@@ -1,24 +1,24 @@
 {
-  "name": "MemoryRequestsCheck",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "true",
-    "arg1": "requests",
-    "arg2": "memory",
     "name": "MemoryRequestsCheck",
-    "not_allowed": "false",
-    "param": "requests",
-    "param1": "resources",
-    "prefix": "",
-    "suffix": "",
-    "value": "false"
-  },
-  "severity": "Medium",
-  "description": "Memory Request Not Set in config file.",
-  "reference_id": "AC-K8-OE-PK-M-0157",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0099"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "true",
+        "arg1": "requests",
+        "arg2": "memory",
+        "name": "MemoryRequestsCheck",
+        "not_allowed": "false",
+        "param": "requests",
+        "param1": "resources",
+        "prefix": "",
+        "suffix": "",
+        "value": "false"
+    },
+    "severity": "Medium",
+    "description": "Memory Request Not Set in config file.",
+    "reference_id": "AC-K8-OE-PK-M-0157",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0099"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0157.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0157.json
@@ -1,23 +1,24 @@
 {
+  "name": "MemoryRequestsCheck",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "true",
+    "arg1": "requests",
+    "arg2": "memory",
     "name": "MemoryRequestsCheck",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "true",
-        "arg1": "requests",
-        "arg2": "memory",
-        "name": "MemoryRequestsCheck",
-        "not_allowed": "false",
-        "param": "requests",
-        "param1": "resources",
-        "prefix": "",
-        "suffix": "",
-        "value": "false"
-    },
-    "severity": "Medium",
-    "description": "Memory Request Not Set in config file.",
-    "reference_id": "AC-K8-OE-PK-M-0157",
-    "category": "Security Best Practices",
-    "version": 1
+    "not_allowed": "false",
+    "param": "requests",
+    "param1": "resources",
+    "prefix": "",
+    "suffix": "",
+    "value": "false"
+  },
+  "severity": "Medium",
+  "description": "Memory Request Not Set in config file.",
+  "reference_id": "AC-K8-OE-PK-M-0157",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0099"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0158.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0158.json
@@ -1,23 +1,24 @@
 {
+  "name": "MemorylimitsCheck",
+  "file": "securityContextCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "allowed": "true",
+    "arg1": "limits",
+    "arg2": "memory",
     "name": "MemorylimitsCheck",
-    "file": "securityContextCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "allowed": "true",
-        "arg1": "limits",
-        "arg2": "memory",
-        "name": "MemorylimitsCheck",
-        "not_allowed": "false",
-        "param": "limits",
-        "param1": "resources",
-        "prefix": "",
-        "suffix": "",
-        "value": "false"
-    },
-    "severity": "Medium",
-    "description": "Memory Limits Not Set in config file.",
-    "reference_id": "AC-K8-OE-PK-M-0158",
-    "category": "Security Best Practices",
-    "version": 1
+    "not_allowed": "false",
+    "param": "limits",
+    "param1": "resources",
+    "prefix": "",
+    "suffix": "",
+    "value": "false"
+  },
+  "severity": "Medium",
+  "description": "Memory Limits Not Set in config file.",
+  "reference_id": "AC-K8-OE-PK-M-0158",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0100"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0158.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PK-M-0158.json
@@ -1,24 +1,24 @@
 {
-  "name": "MemorylimitsCheck",
-  "file": "securityContextCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "allowed": "true",
-    "arg1": "limits",
-    "arg2": "memory",
     "name": "MemorylimitsCheck",
-    "not_allowed": "false",
-    "param": "limits",
-    "param1": "resources",
-    "prefix": "",
-    "suffix": "",
-    "value": "false"
-  },
-  "severity": "Medium",
-  "description": "Memory Limits Not Set in config file.",
-  "reference_id": "AC-K8-OE-PK-M-0158",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0100"
+    "file": "securityContextCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "allowed": "true",
+        "arg1": "limits",
+        "arg2": "memory",
+        "name": "MemorylimitsCheck",
+        "not_allowed": "false",
+        "param": "limits",
+        "param1": "resources",
+        "prefix": "",
+        "suffix": "",
+        "value": "false"
+    },
+    "severity": "Medium",
+    "description": "Memory Limits Not Set in config file.",
+    "reference_id": "AC-K8-OE-PK-M-0158",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0100"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0129.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0129.json
@@ -1,19 +1,19 @@
 {
-  "name": "nolivenessProbe",
-  "file": "probeCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "argument": "livenessProbe",
-    "argumentTF": "liveness_probe",
     "name": "nolivenessProbe",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "LOW",
-  "description": "No liveness probe will ensure there is no recovery in case of unexpected errors",
-  "reference_id": "AC-K8-OE-PO-L-0129",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0070"
+    "file": "probeCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "argument": "livenessProbe",
+        "argumentTF": "liveness_probe",
+        "name": "nolivenessProbe",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "No liveness probe will ensure there is no recovery in case of unexpected errors",
+    "reference_id": "AC-K8-OE-PO-L-0129",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0070"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0129.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0129.json
@@ -1,18 +1,19 @@
 {
+  "name": "nolivenessProbe",
+  "file": "probeCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "argument": "livenessProbe",
+    "argumentTF": "liveness_probe",
     "name": "nolivenessProbe",
-    "file": "probeCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "argument": "livenessProbe",
-        "argumentTF": "liveness_probe",
-        "name": "nolivenessProbe",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "LOW",
-    "description": "No liveness probe will ensure there is no recovery in case of unexpected errors",
-    "reference_id": "AC-K8-OE-PO-L-0129",
-    "category": "Security Best Practices",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "LOW",
+  "description": "No liveness probe will ensure there is no recovery in case of unexpected errors",
+  "reference_id": "AC-K8-OE-PO-L-0129",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0070"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0130.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0130.json
@@ -1,19 +1,19 @@
 {
-  "name": "noReadinessProbe",
-  "file": "probeCheck.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
-    "argument": "readinessProbe",
-    "argumentTF": "readiness_probe",
     "name": "noReadinessProbe",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "LOW",
-  "description": "No readiness probe will affect automatic recovery in case of unexpected errors",
-  "reference_id": "AC-K8-OE-PO-L-0130",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0072"
+    "file": "probeCheck.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "argument": "readinessProbe",
+        "argumentTF": "readiness_probe",
+        "name": "noReadinessProbe",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "No readiness probe will affect automatic recovery in case of unexpected errors",
+    "reference_id": "AC-K8-OE-PO-L-0130",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0072"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0130.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0130.json
@@ -1,18 +1,19 @@
 {
+  "name": "noReadinessProbe",
+  "file": "probeCheck.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
+    "argument": "readinessProbe",
+    "argumentTF": "readiness_probe",
     "name": "noReadinessProbe",
-    "file": "probeCheck.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "argument": "readinessProbe",
-        "argumentTF": "readiness_probe",
-        "name": "noReadinessProbe",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "LOW",
-    "description": "No readiness probe will affect automatic recovery in case of unexpected errors",
-    "reference_id": "AC-K8-OE-PO-L-0130",
-    "category": "Security Best Practices",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "LOW",
+  "description": "No readiness probe will affect automatic recovery in case of unexpected errors",
+  "reference_id": "AC-K8-OE-PO-L-0130",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0072"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0134.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0134.json
@@ -1,16 +1,17 @@
 {
+  "name": "imageWithLatestTag",
+  "file": "imageWithLatestTag.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "imageWithLatestTag",
-    "file": "imageWithLatestTag.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "imageWithLatestTag",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "LOW",
-    "description": "No tag or container image with :Latest tag makes difficult to rollback and track",
-    "reference_id": "AC-K8-OE-PO-L-0134",
-    "category": "Security Best Practices",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "LOW",
+  "description": "No tag or container image with :Latest tag makes difficult to rollback and track",
+  "reference_id": "AC-K8-OE-PO-L-0134",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0068"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0134.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-L-0134.json
@@ -1,17 +1,17 @@
 {
-  "name": "imageWithLatestTag",
-  "file": "imageWithLatestTag.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "imageWithLatestTag",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "LOW",
-  "description": "No tag or container image with :Latest tag makes difficult to rollback and track",
-  "reference_id": "AC-K8-OE-PO-L-0134",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0068"
+    "file": "imageWithLatestTag.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "imageWithLatestTag",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "No tag or container image with :Latest tag makes difficult to rollback and track",
+    "reference_id": "AC-K8-OE-PO-L-0134",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0068"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-M-0166.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-M-0166.json
@@ -1,16 +1,17 @@
 {
+  "name": "otherNamespace",
+  "file": "otherNamespace.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_pod",
+  "template_args": {
     "name": "otherNamespace",
-    "file": "otherNamespace.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_pod",
-    "template_args": {
-        "name": "otherNamespace",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Default Namespace Should Not be Used",
-    "reference_id": "AC-K8-OE-PO-M-0166",
-    "category": "Security Best Practices",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "HIGH",
+  "description": "Default Namespace Should Not be Used",
+  "reference_id": "AC-K8-OE-PO-M-0166",
+  "category": "Security Best Practices",
+  "version": 1,
+  "id": "AC_K8S_0086"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-M-0166.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_pod/AC-K8-OE-PO-M-0166.json
@@ -1,17 +1,17 @@
 {
-  "name": "otherNamespace",
-  "file": "otherNamespace.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_pod",
-  "template_args": {
     "name": "otherNamespace",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "HIGH",
-  "description": "Default Namespace Should Not be Used",
-  "reference_id": "AC-K8-OE-PO-M-0166",
-  "category": "Security Best Practices",
-  "version": 1,
-  "id": "AC_K8S_0086"
+    "file": "otherNamespace.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_pod",
+    "template_args": {
+        "name": "otherNamespace",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "HIGH",
+    "description": "Default Namespace Should Not be Used",
+    "reference_id": "AC-K8-OE-PO-M-0166",
+    "category": "Security Best Practices",
+    "version": 1,
+    "id": "AC_K8S_0086"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0185.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0185.json
@@ -1,16 +1,17 @@
 {
+  "name": "tillerServiceDeleted",
+  "file": "tillerServiceDeleted.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_service",
+  "template_args": {
     "name": "tillerServiceDeleted",
-    "file": "tillerServiceDeleted.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_service",
-    "template_args": {
-        "name": "tillerServiceDeleted",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Ensure that the Tiller Service (Helm v2) is deleted",
-    "reference_id": "AC-K8-NS-SE-M-0185",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Ensure that the Tiller Service (Helm v2) is deleted",
+  "reference_id": "AC-K8-NS-SE-M-0185",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0110"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0185.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0185.json
@@ -1,17 +1,17 @@
 {
-  "name": "tillerServiceDeleted",
-  "file": "tillerServiceDeleted.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_service",
-  "template_args": {
     "name": "tillerServiceDeleted",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Ensure that the Tiller Service (Helm v2) is deleted",
-  "reference_id": "AC-K8-NS-SE-M-0185",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0110"
+    "file": "tillerServiceDeleted.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_service",
+    "template_args": {
+        "name": "tillerServiceDeleted",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Ensure that the Tiller Service (Helm v2) is deleted",
+    "reference_id": "AC-K8-NS-SE-M-0185",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0110"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0188.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0188.json
@@ -1,16 +1,17 @@
 {
+  "name": "ensurePrivateIP",
+  "file": "ensurePrivateIP.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_service",
+  "template_args": {
     "name": "ensurePrivateIP",
-    "file": "ensurePrivateIP.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_service",
-    "template_args": {
-        "name": "ensurePrivateIP",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "MEDIUM",
-    "description": "Restrict the use of externalIPs",
-    "reference_id": "AC-K8-NS-SE-M-0188",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "MEDIUM",
+  "description": "Restrict the use of externalIPs",
+  "reference_id": "AC-K8-NS-SE-M-0188",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0112"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0188.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SE-M-0188.json
@@ -1,17 +1,17 @@
 {
-  "name": "ensurePrivateIP",
-  "file": "ensurePrivateIP.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_service",
-  "template_args": {
     "name": "ensurePrivateIP",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "MEDIUM",
-  "description": "Restrict the use of externalIPs",
-  "reference_id": "AC-K8-NS-SE-M-0188",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0112"
+    "file": "ensurePrivateIP.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_service",
+    "template_args": {
+        "name": "ensurePrivateIP",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "MEDIUM",
+    "description": "Restrict the use of externalIPs",
+    "reference_id": "AC-K8-NS-SE-M-0188",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0112"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SV-L-0132.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SV-L-0132.json
@@ -1,17 +1,17 @@
 {
-  "name": "nodePort",
-  "file": "nodePort.rego",
-  "policy_type": "k8s",
-  "resource_type": "kubernetes_service",
-  "template_args": {
     "name": "nodePort",
-    "prefix": "",
-    "suffix": ""
-  },
-  "severity": "LOW",
-  "description": "Nodeport service can expose the worker nodes as they have public interface",
-  "reference_id": "AC-K8-NS-SV-L-0132",
-  "category": "Infrastructure Security",
-  "version": 1,
-  "id": "AC_K8S_0111"
+    "file": "nodePort.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_service",
+    "template_args": {
+        "name": "nodePort",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "Nodeport service can expose the worker nodes as they have public interface",
+    "reference_id": "AC-K8-NS-SV-L-0132",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0111"
 }

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SV-L-0132.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC-K8-NS-SV-L-0132.json
@@ -1,16 +1,17 @@
 {
+  "name": "nodePort",
+  "file": "nodePort.rego",
+  "policy_type": "k8s",
+  "resource_type": "kubernetes_service",
+  "template_args": {
     "name": "nodePort",
-    "file": "nodePort.rego",
-    "policy_type": "k8s",
-    "resource_type": "kubernetes_service",
-    "template_args": {
-        "name": "nodePort",
-        "prefix": "",
-        "suffix": ""
-    },
-    "severity": "LOW",
-    "description": "Nodeport service can expose the worker nodes as they have public interface",
-    "reference_id": "AC-K8-NS-SV-L-0132",
-    "category": "Infrastructure Security",
-    "version": 1
+    "prefix": "",
+    "suffix": ""
+  },
+  "severity": "LOW",
+  "description": "Nodeport service can expose the worker nodes as they have public interface",
+  "reference_id": "AC-K8-NS-SV-L-0132",
+  "category": "Infrastructure Security",
+  "version": 1,
+  "id": "AC_K8S_0111"
 }


### PR DESCRIPTION
Changes for terrascan policies where names match with SIAC policies

These changes are relevant only for K8s policies

1. Add `id` field with new format
2. Update severity
3. Update category