### PR TITLE
Add ID Field for AWS Policies' Metadata

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_ami/AWS.EC2.Encryption&KeyManagement.Medium.0688.json
+++ b/pkg/policies/opa/rego/aws/aws_ami/AWS.EC2.Encryption&KeyManagement.Medium.0688.json
@@ -8,5 +8,6 @@
     "description": "Enable AWS AMI Encryption",
     "reference_id": "AWS.EC2.Encryption\u0026KeyManagement.Medium.0688",
     "category": "Infrastructure Security",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0005"
 }

--- a/pkg/policies/opa/rego/aws/aws_ami_launch_permission/AWS.AMI.NS.Medium.1040.json
+++ b/pkg/policies/opa/rego/aws/aws_ami_launch_permission/AWS.AMI.NS.Medium.1040.json
@@ -10,5 +10,6 @@
     "description": "Limit access to AWS AMIs",
     "reference_id": "AWS.AMI.NS.Medium.1040",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0006"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_method_settings/AWS.API Gateway.Logging.Medium.0569.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_method_settings/AWS.API Gateway.Logging.Medium.0569.json
@@ -8,5 +8,6 @@
     "description": "Enable Detailed CloudWatch Metrics for APIs",
     "reference_id": "AWS.API Gateway.Logging.Medium.0569",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0007"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_rest_api/AWS.APIGateway.Medium.0568.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_rest_api/AWS.APIGateway.Medium.0568.json
@@ -8,5 +8,6 @@
     "description": "Enable Content Encoding",
     "reference_id": "AWS.APIGateway.Medium.0568",
     "category": "Infrastructure Security",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0010"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_rest_api/AWS.APIGateway.Network Security.Medium.0570.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_rest_api/AWS.APIGateway.Network Security.Medium.0570.json
@@ -8,5 +8,6 @@
     "description": "API Gateway Private Endpoints",
     "reference_id": "AWS.APIGateway.Network Security.Medium.0570",
     "category": "Infrastructure Security",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0011"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0567.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0567.json
@@ -8,5 +8,6 @@
     "description": "Enable AWS CloudWatch Logs for APIs",
     "reference_id": "AWS.API Gateway.Logging.Medium.0567",
     "category": "Logging and Monitoring",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0014"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0571.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0571.json
@@ -4,9 +4,10 @@
     "policy_type": "aws",
     "resource_type": "aws_api_gateway_stage",
     "template_args": null,
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "description": "Ensure AWS API Gateway has active xray tracing enabled",
     "reference_id": "AWS.API Gateway.Logging.Medium.0571",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0015"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0572.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0572.json
@@ -10,5 +10,6 @@
     "description": "Ensure that AWS CloudWatch logs are enabled for all your APIs created with Amazon API Gateway service in order to track and analyze execution behavior at the API stage level.",
     "reference_id": "AWS.API Gateway.Logging.Medium.0572",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0012"
 }

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Network Security.Medium.0565.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Network Security.Medium.0565.json
@@ -8,5 +8,6 @@
     "description": "Enable SSL Client Certificate",
     "reference_id": "AWS.API Gateway.Network Security.Medium.0565",
     "category": "Infrastructure Security",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0013"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudformation_stack/AWS.CloudFormation.Medium.0603.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudformation_stack/AWS.CloudFormation.Medium.0603.json
@@ -11,5 +11,6 @@
     "description": "Enable AWS CloudFormation Stack Notifications",
     "reference_id": "AWS.CloudFormation.Medium.0603",
     "category": "Security Best Practices",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0021"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudformation_stack/AWS.CloudFormation.Medium.0605.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudformation_stack/AWS.CloudFormation.Medium.0605.json
@@ -8,5 +8,6 @@
     "description": "Enable AWS CloudFormation Stack Termination Protection",
     "reference_id": "AWS.CloudFormation.Medium.0605",
     "category": "Security Best Practices",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0022"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AC-AW-IS-CD-M-0026.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AC-AW-IS-CD-M-0026.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "Medium",
+    "severity": "LOW",
     "description": "Ensure that geo restriction is enabled for your Amazon CloudFront CDN distribution to whitelist or blacklist a country in order to allow or restrict users in specific locations from accessing web application content.",
     "reference_id": "AC-AW-IS-CD-M-0026",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0026"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AC-AW-IS-CD-M-1186.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AC-AW-IS-CD-M-1186.json
@@ -8,5 +8,6 @@
     "description": "Ensure that cloud-front has web application firewall enabled",
     "reference_id": "AC-AW-IS-CD-M-1186",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0032"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AWS.CloudFront.EncryptionandKeyManagement.High.0407.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AWS.CloudFront.EncryptionandKeyManagement.High.0407.json
@@ -10,5 +10,6 @@
     "description": "Use encrypted connection between CloudFront and origin server",
     "reference_id": "AWS.CloudFront.EncryptionandKeyManagement.High.0407",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0024"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AWS.CloudFront.EncryptionandKeyManagement.High.0408.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AWS.CloudFront.EncryptionandKeyManagement.High.0408.json
@@ -10,5 +10,6 @@
     "description": "Secure ciphers are not used in CloudFront distribution",
     "reference_id": "AWS.CloudFront.EncryptionandKeyManagement.High.0408",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0023"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AWS.CloudFront.Logging.Medium.0567.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudfront_distribution/AWS.CloudFront.Logging.Medium.0567.json
@@ -10,5 +10,6 @@
     "description": "Ensure that your AWS Cloudfront distributions have the Logging feature enabled in order to track all viewer requests for the content delivered through the Content Delivery Network (CDN).",
     "reference_id": "AWS.CloudFront.Logging.Medium.0567",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0025"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.High.0399.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.High.0399.json
@@ -10,5 +10,6 @@
     "description": "Ensure CloudTrail logs are encrypted using KMS",
     "reference_id": "AWS.CloudTrail.Logging.High.0399",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0033"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Low.009.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Low.009.json
