### PR TITLE
add check for env vars and kms

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_lambda_function/lambdaNotEncryptedWithKms.rego
+++ b/pkg/policies/opa/rego/aws/aws_lambda_function/lambdaNotEncryptedWithKms.rego
@@ -1,6 +1,11 @@
 package accurics
 
 lambdaNotEncryptedWithKms[lambda.id] {
-  lambda := input.aws_lambda_function[_]
-  not lambda.config.kms_key_arn
+	lambda := input.aws_lambda_function[_]
+
+	object.get(lambda.config, "environment", "undefined") != "undefined"
+	object.get(lambda.config.environment[_], "variables", "undefined") != "undefined"
+	lambda.config.environment[_].variables != {}
+
+	object.get(lambda.config, "kms_key_arn", "undefined") == "undefined"
 }


### PR DESCRIPTION
- Update rego code for rule `lambdaNotEncryptedWithKms`
- Fixes issue #682 
- Attaching terraform snippet used for testing with positive and negative test cases below

```tf
provider "aws" {
  region = "us-east-1"
}

resource "aws_lambda_function" "noVars_NoKms" {
  function_name = "noVars"
  role          = "somerole"
  handler       = "exports.test"
}

resource "aws_lambda_function" "yesVars_NoKms" {
  function_name = "yesVars"
  role          = "somerole"
  handler       = "exports.test"

  environment {
    variables = {
      foo = "bar"
    }
  }
}

resource "aws_lambda_function" "yesVars_YesKms" {
  function_name = "yesVars"
  role          = "somerole"
  handler       = "exports.test"

  kms_key_arn = "arn:aws:iam::123456789012:user/Development/product_1234/*"

  environment {
    variables = {
      foo = "bar"
    }
  }
}

resource "aws_lambda_function" "yesEnvVar_NoKms" {
  function_name = "yesEnvVar"
  role          = "somerole"
  handler       = "exports.test"

  environment {
    variables = {
    }
  }
}

resource "aws_lambda_function" "yesEnv_NoKms" {
  function_name = "yesEnvVar"
  role          = "somerole"
  handler       = "exports.test"

  environment {
  }
}
```