### PR TITLE
Fix AC_AZURE_0185 policy

### DIFF
--- a/pkg/policies/opa/rego/azure/azurerm_container_registry/containerRegistryResourceLock.rego
+++ b/pkg/policies/opa/rego/azure/azurerm_container_registry/containerRegistryResourceLock.rego
@@ -26,4 +26,9 @@ resourceLockExist(registry, registry_input) = exists {
     registry_name := sprintf("azurerm_container_registry.%s", [registry.name])
 	resource_lock_exist_set[registry_name]
     exists = true
+} else = exists {
+  # hcl inspection
+    resource_lock_exist_set := { resource_lock_id | resource_lock_id := split(input.azurerm_management_lock[i].config.scope, ".")[1] }
+    resource_lock_exist_set[registry.name]
+    exists = true
 }


### PR DESCRIPTION
This PR should fix the rego policy for Azure Container Registry which ensure the presence of a Azure Management Lock on that resource (`AC_AZURE_0185`).

In particular it adds a case that should be also accepted.

This Rego expression is evaluated to `true` when the `azurerm_management_lock` resource has the correct `scope` field value.
In particular this is relevant for the validation of the HCL code.

The `scope` value can be a Terraform attribute reference expression that references the `id` attribute of the `azurerm_container_registry` resource to be locked.

So, for example:
```hcl
resource "azurerm_container_registry" "foo" {
  name = "foo"
  # ...
}

resource "azurerm_management_lock" "bar" {
  name = "bar"
  scope      = azurerm_container_registry.foo.id
  lock_level = "CanNotDelete"
}
```

Without this new Rego expression the only accepted HCL code is when the `azurerm_managament_lock` resource `name` field is equal to a string composed like this: `""<resource_to_lock_type>.<resource_to_lock_name>"`. For example:

```hcl
resource "azurerm_container_registry" "foo" {
  name = "foo"
  # [...]
}

resource "azurerm_management_lock" "bar" {
  name       = "azurerm_container_registry.foo" # Only accepted value
  scope      = azurerm_container_registry.foo.id
  lock_level = "CanNotDelete"
}
```

This shouldn't add regression as when the `scope` value has always to match the resource name of the `registry` from the Rego `input`.

Furthermore, this is pretty similar to what is declared for [Resource Group locking](https://github.com/accurics/terrascan/blob/v1.7.0/pkg/policies/opa/rego/azure/azurerm_resource_group/resourceGroupLock.rego).

What do you think?