@@ -1,8 +1,8 @@
 {
     "name": "ecrmaketagsimmutable",
     "file": "ecr_make_tags_immutable.rego",
-    "policy_type": "",
-    "resource_type": "",
+    "policy_type": "aws",
+    "resource_type": "aws_cloudtrail",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Low.009.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Low.009.json
@@ -1,6 +1,8 @@
 {
     "name": "ecrmaketagsimmutable",
     "file": "ecr_make_tags_immutable.rego",
+    "policy_type": "",
+    "resource_type": "",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Low.0559.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Low.0559.json
@@ -10,5 +10,6 @@
     "description": "Ensure appropriate subscribers to each SNS topic",
     "reference_id": "AWS.CloudTrail.Logging.Low.0559",
     "category": "Logging and Monitoring",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0035"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.004.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.004.json
@@ -1,8 +1,8 @@
 {
     "name": "cloudTrailMultiRegionEnabled",
     "file": "cloudTrailMultiRegion.rego",
-    "policy_type": "",
-    "resource_type": "",
+    "policy_type": "aws",
+    "resource_type": "aws_cloudtrail",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.004.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.004.json
@@ -1,6 +1,8 @@
 {
     "name": "cloudTrailMultiRegionEnabled",
     "file": "cloudTrailMultiRegion.rego",
+    "policy_type": "",
+    "resource_type": "",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.007.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.007.json
@@ -1,6 +1,8 @@
 {
     "name": "dynamoderecovery_enabled",
     "file": "dynamodb_without_recovery_enabled.rego",
+    "policy_type": "",
+    "resource_type": "",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.007.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.007.json
@@ -1,8 +1,8 @@
 {
     "name": "dynamoderecovery_enabled",
     "file": "dynamodb_without_recovery_enabled.rego",
-    "policy_type": "",
-    "resource_type": "",
+    "policy_type": "aws",
+    "resource_type": "aws_cloudtrail",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.008.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.008.json
@@ -1,8 +1,8 @@
 {
     "name": "ec2ebsnotoptimized",
     "file": "ec2_ebs_not_optimized.rego",
-    "policy_type": "",
-    "resource_type": "",
+    "policy_type": "aws",
+    "resource_type": "aws_cloudtrail",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.008.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.008.json
@@ -1,6 +1,8 @@
 {
     "name": "ec2ebsnotoptimized",
     "file": "ec2_ebs_not_optimized.rego",
+    "policy_type": "",
+    "resource_type": "",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.0460.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.0460.json
@@ -1,12 +1,15 @@
 {
     "name": "cloudTrailMultiRegionNotCreated",
     "file": "cloudTrailMultiRegionNotCreated.rego",
+    "policy_type": "",
+    "resource_type": "",
     "template_args": {
         "prefix": ""
     },
     "severity": "MEDIUM",
     "description": "Cloud Trail Multi Region not enabled",
     "reference_id": "AWS.CloudTrail.Logging.Medium.0460",
-    "category": "Logging",
-    "version": 2
+    "category": "Logging and Monitoring",
+    "version": 2,
+    "id": "AC_AWS_0034"
 }

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.0460.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.CloudTrail.Logging.Medium.0460.json
@@ -1,8 +1,8 @@
 {
     "name": "cloudTrailMultiRegionNotCreated",
     "file": "cloudTrailMultiRegionNotCreated.rego",
-    "policy_type": "",
-    "resource_type": "",
+    "policy_type": "aws",
+    "resource_type": "aws_cloudtrail",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.Config.Logging.Medium.0590.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.Config.Logging.Medium.0590.json
@@ -1,8 +1,8 @@
 {
     "name": "configEnabledForAllRegions",
     "file": "configEnabled.rego",
-    "policy_type": "",
-    "resource_type": "",
+    "policy_type": "aws",
+    "resource_type": "aws_cloudtrail",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.Config.Logging.Medium.0590.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/AWS.Config.Logging.Medium.0590.json
@@ -1,6 +1,8 @@
 {
     "name": "configEnabledForAllRegions",
     "file": "configEnabled.rego",
+    "policy_type": "",
+    "resource_type": "",
     "template_args": {
         "prefix": ""
     },

--- a/pkg/policies/opa/rego/aws/aws_cloudwatch/AWS.CloudWatch.Logging.Medium.0631.json
+++ b/pkg/policies/opa/rego/aws/aws_cloudwatch/AWS.CloudWatch.Logging.Medium.0631.json
@@ -8,5 +8,6 @@
     "description": "App-Tier CloudWatch Log Group Retention Period",
     "reference_id": "AWS.CloudWatch.Logging.Medium.0631",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0041"
 }

--- a/pkg/policies/opa/rego/aws/aws_config/AWS.Config.Encryption&KeyManagement.Medium.0660.json
+++ b/pkg/policies/opa/rego/aws/aws_config/AWS.Config.Encryption&KeyManagement.Medium.0660.json
@@ -8,5 +8,6 @@
     "description": "Ensure AWS Config Rule is enabled for Encrypted Volumes",
     "reference_id": "AWS.Config.Encryption\u0026KeyManagement.Medium.0660",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0048"
 }

--- a/pkg/policies/opa/rego/aws/aws_config_configuration_aggregator/AWS.Config.Logging.HIGH.0590.json
+++ b/pkg/policies/opa/rego/aws/aws_config_configuration_aggregator/AWS.Config.Logging.HIGH.0590.json
@@ -10,5 +10,6 @@
     "description": "Ensure AWS Config is enabled in all regions",
     "reference_id": "AWS.Config.Logging.HIGH.0590",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0049"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DS.High.1041.json
+++ b/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DS.High.1041.json
@@ -10,5 +10,6 @@
     "description": "RDS Instance Auto Minor Version Upgrade flag disabled",
     "reference_id": "AWS.RDS.DS.High.1041",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0056"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DS.High.1042.json
+++ b/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DS.High.1042.json
@@ -10,5 +10,6 @@
     "description": "Ensure Certificate used in RDS instance is updated",
     "reference_id": "AWS.RDS.DS.High.1042",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0057"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DataSecurity.High.0414.json
+++ b/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DataSecurity.High.0414.json
@@ -8,5 +8,6 @@
     "description": "Ensure that your RDS database instances encrypt the underlying storage. Encrypted RDS instances use the industry standard AES-256 encryption algorithm to encrypt data on the server that hosts RDS DB instances. After data is encrypted, RDS handles authentication of access and descryption of data transparently with minimal impact on performance.",
     "reference_id": "AWS.RDS.DataSecurity.High.0414",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0058"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DataSecurity.High.0577.json
+++ b/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.DataSecurity.High.0577.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "HIGH",
+    "severity": "MEDIUM",
     "description": "Ensure that your RDS database has IAM Authentication enabled.",
     "reference_id": "AWS.RDS.DataSecurity.High.0577",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0053"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.NS.High.0101.json
+++ b/pkg/policies/opa/rego/aws/aws_db_instance/AWS.RDS.NS.High.0101.json
@@ -10,5 +10,6 @@
     "description": "RDS Instance publicly_accessible flag is true",
     "reference_id": "AWS.RDS.NS.High.0101",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0054"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_security_group/AWS.RDS.NetworkSecurity.High.0101.json
+++ b/pkg/policies/opa/rego/aws/aws_db_security_group/AWS.RDS.NetworkSecurity.High.0101.json
@@ -10,5 +10,6 @@
     "description": "RDS should not be defined with public interface. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment.",
     "reference_id": "AWS.RDS.NetworkSecurity.High.0101",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0066"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_security_group/AWS.RDS.NetworkSecurity.High.0102.json
+++ b/pkg/policies/opa/rego/aws/aws_db_security_group/AWS.RDS.NetworkSecurity.High.0102.json
@@ -10,5 +10,6 @@
     "description": "RDS should not be open to a public scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment.",
     "reference_id": "AWS.RDS.NetworkSecurity.High.0102",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0067"
 }

--- a/pkg/policies/opa/rego/aws/aws_db_security_group/AWS.RDS.NetworkSecurity.High.0103.json
+++ b/pkg/policies/opa/rego/aws/aws_db_security_group/AWS.RDS.NetworkSecurity.High.0103.json
@@ -10,5 +10,6 @@
     "description": "RDS should not be open to a large scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment.",
     "reference_id": "AWS.RDS.NetworkSecurity.High.0103",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0065"
 }

--- a/pkg/policies/opa/rego/aws/aws_ebs_encryption_by_default/AWS.EBS.DataSecurity.High.0580.json
+++ b/pkg/policies/opa/rego/aws/aws_ebs_encryption_by_default/AWS.EBS.DataSecurity.High.0580.json
@@ -10,5 +10,6 @@
     "description": "Ensure that the AWS EBS that hold sensitive and critical data is encrypted by default to fulfill compliance requirements for data-at-rest encryption.",
     "reference_id": "AWS.EBS.DataSecurity.High.0580",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0079"
 }

--- a/pkg/policies/opa/rego/aws/aws_ecr_repository/AWS.ECR.DataSecurity.High.0578.json
+++ b/pkg/policies/opa/rego/aws/aws_ecr_repository/AWS.ECR.DataSecurity.High.0578.json
@@ -10,5 +10,6 @@
     "description": "Unscanned images may contain vulnerabilities",
     "reference_id": "AWS.ECR.DataSecurity.High.0578",
     "category": "Configuration and Vulnerability Analysis",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0083"
 }

--- a/pkg/policies/opa/rego/aws/aws_ecr_repository_policy/AWS.ECR.DataSecurity.High.0579.json
+++ b/pkg/policies/opa/rego/aws/aws_ecr_repository_policy/AWS.ECR.DataSecurity.High.0579.json
@@ -10,5 +10,6 @@
     "description": "Identify any exposed Amazon ECR image repositories available within your AWS account and update their permissions in order to protect against unauthorized access. Amazon Elastic Container Registry (ECR) is a managed Docker registry service that makes it easy for DevOps teams to store, manage and deploy Docker container images. An ECR repository is a collection of Docker images available on AWS cloud.",
     "reference_id": "AWS.ECR.DataSecurity.High.0579",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0084"
 }

--- a/pkg/policies/opa/rego/aws/aws_ecs_service/AWS.ECS.High.0436.json
+++ b/pkg/policies/opa/rego/aws/aws_ecs_service/AWS.ECS.High.0436.json
@@ -8,5 +8,6 @@
     "description": "Ensure there are no ECS services Admin roles",
     "reference_id": "AWS.ECS.High.0436",
     "category": "Identity and Access Management",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0087"
 }

--- a/pkg/policies/opa/rego/aws/aws_ecs_task_definition/AWS.EcsCluster.NetworkSecurity.High.0104.json
+++ b/pkg/policies/opa/rego/aws/aws_ecs_task_definition/AWS.EcsCluster.NetworkSecurity.High.0104.json
@@ -10,5 +10,6 @@
     "description": "Like any other EC2 instance it is recommended to place ECS instance within a VPC. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations",
     "reference_id": "AWS.EcsCluster.NetworkSecurity.High.0104",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0088"
 }

--- a/pkg/policies/opa/rego/aws/aws_ecs_task_definition/AWS.LaunchConfiguration.DataSecurity.High.0101.json
+++ b/pkg/policies/opa/rego/aws/aws_ecs_task_definition/AWS.LaunchConfiguration.DataSecurity.High.0101.json
@@ -12,5 +12,6 @@
     "description": "Sensitive Information Disclosure",
     "reference_id": "AWS.LaunchConfiguration.DataSecurity.High.0101",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0095"
 }

--- a/pkg/policies/opa/rego/aws/aws_efs_file_system/AWS.EFS.EncryptionandKeyManagement.High.0409.json
+++ b/pkg/policies/opa/rego/aws/aws_efs_file_system/AWS.EFS.EncryptionandKeyManagement.High.0409.json
@@ -11,5 +11,6 @@
     "description": "Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization.",
     "reference_id": "AWS.EFS.EncryptionandKeyManagement.High.0409",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0097"
 }

