### PR TITLE
Fix AWS dynamo Db policy for point in time recovery

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_dynamodb_table/AWS.DynamoDb.Logging.Medium.007.json
+++ b/pkg/policies/opa/rego/aws/aws_dynamodb_table/AWS.DynamoDb.Logging.Medium.007.json
@@ -2,13 +2,13 @@
     "name": "dynamoderecovery_enabled",
     "file": "dynamodb_without_recovery_enabled.rego",
     "policy_type": "aws",
-    "resource_type": "aws_cloudtrail",
+    "resource_type": "aws_dynamodb_table",
     "template_args": {
         "prefix": ""
     },
     "severity": "MEDIUM",
     "description": "Ensure Point In Time Recovery is enabled for DynamoDB Tables",
-    "reference_id": "AWS.CloudTrail.Logging.Medium.007",
+    "reference_id": "AWS.DynamoDb.Logging.Medium.007",
     "category": "Resilience",
     "version": 2
 }

--- a/pkg/policies/opa/rego/aws/aws_dynamodb_table/dynamodb_without_recovery_enabled.rego
+++ b/pkg/policies/opa/rego/aws/aws_dynamodb_table/dynamodb_without_recovery_enabled.rego
@@ -2,7 +2,7 @@ package accurics
 
 {{.prefix}}dynamoderecovery_enabled[policy.id] {
     policy := input.aws_dynamodb_table[_]
-    object.get(policy, "point_in_time_recovery", "undefined") == "undefined"
+    object.get(policy.config, "point_in_time_recovery", "undefined") == "undefined"
 }
 
 {{.prefix}}dynamoderecovery_enabled[policy.id] {


### PR DESCRIPTION
This PR includes:
1. Solves issue #838.
2. Policy is moved from aws_cloudtrail to aws_dyanmodb_table