### PR TITLE
improves: filename in remote module

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -190,6 +190,11 @@ func (s *ScanOptions) Run() error {
 		return err
 	}
 
+	// set the ResourcePath to remoteURL if remote directory is scanned.
+	if s.remoteURL != "" {
+		results.Violations.ViolationStore.Summary.ResourcePath = s.remoteURL
+	}
+
 	// write results to console
 	err = s.writeResults(results)
 	if err != nil {

--- a/pkg/downloader/interface.go
+++ b/pkg/downloader/interface.go
@@ -36,6 +36,7 @@ type ModuleDownloader interface {
 	DownloadModule(addr, destPath string) (string, error)
 	DownloadRemoteModule(requiredVersion hclConfigs.VersionConstraint, destPath string, module *regsrc.Module) (string, error)
 	CleanUp()
+	GetModuleInstalledCache() map[string]string
 }
 
 // terraformRegistryClient will help interact with terraform registries

--- a/pkg/downloader/interface.go
+++ b/pkg/downloader/interface.go
@@ -36,7 +36,7 @@ type ModuleDownloader interface {
 	DownloadModule(addr, destPath string) (string, error)
 	DownloadRemoteModule(requiredVersion hclConfigs.VersionConstraint, destPath string, module *regsrc.Module) (string, error)
 	CleanUp()
-	GetModuleInstalledCache() map[string]string
+	GetDownloaderCache() map[string]string
 }
 
 // terraformRegistryClient will help interact with terraform registries

--- a/pkg/downloader/module-download.go
+++ b/pkg/downloader/module-download.go
@@ -288,3 +288,8 @@ func getVersionToDownload(moduleVersions *response.ModuleVersions, requiredVersi
 
 	return versionToDownload, nil
 }
+
+// GetModuleInstalledCache - returns the cache of dowloaded modules mapping
+func (r *remoteModuleInstaller) GetModuleInstalledCache() map[string]string {
+	return r.cache
+}

--- a/pkg/downloader/module-download.go
+++ b/pkg/downloader/module-download.go
@@ -289,7 +289,7 @@ func getVersionToDownload(moduleVersions *response.ModuleVersions, requiredVersi
 	return versionToDownload, nil
 }
 
-// GetModuleInstalledCache - returns the cache of dowloaded modules mapping
-func (r *remoteModuleInstaller) GetModuleInstalledCache() map[string]string {
+// GetDownloaderCache - returns the cache of dowloaded modules mapping
+func (r *remoteModuleInstaller) GetDownloaderCache() map[string]string {
 	return r.cache
 }

--- a/pkg/http-server/remote-repo.go
+++ b/pkg/http-server/remote-repo.go
@@ -141,6 +141,10 @@ func (s *scanRemoteRepoReq) ScanRemoteRepo(iacType, iacVersion string, cloudType
 		zap.S().Error(errMsg)
 		return output, isAdmissionDenied, err
 	}
+	// set remote url in case remote repo is scanned
+	if s.RemoteURL != "" {
+		results.Violations.Summary.ResourcePath = s.RemoteURL
+	}
 
 	if !s.ShowPassed {
 		results.Violations.ViolationStore.PassedRules = nil

--- a/pkg/iac-providers/terraform/commons/load-dir.go
+++ b/pkg/iac-providers/terraform/commons/load-dir.go
@@ -119,7 +119,7 @@ func (t TerraformDirectoryLoader) loadDirRecursive(dirList []string) (output.All
 		unified, diags := t.buildUnifiedConfig(rootMod, dir)
 
 		// Get the downloader chache
-		remoteURLMapping := t.remoteDownloader.GetModuleInstalledCache()
+		remoteURLMapping := t.remoteDownloader.GetDownloaderCache()
 
 		if diags.HasErrors() {
 			// log a warn message in this case because there are errors in
@@ -237,7 +237,7 @@ func (t TerraformDirectoryLoader) loadDirNonRecursive() (output.AllResourceConfi
 	unified, diags := t.buildUnifiedConfig(rootMod, t.absRootDir)
 
 	// Get the downloader chache
-	remoteURLMapping := t.remoteDownloader.GetModuleInstalledCache()
+	remoteURLMapping := t.remoteDownloader.GetDownloaderCache()
 
 	if diags.HasErrors() {
 		// log a warn message in this case because there are errors in
@@ -418,7 +418,7 @@ func (m *ModuleConfig) getChildConfigs() []*ModuleConfig {
 	return allConfigs
 }
 
-// GetRemoteLocation check wether the source belongs to the remote module present in downloader cache.
+// GetRemoteLocation checks wether the source belongs to the remote module present in downloader cache.
 // cache has key = remoteURL and value = tempDir
 func GetRemoteLocation(cache map[string]string, resourcePath string) (remoteURL, tmpDir string) {
 	dir := filepath.Dir(resourcePath)


### PR DESCRIPTION
- Improves the filename when the remote module is used.
- Output of the scan of terraform directory with the remote module.
 ```
~ ./bin/terrascan scan -d  testfolder  -o json -i terraform
{
  "results": {
    "violations": [
      {
        "rule_name": "eksControlPlaneLoggingDisabled",
        "description": "Ensure EKS clusters have control plane logging enabled.",
        "rule_id": "AWS.AEC.LM.MEDIUM.0071",
        "severity": "MEDIUM",
        "category": "Logging and Monitoring",
        "resource_name": "this",
        "resource_type": "aws_eks_cluster",
        "module_name": "eks",
        "file": "git::https:/github.com/terraform-aws-modules/terraform-aws-eks?ref=v17.1.0/cluster.tf",
        "plan_root": "./",
        "line": 9
      },
      {
        "rule_name": "kmsKeyRotationDisabled",
        "description": "Ensure rotation for customer created CMKs is enabled",
        "rule_id": "AWS.AKK.DP.HIGH.0012",
        "severity": "HIGH",
        "category": "Data Protection",
        "resource_name": "kmsKeyDisabled",
        "resource_type": "aws_kms_key",
        "module_name": "sub-cloudfront",
        "file": "cloudfront/sub-cloudfront/main.tf",
        "plan_root": "cloudfront",
        "line": 1
      },
      {
        "rule_name": "imdsv1LaunchConfig",
        "description": "Launch configuration uses IMDSv1 which vulnerable to SSRF",
        "rule_id": "AC-AW-CA-LC-H-0439",
        "severity": "HIGH",
        "category": "Configuration and Vulnerability Analysis",
        "resource_name": "launch_configuration",
        "resource_type": "aws_launch_configuration",
        "module_name": "consul_servers",
        "file": "git::https:/github.com/hashicorp/terraform-aws-consul?ref=v0.1.0/modules/consul-cluster/main.tf",
        "plan_root": "./",
        "line": 48
      },
    ],
    "skipped_violations": null,
    "scan_summary": {
      "file/folder": "/Users/suvarna/testfolder",
      "iac_type": "terraform",
      "scanned_at": "2021-06-15 12:14:46.002086 +0000 UTC",
      "policies_validated": 65,
      "violated_policies": 3
      "low": 0,
      "medium": 1,
      "high": 2
    }
  }
}
```