--- a/pkg/policies/opa/rego/aws/aws_efs_file_system/AWS.EFS.EncryptionandKeyManagement.High.0410.json
+++ b/pkg/policies/opa/rego/aws/aws_efs_file_system/AWS.EFS.EncryptionandKeyManagement.High.0410.json
@@ -11,5 +11,6 @@
     "description": "Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization.",
     "reference_id": "AWS.EFS.EncryptionandKeyManagement.High.0410",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0098"
 }

--- a/pkg/policies/opa/rego/aws/aws_elasticache_cluster/AWS.ElastiCache.DataSecurity.High.0424.json
+++ b/pkg/policies/opa/rego/aws/aws_elasticache_cluster/AWS.ElastiCache.DataSecurity.High.0424.json
@@ -12,5 +12,6 @@
     "description": "ElastiCache for Memcached is not in use in AWS PCI DSS environments",
     "reference_id": "AWS.ElastiCache.DataSecurity.High.0424",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0103"
 }

--- a/pkg/policies/opa/rego/aws/aws_elasticache_cluster/AWS.ElastiCache.DataSecurity.High.0425.json
+++ b/pkg/policies/opa/rego/aws/aws_elasticache_cluster/AWS.ElastiCache.DataSecurity.High.0425.json
@@ -17,5 +17,6 @@
     "description": "ElastiCache for Redis version is not compliant with AWS PCI DSS requirements",
     "reference_id": "AWS.ElastiCache.DataSecurity.High.0425",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0102"
 }

