### PR TITLE
K8s Policy to detect a service type Loadbalancer without a selector

### DIFF
--- a/pkg/policies/opa/rego/k8s/kubernetes_service/AC_K8S_0114.json
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/AC_K8S_0114.json
@@ -1,0 +1,17 @@
+{
+    "name": "ensureServiceWithSelector",
+    "file": "ensureServiceWithSelector.rego",
+    "policy_type": "k8s",
+    "resource_type": "kubernetes_service",
+    "template_args": {
+        "name": "ensureServiceWithSelector",
+        "prefix": "",
+        "suffix": ""
+    },
+    "severity": "LOW",
+    "description": "Ensure the use of selector is enforced for Kubernetes Ingress or LoadBalancer service",
+    "reference_id": "AC_K8S_0114",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "AC_K8S_0114"
+}

--- a/pkg/policies/opa/rego/k8s/kubernetes_service/ensureServiceWithSelector.rego
+++ b/pkg/policies/opa/rego/k8s/kubernetes_service/ensureServiceWithSelector.rego
@@ -1,0 +1,8 @@
+package accurics
+
+{{.prefix}}{{.name}}{{.suffix}}[service.id] {
+    service := input.kubernetes_service[_]
+    service_config := service.config
+    service_config.spec.type == ["LoadBalancer", "Ingress"][_]
+    object.get(service_config, "selector", "undefined") == "undefined"
+}


### PR DESCRIPTION
This PR includes a policy for CVE-2021-25740
Link to CVE: https://github.com/kubernetes/kubernetes/issues/103675