### PR TITLE
Policy to check CVE-2021-25737

### DIFF
--- a/pkg/policies/opa/rego/k8s/kubernetes_endpoint_slice/AC_K8S_0113.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_endpoint_slice/AC_K8S_0113.json
@@ -1,0 +1,17 @@
+{
+    "name": "loopbackAddressUsed",
+    "file": "loopbackAddressUsed.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_endpoint_slice",
+    "template_args": {
+        "name": "loopbackAddressUsed",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "Ensure endpoint slice is not created or updated with loopback addresses as this acts as an attack vector for exploiting CVE-2021-25737 by an authorized user",
+    "reference_id": "AC_K8S_0113",
+    "id": "AC_K8S_0113",
+    "category": "Infrastructure Security",
+    "version": 1
+}

--- a/pkg/policies/opa/rego/k8s/kubernetes_endpoint_slice/loopbackAddressUsed.rego
+++ b/pkg/policies/opa/rego/k8s/kubernetes_endpoint_slice/loopbackAddressUsed.rego
@@ -1,0 +1,9 @@
+package accurics
+
+{{.prefix}}{{.name}}{{.suffix}}[endpoint_slice.id] {
+   endpoint_slice = input.kubernetes_endpoint_slice[_]
+   address := endpoint_slice.config.endpoints[_].addresses[_]
+
+   not_allowed_addresses := ["127.0.0.0/8", "169.254.0.0/16"]
+   net.cidr_contains(not_allowed_addresses[_], address)
+}


### PR DESCRIPTION
This policy checks for [CVE-2021-25737](https://sysdig.com/blog/cve-2021-25737-endpointslice/) attack vector, that is, loopback addresses in kubernetes endpoint slice.