--- a/pkg/policies/opa/rego/aws/aws_elasticache_cluster/AWS.ElastiCache.HighAvailability.Medium.0757.json
+++ b/pkg/policies/opa/rego/aws/aws_elasticache_cluster/AWS.ElastiCache.HighAvailability.Medium.0757.json
@@ -8,5 +8,6 @@
     "description": "AWS ElastiCache Multi-AZ",
     "reference_id": "AWS.ElastiCache.HighAvailability.Medium.0757",
     "category": "Resilience",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0104"
 }

--- a/pkg/policies/opa/rego/aws/aws_elasticsearch_domain/AWS.ElasticSearch.EKM.Medium.0768.json
+++ b/pkg/policies/opa/rego/aws/aws_elasticsearch_domain/AWS.ElasticSearch.EKM.Medium.0768.json
@@ -8,5 +8,6 @@
     "description": "ElasticSearch Domain Encrypted with KMS CMKs",
     "reference_id": "AWS.ElasticSearch.EKM.Medium.0768",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0111"
 }

--- a/pkg/policies/opa/rego/aws/aws_elasticsearch_domain/AWS.ElasticSearch.EKM.Medium.0778.json
+++ b/pkg/policies/opa/rego/aws/aws_elasticsearch_domain/AWS.ElasticSearch.EKM.Medium.0778.json
@@ -4,9 +4,10 @@
     "policy_type": "aws",
     "resource_type": "aws_elasticsearch_domain",
     "template_args": null,
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "description": "Enable AWS ElasticSearch Encryption At Rest",
     "reference_id": "AWS.ElasticSearch.EKM.Medium.0778",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0112"
 }

--- a/pkg/policies/opa/rego/aws/aws_elasticsearch_domain/AWS.Elasticsearch.Logging.Medium.0573.json
+++ b/pkg/policies/opa/rego/aws/aws_elasticsearch_domain/AWS.Elasticsearch.Logging.Medium.0573.json
@@ -10,5 +10,6 @@
     "description": "Ensure that your AWS Elasticsearch clusters have enabled the support for publishing slow logs to AWS CloudWatch Logs. This feature enables you to publish slow logs from the indexing and search operations performed on your ES clusters and gain full insight into the performance of these operations.",
     "reference_id": "AWS.Elasticsearch.Logging.Medium.0573",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0105"
 }

--- a/pkg/policies/opa/rego/aws/aws_elb/AWS.ELB.NetworkPortsSecurity.Low.0563.json
+++ b/pkg/policies/opa/rego/aws/aws_elb/AWS.ELB.NetworkPortsSecurity.Low.0563.json
@@ -10,5 +10,6 @@
     "description": "AWS ELB incoming traffic not encrypted",
     "reference_id": "AWS.ELB.NetworkPortsSecurity.Low.0563",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0120"
 }

--- a/pkg/policies/opa/rego/aws/aws_guardduty_detector/AWS.GuardDuty Enabled.Security.Medium.0575.json
+++ b/pkg/policies/opa/rego/aws/aws_guardduty_detector/AWS.GuardDuty Enabled.Security.Medium.0575.json
@@ -10,5 +10,6 @@
     "description": "Ensure that Amazon GuardDuty service is currently enabled in all regions in order to protect your AWS environment and infrastructure (AWS accounts and resources, IAM credentials, guest operating systems, applications, etc) against security threats. AWS GuardDuty is a managed threat detection service that continuously monitors your VPC flow logs, AWS CloudTrail event logs and DNS logs for malicious or unauthorized behavior. The service monitors for activity such as unusual API calls, potentially compromised EC2 instances or potentially unauthorized deployments that indicate a possible AWS account compromise. AWS GuardDuty operates entirely on Amazon Web Services infrastructure and does not affect the performance or reliability of your applications. The service does not require any software agents, sensors or network appliances.",
     "reference_id": "AWS.GuardDuty Enabled.Security.Medium.0575",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0131"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_access_key/AWS.IamUser.IAM.High.0390.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_access_key/AWS.IamUser.IAM.High.0390.json
@@ -10,5 +10,6 @@
     "description": "The root account is the most privileged user in an AWS account. AWS Access Keys provide programmatic access to a given AWS account. It is recommended that all access keys associated with the root account be removed. Removing access keys associated with the root account limits vectors by which the account can be compromised. Additionally, removing the root access keys encourages the creation and use of role based accounts that are least privileged.",
     "reference_id": "AWS.IamUser.IAM.High.0390",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0132"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_access_key/AWS.IamUser.IAM.High.0391.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_access_key/AWS.IamUser.IAM.High.0391.json
@@ -10,5 +10,6 @@
     "description": "Ensure that there are no exposed Amazon IAM access keys in order to protect your AWS resources against unapproved access",
     "reference_id": "AWS.IamUser.IAM.High.0391",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0133"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Low.0540.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Low.0540.json
@@ -11,5 +11,6 @@
     "description": "Reducing the password lifetime increases account resiliency against brute force login attempts",
     "reference_id": "AWS.Iam.IAM.Low.0540",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0138"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0454.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0454.json
@@ -8,9 +8,10 @@
         "prefix": "",
         "required_parameter": "require_lowercase_characters"
     },
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "description": "Lower case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack",
     "reference_id": "AWS.Iam.IAM.Medium.0454",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0134"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0455.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0455.json
@@ -12,5 +12,6 @@
     "description": "Number not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack",
     "reference_id": "AWS.Iam.IAM.Medium.0455",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0136"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0456.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0456.json
@@ -12,5 +12,6 @@
     "description": "Special symbols not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack",
     "reference_id": "AWS.Iam.IAM.Medium.0456",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0137"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0457.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0457.json
@@ -12,5 +12,6 @@
     "description": "Upper case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack",
     "reference_id": "AWS.Iam.IAM.Medium.0457",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0135"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0458.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0458.json
@@ -13,5 +13,6 @@
     "description": "Setting a lengthy password increases account resiliency against brute force login attempts",
     "reference_id": "AWS.Iam.IAM.Medium.0458",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0142"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0495.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Medium.0495.json
@@ -13,5 +13,6 @@
     "description": "Setting a lengthy password increases account resiliency against brute force login attempts",
     "reference_id": "AWS.Iam.IAM.Medium.0495",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0141"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_group_policy/AC-AW-IA-H-0392.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_group_policy/AC-AW-IA-H-0392.json
