### PR TITLE
aws s3 policy `s3EnforceUserAcl` update

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/s3EnforceUserACL.rego
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/s3EnforceUserACL.rego
@@ -6,14 +6,23 @@ package accurics
     #proceeding forward only if inline policy is not included
     not bucket.config.policy
 
-    bucket_policies_set := { policy_id | policy_id := split(input.aws_s3_bucket_policy[_].id, "." )[1] }
+    bucket_policy := input.aws_s3_bucket_policy[_]
 
-    not bucket_policies_set[split(bucket.id, ".")[1]]
+    bucket_id := split(bucket.id, ".")[1]
+    not contains(bucket_policy.config.bucket, bucket_id)
 
-	rc = "cmVzb3VyY2UgImF3c19zM19idWNrZXRfcG9saWN5IiAiIyNyZXNvdXJjZV9uYW1lIyNQb2xpY3kiIHsKICBidWNrZXQgPSAiJHthd3NfczNfYnVja2V0LiMjcmVzb3VyY2VfbmFtZSMjLmlkfSIKCiAgcG9saWN5ID0gPDxQT0xJQ1kKewogICJWZXJzaW9uIjogIjIwMTItMTAtMTciLAogICJTdGF0ZW1lbnQiOiBbCiAgICB7CiAgICAgICJTaWQiOiAiIyNyZXNvdXJjZV9uYW1lIyMtcmVzdHJpY3QtYWNjZXNzLXRvLXVzZXJzLW9yLXJvbGVzIiwKICAgICAgIkVmZmVjdCI6ICJBbGxvdyIsCiAgICAgICJQcmluY2lwYWwiOiBbCiAgICAgICAgewogICAgICAgICAgIkFXUyI6IFsKICAgICAgICAgICAgImFybjphd3M6aWFtOjojI2Fjb3VudF9pZCMjOnJvbGUvIyNyb2xlX25hbWUjIyIsCiAgICAgICAgICAgICJhcm46YXdzOmlhbTo6IyNhY291bnRfaWQjIzp1c2VyLyMjdXNlcl9uYW1lIyMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdLAogICAgICAiQWN0aW9uIjogInMzOkdldE9iamVjdCIsCiAgICAgICJSZXNvdXJjZSI6ICJhcm46YXdzOnMzOjo6JHthd3NfczNfYnVja2V0LiMjcmVzb3VyY2VfbmFtZSMjLmlkfS8qIgogICAgfQogIF0KfQpQT0xJQ1kKfQ=="
-    decode_rc = base64.decode(rc)
+    rc := "cmVzb3VyY2UgImF3c19zM19idWNrZXRfcG9saWN5IiAiIyNyZXNvdXJjZV9uYW1lIyNQb2xpY3kiIHsKICBidWNrZXQgPSAiJHthd3NfczNfYnVja2V0LiMjcmVzb3VyY2VfbmFtZSMjLmlkfSIKCiAgcG9saWN5ID0gPDxQT0xJQ1kKewogICJWZXJzaW9uIjogIjIwMTItMTAtMTciLAogICJTdGF0ZW1lbnQiOiBbCiAgICB7CiAgICAgICJTaWQiOiAiIyNyZXNvdXJjZV9uYW1lIyMtcmVzdHJpY3QtYWNjZXNzLXRvLXVzZXJzLW9yLXJvbGVzIiwKICAgICAgIkVmZmVjdCI6ICJBbGxvdyIsCiAgICAgICJQcmluY2lwYWwiOiBbCiAgICAgICAgewogICAgICAgICAgIkFXUyI6IFsKICAgICAgICAgICAgImFybjphd3M6aWFtOjojI2Fjb3VudF9pZCMjOnJvbGUvIyNyb2xlX25hbWUjIyIsCiAgICAgICAgICAgICJhcm46YXdzOmlhbTo6IyNhY291bnRfaWQjIzp1c2VyLyMjdXNlcl9uYW1lIyMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdLAogICAgICAiQWN0aW9uIjogInMzOkdldE9iamVjdCIsCiAgICAgICJSZXNvdXJjZSI6ICJhcm46YXdzOnMzOjo6JHthd3NfczNfYnVja2V0LiMjcmVzb3VyY2VfbmFtZSMjLmlkfS8qIgogICAgfQogIF0KfQpQT0xJQ1kKfQ=="
+    decode_rc := base64.decode(rc)
     replaced_resource_name := replace(decode_rc, "##resource_name##", bucket.name)
 
-    traverse = ""
-    retVal := { "Id": bucket.id, "ReplaceType": "add", "CodeType": "resource", "Traverse": traverse, "Attribute": "", "AttributeDataType": "resource", "Expected": base64.encode(replaced_resource_name), "Actual": null }
+    retVal := {
+        "Id": bucket.id,
+        "ReplaceType": "add",
+        "CodeType": "resource",
+        "Traverse": "",
+        "Attribute": "",
+        "AttributeDataType": "resource",
+        "Expected": base64.encode(replaced_resource_name),
+        "Actual": null
+     }
 }


### PR DESCRIPTION
- Updated rego code where bucket and it's attached policy was checked
- Fixes #659 
- Following is a terraform snippet with a positive and negative case

```tf
provider "aws" {
  region = "us-east-1"
}


resource "aws_s3_bucket" "no_policy" {
  bucket = "frontend-access-logs"
  acl    = "private"

  versioning {
    enabled = true
  }

  logging {
    target_bucket = "log-bucket"
    target_prefix = "AWSLogs/frontend-lb-access-logs/"
  }
}


resource "aws_s3_bucket" "yes_policy" {
  bucket = "frontend-access-logs"
  acl    = "private"

  versioning {
    enabled = true
  }

  logging {
    target_bucket = "log-bucket"
    target_prefix = "AWSLogs/frontend-lb-access-logs/"
  }
}

resource "aws_s3_bucket_policy" "frontend_lb_logs_policy" {
  bucket = aws_s3_bucket.yes_policy.id

  policy = jsonencode({
    Version = "2012-10-17"
    Id      = "MYBUCKETPOLICY"
    Statement = [
      {
        Sid       = "IPAllow"
        Effect    = "Deny"
        Principal = "*"
        Action    = "s3:*"
        Resource = [
          aws_s3_bucket.b.arn,
          "${aws_s3_bucket.b.arn}/*",
        ]
        Condition = {
          IpAddress = {
            "aws:SourceIp" = "8.8.8.8/32"
          }
        }
      },
    ]
  })
}
```