### PR TITLE
reference ids with & and <space> fixed

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_ami/AWS.EC2.Encryption&KeyManagement.Medium.0688.json
+++ b/pkg/policies/opa/rego/aws/aws_ami/AWS.EC2.Encryption&KeyManagement.Medium.0688.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "MEDIUM",
     "description": "Enable AWS AMI Encryption",
-    "reference_id": "AWS.EC2.Encryption\u0026KeyManagement.Medium.0688",
+    "reference_id": "AWS.EC2.EncryptionandKeyManagement.Medium.0688",
     "category": "Infrastructure Security",
     "version": 1,
     "id": "AC_AWS_0005"

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_method_settings/AWS.API Gateway.Logging.Medium.0569.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_method_settings/AWS.API Gateway.Logging.Medium.0569.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "MEDIUM",
     "description": "Enable Detailed CloudWatch Metrics for APIs",
-    "reference_id": "AWS.API Gateway.Logging.Medium.0569",
+    "reference_id": "AWS.APIGateway.Logging.Medium.0569",
     "category": "Logging and Monitoring",
     "version": 2,
     "id": "AC_AWS_0007"

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_rest_api/AWS.APIGateway.Network Security.Medium.0570.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_rest_api/AWS.APIGateway.Network Security.Medium.0570.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "MEDIUM",
     "description": "API Gateway Private Endpoints",
-    "reference_id": "AWS.APIGateway.Network Security.Medium.0570",
+    "reference_id": "AWS.APIGateway.NetworkSecurity.Medium.0570",
     "category": "Infrastructure Security",
     "version": 1,
     "id": "AC_AWS_0011"

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0567.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0567.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "MEDIUM",
     "description": "Enable AWS CloudWatch Logs for APIs",
-    "reference_id": "AWS.API Gateway.Logging.Medium.0567",
+    "reference_id": "AWS.APIGateway.Logging.Medium.0567",
     "category": "Logging and Monitoring",
     "version": 1,
     "id": "AC_AWS_0014"

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0571.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0571.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "LOW",
     "description": "Ensure AWS API Gateway has active xray tracing enabled",
-    "reference_id": "AWS.API Gateway.Logging.Medium.0571",
+    "reference_id": "AWS.APIGateway.Logging.Medium.0571",
     "category": "Logging and Monitoring",
     "version": 2,
     "id": "AC_AWS_0015"

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0572.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Logging.Medium.0572.json
@@ -8,7 +8,7 @@
     },
     "severity": "MEDIUM",
     "description": "Ensure that AWS CloudWatch logs are enabled for all your APIs created with Amazon API Gateway service in order to track and analyze execution behavior at the API stage level.",
-    "reference_id": "AWS.API Gateway.Logging.Medium.0572",
+    "reference_id": "AWS.APIGateway.Logging.Medium.0572",
     "category": "Logging and Monitoring",
     "version": 2,
     "id": "AC_AWS_0012"

--- a/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Network Security.Medium.0565.json
+++ b/pkg/policies/opa/rego/aws/aws_api_gateway_stage/AWS.API Gateway.Network Security.Medium.0565.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "MEDIUM",
     "description": "Enable SSL Client Certificate",
-    "reference_id": "AWS.API Gateway.Network Security.Medium.0565",
+    "reference_id": "AWS.APIGateway.NetworkSecurity.Medium.0565",
     "category": "Infrastructure Security",
     "version": 1,
     "id": "AC_AWS_0013"

--- a/pkg/policies/opa/rego/aws/aws_config/AWS.Config.Encryption&KeyManagement.Medium.0660.json
+++ b/pkg/policies/opa/rego/aws/aws_config/AWS.Config.Encryption&KeyManagement.Medium.0660.json
@@ -6,7 +6,7 @@
     "template_args": null,
     "severity": "MEDIUM",
     "description": "Ensure AWS Config Rule is enabled for Encrypted Volumes",
-    "reference_id": "AWS.Config.Encryption\u0026KeyManagement.Medium.0660",
+    "reference_id": "AWS.Config.EncryptionandKeyManagement.Medium.0660",
     "category": "Data Protection",
     "version": 1,
     "id": "AC_AWS_0048"

--- a/pkg/policies/opa/rego/aws/aws_guardduty_detector/AWS.GuardDuty Enabled.Security.Medium.0575.json
+++ b/pkg/policies/opa/rego/aws/aws_guardduty_detector/AWS.GuardDuty Enabled.Security.Medium.0575.json
@@ -8,7 +8,7 @@
     },
     "severity": "MEDIUM",
     "description": "Ensure that Amazon GuardDuty service is currently enabled in all regions in order to protect your AWS environment and infrastructure (AWS accounts and resources, IAM credentials, guest operating systems, applications, etc) against security threats. AWS GuardDuty is a managed threat detection service that continuously monitors your VPC flow logs, AWS CloudTrail event logs and DNS logs for malicious or unauthorized behavior. The service monitors for activity such as unusual API calls, potentially compromised EC2 instances or potentially unauthorized deployments that indicate a possible AWS account compromise. AWS GuardDuty operates entirely on Amazon Web Services infrastructure and does not affect the performance or reliability of your applications. The service does not require any software agents, sensors or network appliances.",
-    "reference_id": "AWS.GuardDuty Enabled.Security.Medium.0575",
+    "reference_id": "AWS.GuardDutyEnabled.Security.Medium.0575",
     "category": "Logging and Monitoring",
     "version": 2,
     "id": "AC_AWS_0131"

--- a/pkg/policies/opa/rego/aws/aws_route53_query_log/AWS.Route53 query logs.Logging.Medium.0574.json
+++ b/pkg/policies/opa/rego/aws/aws_route53_query_log/AWS.Route53 query logs.Logging.Medium.0574.json
@@ -8,7 +8,7 @@
     },
     "severity": "MEDIUM",
     "description": "Ensure CloudWatch logging is enabled for Route53 hosted zones.",
-    "reference_id": "AWS.Route53 query logs.Logging.Medium.0574",
+    "reference_id": "AWS.Route53querylogs.Logging.Medium.0574",
     "category": "Logging and Monitoring",
     "version": 1,
     "id": "AC_AWS_0204"


### PR DESCRIPTION
- some reference ids had `&` symbol and whitespace ` `, they have been taken care of 