@@ -10,5 +10,6 @@
     "description": "It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges.",
     "reference_id": "AC-AW-IA-H-0392",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0143"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_policy/AC-AW-IA-H-1187.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_policy/AC-AW-IA-H-1187.json
@@ -10,5 +10,6 @@
     "description": "It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges.",
     "reference_id": "AC-AW-IA-H-1187",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0144"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_role/AC-AW-IA-H-1188.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_role/AC-AW-IA-H-1188.json
@@ -10,5 +10,6 @@
     "description": "It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges.",
     "reference_id": "AC-AW-IA-H-1188",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0146"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_role_policy/AC-AW-IA-H-1189.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_role_policy/AC-AW-IA-H-1189.json
@@ -10,5 +10,6 @@
     "description": "It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges.",
     "reference_id": "AC-AW-IA-H-1189",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0147"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_user_login_profile/AWS.Iam.IAM.High.0391.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_user_login_profile/AWS.Iam.IAM.High.0391.json
@@ -10,5 +10,6 @@
     "description": "Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are comprised of different character sets, have minimal length, rotation and history restrictions",
     "reference_id": "AWS.Iam.IAM.High.0391",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0148"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_user_policy/AWS.IamUser.IAM.High.0387.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_user_policy/AWS.IamUser.IAM.High.0387.json
@@ -10,5 +10,6 @@
     "description": "Ensure Hardware MFA device is enabled for the \"root\" account",
     "reference_id": "AWS.IamUser.IAM.High.0387",
     "category": "Compliance Validation",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0150"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_user_policy/AWS.IamUser.IAM.High.0388.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_user_policy/AWS.IamUser.IAM.High.0388.json
@@ -10,5 +10,6 @@
     "description": "Ensure Virtual MFA device is enabled for the \"root\" account",
     "reference_id": "AWS.IamUser.IAM.High.0388",
     "category": "Compliance Validation",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0149"
 }

--- a/pkg/policies/opa/rego/aws/aws_iam_user_policy/AWS.IamUser.IAM.High.0389.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_user_policy/AWS.IamUser.IAM.High.0389.json
@@ -10,5 +10,6 @@
     "description": "It is recommended that MFA be enabled for all accounts that have a console password. Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential",
     "reference_id": "AWS.IamUser.IAM.High.0389",
     "category": "Compliance Validation",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0151"
 }

--- a/pkg/policies/opa/rego/aws/aws_instance/AC-AW-IS-IN-M-0144.json
+++ b/pkg/policies/opa/rego/aws/aws_instance/AC-AW-IS-IN-M-0144.json
@@ -10,5 +10,6 @@
     "description": "Ensure that your AWS application is not deployed within the default Virtual Private Cloud in order to follow security best practices",
     "reference_id": "AC-AW-IS-IN-M-0144",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0153"
 }

--- a/pkg/policies/opa/rego/aws/aws_kinesis_firehose_delivery_stream/AWS.Kinesis.EncryptionandKeyManagement.High.0411.json
+++ b/pkg/policies/opa/rego/aws/aws_kinesis_firehose_delivery_stream/AWS.Kinesis.EncryptionandKeyManagement.High.0411.json
@@ -10,5 +10,6 @@
     "description": "AWS Kinesis Server data at rest has server side encryption (SSE)",
     "reference_id": "AWS.Kinesis.EncryptionandKeyManagement.High.0411",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0156"
 }

--- a/pkg/policies/opa/rego/aws/aws_kinesis_stream/AWS.Kinesis.EncryptionandKeyManagement.High.0412.json
+++ b/pkg/policies/opa/rego/aws/aws_kinesis_stream/AWS.Kinesis.EncryptionandKeyManagement.High.0412.json
@@ -10,5 +10,6 @@
     "description": "Ensure Kinesis Stream is encrypted",
     "reference_id": "AWS.Kinesis.EncryptionandKeyManagement.High.0412",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0157"
 }

--- a/pkg/policies/opa/rego/aws/aws_kms_key/AC_AWS_012.json
+++ b/pkg/policies/opa/rego/aws/aws_kms_key/AC_AWS_012.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "description": "Ensure rotation for customer created CMKs is enabled",
     "reference_id": "AC_AWS_012",
-    "category": "Security Best Practices",
-    "version": 2
+    "category": "Data Protection",
+    "version": 2,
+    "id": "AC_AWS_0160"
 }

--- a/pkg/policies/opa/rego/aws/aws_kms_key/AWS.KMS.Logging.High.0400.json
+++ b/pkg/policies/opa/rego/aws/aws_kms_key/AWS.KMS.Logging.High.0400.json
@@ -10,5 +10,6 @@
     "description": "Ensure rotation for customer created CMKs is enabled",
     "reference_id": "AWS.KMS.Logging.High.0400",
     "category": "Security Best Practices",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0161"
 }

--- a/pkg/policies/opa/rego/aws/aws_kms_key/AWS.KMS.NetworkSecurity.High.0566.json
+++ b/pkg/policies/opa/rego/aws/aws_kms_key/AWS.KMS.NetworkSecurity.High.0566.json
@@ -10,5 +10,6 @@
     "description": "Identify any publicly accessible AWS Key Management Service master keys and update their access policy in order to stop any unsigned requests made to these resources.",
     "reference_id": "AWS.KMS.NetworkSecurity.High.0566",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0162"
 }

--- a/pkg/policies/opa/rego/aws/aws_lambda_function/AWS.LambdaFunction.Logging.0470.json
+++ b/pkg/policies/opa/rego/aws/aws_lambda_function/AWS.LambdaFunction.Logging.0470.json
@@ -1,0 +1,15 @@
+{
+    "name": "lambdaXRayTracingDisabled",
+    "file": "lambdaXRayTracingDisabled.rego",
+    "policy_type": "aws",
+    "resource_type": "aws_lambda_function",
+    "template_args": {
+        "prefix": ""
+    },
+    "severity": "LOW",
+    "description": "Lambda tracing is not enabled.",
+    "reference_id": "AWS.LambdaFunction.Logging.0470",
+    "category": "Logging and Monitoring",
+    "version": 2,
+    "id": "AC_AWS_0163"
+}

--- a/pkg/policies/opa/rego/aws/aws_launch_configuration/AWS.EcsCluster.EncryptionandKeyManagement.High.0413.json
+++ b/pkg/policies/opa/rego/aws/aws_launch_configuration/AWS.EcsCluster.EncryptionandKeyManagement.High.0413.json
@@ -10,5 +10,6 @@
     "description": "Ensure that AWS ECS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS ECS clusters and associated cache storage systems.",
     "reference_id": "AWS.EcsCluster.EncryptionandKeyManagement.High.0413",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0167"
 }

--- a/pkg/policies/opa/rego/aws/aws_launch_configuration/AWS.LaunchConfiguration.DataSecurity.High.0101.json
+++ b/pkg/policies/opa/rego/aws/aws_launch_configuration/AWS.LaunchConfiguration.DataSecurity.High.0101.json
@@ -10,5 +10,6 @@
     "description": "Avoid using base64 encoded shell script as part of config",
     "reference_id": "AWS.LaunchConfiguration.DataSecurity.High.0101",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0170"
 }

--- a/pkg/policies/opa/rego/aws/aws_launch_configuration/AWS.LaunchConfiguration.DataSecurity.High.0102.json
+++ b/pkg/policies/opa/rego/aws/aws_launch_configuration/AWS.LaunchConfiguration.DataSecurity.High.0102.json
@@ -10,5 +10,6 @@
     "description": "Avoid using base64 encoded private keys as part of config",
     "reference_id": "AWS.LaunchConfiguration.DataSecurity.High.0102",
     "category": "Data Protection",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0168"
 }

--- a/pkg/policies/opa/rego/aws/aws_load_balancer_policy/AWS.ELB.EncryptionandKeyManagement.High.0401.json
+++ b/pkg/policies/opa/rego/aws/aws_load_balancer_policy/AWS.ELB.EncryptionandKeyManagement.High.0401.json
@@ -14,5 +14,6 @@
     "description": "Using insecure ciphers for your ELB Predefined or Custom Security Policy, could make the SSL connection between the client and the load balancer vulnerable to exploits. TLS 1.0 was recommended to be disabled by PCI Council after June 30, 2016",
     "reference_id": "AWS.ELB.EncryptionandKeyManagement.High.0401",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0172"
 }

--- a/pkg/policies/opa/rego/aws/aws_load_balancer_policy/AWS.ELB.EncryptionandKeyManagement.High.0403.json
+++ b/pkg/policies/opa/rego/aws/aws_load_balancer_policy/AWS.ELB.EncryptionandKeyManagement.High.0403.json
@@ -81,5 +81,6 @@
     "description": "Remove insecure ciphers for your ELB Predefined or Custom Security Policy, to reduce the risk of the SSL connection between the client and the load balancer being exploited.",
     "reference_id": "AWS.ELB.EncryptionandKeyManagement.High.0403",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0171"
 }

--- a/pkg/policies/opa/rego/aws/aws_mq_broker/AWS.ElasticSearch.Logging.Medium.0885.json
+++ b/pkg/policies/opa/rego/aws/aws_mq_broker/AWS.ElasticSearch.Logging.Medium.0885.json
@@ -4,9 +4,10 @@
     "policy_type": "aws",
     "resource_type": "aws_mq_broker",
     "template_args": null,
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "description": "Enable AWS MQ Log Exports",
     "reference_id": "AWS.ElasticSearch.Logging.Medium.0885",
     "category": "Logging and Monitoring",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0174"
 }

--- a/pkg/policies/opa/rego/aws/aws_mq_broker/AWS.ElasticSearch.NetworkSecurity.Medium.0887.json
+++ b/pkg/policies/opa/rego/aws/aws_mq_broker/AWS.ElasticSearch.NetworkSecurity.Medium.0887.json
@@ -8,5 +8,6 @@
     "description": "Publicly Accessible MQ Brokers",
     "reference_id": "AWS.ElasticSearch.NetworkSecurity.Medium.0887",
     "category": "Security Best Practices",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0175"
 }

--- a/pkg/policies/opa/rego/aws/aws_rds_cluster/AWS.RDS.EncryptionandKeyManagement.High.0414.json
+++ b/pkg/policies/opa/rego/aws/aws_rds_cluster/AWS.RDS.EncryptionandKeyManagement.High.0414.json
@@ -10,5 +10,6 @@
     "description": "Encrypt Amazon RDS instances and snapshots at rest, by enabling the encryption option for your Amazon RDS DB instance",
     "reference_id": "AWS.RDS.EncryptionandKeyManagement.High.0414",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0186"
 }

--- a/pkg/policies/opa/rego/aws/aws_redshift_cluster/AWS.Redshift.EncryptionandKeyManagement.High.0415.json
+++ b/pkg/policies/opa/rego/aws/aws_redshift_cluster/AWS.Redshift.EncryptionandKeyManagement.High.0415.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "HIGH",
+    "severity": "MEDIUM",
     "description": "Use customer-managed KMS keys instead of AWS-managed keys, to have granular control over encrypting and encrypting data. Encrypt Redshift clusters with a Customer-managed KMS key. This is a recommended best practice.",
     "reference_id": "AWS.Redshift.EncryptionandKeyManagement.High.0415",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0198"
 }

--- a/pkg/policies/opa/rego/aws/aws_redshift_cluster/AWS.Redshift.Logging.Medium.0565.json
+++ b/pkg/policies/opa/rego/aws/aws_redshift_cluster/AWS.Redshift.Logging.Medium.0565.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "description": "Ensure AWS Redshift cluster instances have logging enabled.",
     "reference_id": "AWS.Redshift.Logging.Medium.0565",
     "category": "Logging and Monitoring",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0200"
 }

--- a/pkg/policies/opa/rego/aws/aws_redshift_cluster/AWS.Redshift.NetworkSecurity.HIGH.0564.json
+++ b/pkg/policies/opa/rego/aws/aws_redshift_cluster/AWS.Redshift.NetworkSecurity.HIGH.0564.json
@@ -10,5 +10,6 @@
     "description": "Ensure Redshift clusters are not publicly accessible to minimize security risks.",
     "reference_id": "AWS.Redshift.NetworkSecurity.HIGH.0564",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0199"
 }

--- a/pkg/policies/opa/rego/aws/aws_route53_query_log/AWS.Route53 query logs.Logging.Medium.0574.json
+++ b/pkg/policies/opa/rego/aws/aws_route53_query_log/AWS.Route53 query logs.Logging.Medium.0574.json
@@ -10,5 +10,6 @@
     "description": "Ensure CloudWatch logging is enabled for Route53 hosted zones.",
     "reference_id": "AWS.Route53 query logs.Logging.Medium.0574",
     "category": "Logging and Monitoring",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0204"
 }

--- a/pkg/policies/opa/rego/aws/aws_route53_record/AWS.Route53HostedZone.DNSManagement.High.0422.json
+++ b/pkg/policies/opa/rego/aws/aws_route53_record/AWS.Route53HostedZone.DNSManagement.High.0422.json
@@ -10,5 +10,6 @@
     "description": "Route53HostedZone should have recordSets.",
     "reference_id": "AWS.Route53HostedZone.DNSManagement.High.0422",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0205"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.DS.High.1043.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.DS.High.1043.json
@@ -10,5 +10,6 @@
     "description": "S3 bucket Access is allowed to all AWS Account Users.",
     "reference_id": "AWS.S3Bucket.DS.High.1043",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0215"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.EncryptionandKeyManagement.High.0405.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.EncryptionandKeyManagement.High.0405.json
@@ -10,5 +10,6 @@
     "description": "Ensure that S3 Buckets have server side encryption at rest enabled with KMS key to protect sensitive data.",
     "reference_id": "AWS.S3Bucket.EncryptionandKeyManagement.High.0405",
     "category": "Data Protection",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0207"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0370.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0370.json
@@ -10,5 +10,6 @@
     "description": "Enabling S3 versioning will enable easy recovery from both unintended user actions, like deletes and overwrites",
     "reference_id": "AWS.S3Bucket.IAM.High.0370",
     "category": "Resilience",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0214"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0377.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0377.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.S3Bucket.IAM.High.0377",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0210"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0378.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0378.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.S3Bucket.IAM.High.0378",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0211"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0379.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0379.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.S3Bucket.IAM.High.0379",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0212"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0381.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.IAM.High.0381.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.S3Bucket.IAM.High.0381",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0213"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.NetworkSecurity.High.0417.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/AWS.S3Bucket.NetworkSecurity.High.0417.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "HIGH",
+    "severity": "LOW",
     "description": "Ensure that there are not any static websites being hosted on buckets you aren't aware of",
     "reference_id": "AWS.S3Bucket.NetworkSecurity.High.0417",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0208"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0373.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0373.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.IamPolicy.IAM.High.0373",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0219"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0374.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0374.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.IamPolicy.IAM.High.0374",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0220"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0375.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0375.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.IamPolicy.IAM.High.0375",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0221"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0376.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.IamPolicy.IAM.High.0376.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.IamPolicy.IAM.High.0376",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0224"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.S3Bucket.IAM.High.0371.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.S3Bucket.IAM.High.0371.json
@@ -10,5 +10,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.S3Bucket.IAM.High.0371",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0217"
 }

--- a/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.S3Bucket.IAM.High.0372.json
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket_policy/AWS.S3Bucket.IAM.High.0372.json
@@ -12,5 +12,6 @@
     "description": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion",
     "reference_id": "AWS.S3Bucket.IAM.High.0372",
     "category": "Identity and Access Management",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0218"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0194.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0194.json
@@ -9,9 +9,10 @@
         "prefix": "",
         "protocol": "tcp"
     },
-    "severity": "HIGH",
+    "severity": "LOW",
     "description": "'SSH' (TCP:22) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0194",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0319"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0196.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0196.json
@@ -14,5 +14,6 @@
     "description": "'SaltStack Master' (TCP:4505) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0196",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0277"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0218.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0218.json
@@ -13,5 +13,6 @@
     "description": "'CIFS / SMB' (TCP:3020) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0218",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0279"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0220.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0220.json
@@ -13,5 +13,6 @@
     "description": "'Cassandra OpsCenter agent port' (TCP:61621) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0220",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0280"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0222.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0222.json
@@ -13,5 +13,6 @@
     "description": "'Cassandra' (TCP:7001) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0222",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0281"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0224.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0224.json
@@ -13,5 +13,6 @@
     "description": "'Hadoop Name Node' (TCP:9000) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0224",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0282"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0226.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0226.json
@@ -13,5 +13,6 @@
     "description": "'Known internal web port' (TCP:8000) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0226",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0283"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0228.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0228.json
@@ -13,5 +13,6 @@
     "description": "'Known internal web port' (TCP:8080) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0228",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0284"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0230.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0230.json
@@ -13,5 +13,6 @@
     "description": "'LDAP SSL ' (TCP:636) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0230",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0285"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0232.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0232.json
@@ -13,5 +13,6 @@
     "description": "'MSSQL Admin' (TCP:1434) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0232",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0286"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0234.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0234.json
@@ -13,5 +13,6 @@
     "description": "'MSSQL Browser Service' (UDP:1434) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0234",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0287"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0236.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0236.json
@@ -13,5 +13,6 @@
     "description": "'MSSQL Debugger' (TCP:135) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0236",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0288"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0238.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0238.json
@@ -13,5 +13,6 @@
     "description": "'MSSQL Server' (TCP:1433) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0238",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0289"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0240.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0240.json
@@ -13,5 +13,6 @@
     "description": "'Memcached SSL' (TCP:11214) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0240",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0290"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0242.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0242.json
@@ -13,5 +13,6 @@
     "description": "'Memcached SSL' (TCP:11215) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0242",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0291"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0244.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0244.json
@@ -13,5 +13,6 @@
     "description": "'Memcached SSL' (UDP:11214) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0244",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0292"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0246.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0246.json
@@ -13,5 +13,6 @@
     "description": "'Memcached SSL' (UDP:11215) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0246",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0293"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0248.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0248.json
@@ -13,5 +13,6 @@
     "description": "'Mongo Web Portal' (TCP:27018) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0248",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0294"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0250.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0250.json
@@ -13,5 +13,6 @@
     "description": "'MySQL' (TCP:3306) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0250",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0295"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0252.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0252.json
@@ -13,5 +13,6 @@
     "description": "'NetBIOS Name Service' (TCP:137) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0252",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0296"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0254.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0254.json
@@ -13,5 +13,6 @@
     "description": "'NetBIOS Name Service' (UDP:137) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0254",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0297"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0256.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0256.json
@@ -13,5 +13,6 @@
     "description": "'NetBIOS Datagram Service' (TCP:138) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0256",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0298"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0258.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0258.json
@@ -13,5 +13,6 @@
     "description": "'NetBIOS Datagram Service' (UDP:138) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0258",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0299"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0260.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0260.json
@@ -13,5 +13,6 @@
     "description": "'NetBIOS Session Service' (TCP:139) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0260",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0300"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0262.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0262.json
@@ -13,5 +13,6 @@
     "description": "'NetBIOS Session Service' (UDP:139) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0262",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0301"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0264.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0264.json
@@ -13,5 +13,6 @@
     "description": "'Oracle DB SSL' (TCP:2484) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0264",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0302"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0266.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0266.json
@@ -13,5 +13,6 @@
     "description": "'Oracle DB SSL' (UDP:2484) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0266",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0303"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0268.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0268.json
@@ -13,5 +13,6 @@
     "description": "'Postgres SQL' (TCP:5432) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0268",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0304"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0270.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0270.json
@@ -13,5 +13,6 @@
     "description": "'Postgres SQL' (UDP:5432) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0270",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0305"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0272.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0272.json
@@ -13,5 +13,6 @@
     "description": "'Prevalent known internal port' (TCP:3000) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0272",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0306"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0274.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0274.json
@@ -13,5 +13,6 @@
     "description": "'Puppet Master' (TCP:8140) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0274",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0307"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0276.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0276.json
@@ -13,5 +13,6 @@
     "description": "'SNMP' (UDP:161) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0276",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0308"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0278.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0278.json
@@ -13,5 +13,6 @@
     "description": "'SQL Server Analysis Service browser' (TCP:2382) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0278",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0309"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0280.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.ALB.NetworkPortsSecurity.High.0280.json
@@ -13,5 +13,6 @@
     "description": "'SQL Server Analysis Services' (TCP:2383) is accessible by a CIDR block range",
     "reference_id": "AWS.ALB.NetworkPortsSecurity.High.0280",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0310"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NPS.High.1045.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NPS.High.1045.json
@@ -10,5 +10,6 @@
     "description": "It is recommended that no security group allows unrestricted ingress access",
     "reference_id": "AWS.SecurityGroup.NPS.High.1045",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0275"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NPS.High.1046.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NPS.High.1046.json
@@ -49,5 +49,6 @@
     "description": "Unknown Port is exposed to the entire internet",
     "reference_id": "AWS.SecurityGroup.NPS.High.1046",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0276"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkPortsSecurity.Low.0560.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkPortsSecurity.Low.0560.json
@@ -13,5 +13,6 @@
     "description": "ssh port open to internet",
     "reference_id": "AWS.SecurityGroup.NetworkPortsSecurity.Low.0560",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0227"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkPortsSecurity.Low.0561.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkPortsSecurity.Low.0561.json
@@ -13,5 +13,6 @@
     "description": "http port open to internet",
     "reference_id": "AWS.SecurityGroup.NetworkPortsSecurity.Low.0561",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0228"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkPortsSecurity.Low.0562.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkPortsSecurity.Low.0562.json
@@ -13,5 +13,6 @@
     "description": "remote desktop port open to internet",
     "reference_id": "AWS.SecurityGroup.NetworkPortsSecurity.Low.0562",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0230"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkSecurity.High.0094.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkSecurity.High.0094.json
@@ -10,5 +10,6 @@
     "description": " It is recommended that no security group allows unrestricted ingress access",
     "reference_id": "AWS.SecurityGroup.NetworkSecurity.High.0094",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0231"
 }

--- a/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkSecurity.High.0097.json
+++ b/pkg/policies/opa/rego/aws/aws_security_group/AWS.SecurityGroup.NetworkSecurity.High.0097.json
@@ -10,5 +10,6 @@
     "description": "A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic. Configuring the default security group to restrict all traffic will encourage least privilege security group development and mindful placement of AWS resource into security groups which will in-turn reduce the exposure of those resources.",
     "reference_id": "AWS.SecurityGroup.NetworkSecurity.High.0097",
     "category": "Infrastructure Security",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0232"
 }

--- a/pkg/policies/opa/rego/aws/aws_sns_topic/AWS.SNS.NS.Medium.1044.json
+++ b/pkg/policies/opa/rego/aws/aws_sns_topic/AWS.SNS.NS.Medium.1044.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "description": "Ensure SNS Topic is Publicly Accessible For Subscription",
     "reference_id": "AWS.SNS.NS.Medium.1044",
     "category": "Compliance Validation",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0385"
 }

--- a/pkg/policies/opa/rego/aws/aws_sqs_queue/AWS.SQS.NetworkSecurity.High.0569.json
+++ b/pkg/policies/opa/rego/aws/aws_sqs_queue/AWS.SQS.NetworkSecurity.High.0569.json
@@ -10,5 +10,6 @@
     "description": "Identify any publicly accessible SQS queues available in your AWS account and update their permissions in order to protect against unauthorized users.",
     "reference_id": "AWS.SQS.NetworkSecurity.High.0569",
     "category": "Security Best Practices",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0365"
 }

--- a/pkg/policies/opa/rego/aws/aws_sqs_queue/AWS.SQS.NetworkSecurity.High.0570.json
+++ b/pkg/policies/opa/rego/aws/aws_sqs_queue/AWS.SQS.NetworkSecurity.High.0570.json
@@ -10,5 +10,6 @@
     "description": "Ensure that your Amazon Simple Queue Service (SQS) queues are protecting the contents of their messages using Server-Side Encryption (SSE). The SQS service uses an AWS KMS Customer Master Key (CMK) to generate data keys required for the encryption/decryption process of SQS messages. There is no additional charge for using SQS Server-Side Encryption, however, there is a charge for using AWS KMS",
     "reference_id": "AWS.SQS.NetworkSecurity.High.0570",
     "category": "Security Best Practices",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0366"
 }

--- a/pkg/policies/opa/rego/aws/aws_vpc/AWS.VPC.Logging.Medium.0470.json
+++ b/pkg/policies/opa/rego/aws/aws_vpc/AWS.VPC.Logging.Medium.0470.json
@@ -6,9 +6,10 @@
     "template_args": {
         "prefix": ""
     },
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "description": "Ensure VPC flow logging is enabled in all VPCs",
     "reference_id": "AWS.VPC.Logging.Medium.0470",
     "category": "Logging and Monitoring",
-    "version": 2
+    "version": 2,
+    "id": "AC_AWS_0369"
 }

--- a/pkg/policies/opa/rego/aws/aws_vpc/AWS.VPC.Logging.Medium.0471.json
+++ b/pkg/policies/opa/rego/aws/aws_vpc/AWS.VPC.Logging.Medium.0471.json
@@ -10,5 +10,6 @@
     "description": "Avoid creating resources in default VPC",
     "reference_id": "AWS.VPC.Logging.Medium.0471",
     "category": "Security Best Practices",
-    "version": 1
+    "version": 1,
+    "id": "AC_AWS_0370"
 }


### PR DESCRIPTION
Changes for terrascan policies where names match with SIAC policies

These changes are relevant only for AWS policies

1. Add `id` field with new format
2. Update severity
3. Update category

PR created for issue #805 