### PR TITLE
Adds : docker as cloud provider

### DIFF
--- a/docs/usage/command_line_mode.md
+++ b/docs/usage/command_line_mode.md
@@ -199,7 +199,7 @@ aws_ecr_repository:
 | -i type  | Use this to change the IaC provider | arm, cft, docker, helm, k8s, kustomize, **terraform**|
 | -i version  | Use this in conjunction with `- i type` to specify the version of IaC provider | Supported versions of each IaC are: `arm: v1, cft: v1, docker: v1, helm: v3, k8s: v1, kustomize: v3, terraform: v12, v13, v14, v15`|
 | -p | Use this to specify directory path for policies | By default policies are installed here: <tbd specify a default path> |
-| -t  | Use this to specify individual cloud providers | **all**, aws, azure, gcp, github, k8s|
+| -t  | Use this to specify individual cloud providers | **all**, aws, azure, docker, gcp, github, k8s|
 | -r | Use this to specify directory path for remote backend | git, s3, gcs, http |
 | -u | Use this to specify directory URL for remote IaC repositories | see options below |
 | |scan-rules|Specify rules to scan, example: --scan-rules="ruleID1,ruleID2"|
@@ -238,7 +238,7 @@ Flags:
       --iac-version string        iac version (arm: v1, cft: v1, docker: v1, helm: v3, k8s: v1, kustomize: v3, terraform: v12, v13, v14, v15, tfplan: v1)
       --non-recursive             do not scan directories and modules recursively
   -p, --policy-path stringArray   policy path directory
-  -t, --policy-type strings       policy type (all, aws, azure, gcp, github, k8s) (default [all])
+  -t, --policy-type strings       policy type (all, aws, azure, docker, gcp, github, k8s) (default [all])
   -r, --remote-type string        type of remote backend (git, s3, gcs, http, terraform-registry)
   -u, --remote-url string         url pointing to remote IaC repository
       --scan-rules strings        one or more rules to scan (example: --scan-rules="ruleID1,ruleID2")

--- a/pkg/policy/docker.go
+++ b/pkg/policy/docker.go
@@ -1,0 +1,25 @@
+/*
+    Copyright (C) 2020 Accurics, Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package policy
+
+const (
+	docker                  supportedCloudType  = "docker"
+	defaultDockerIacType    supportedIacType    = "docker"
+	defaultDockerIacVersion supportedIacVersion = version1
+)
+
+func init() {
+	// Register docker as a cloud provider with terrascan
+	RegisterCloudProvider(docker, defaultDockerIacType, defaultDockerIacVersion)
+}

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -17,8 +17,9 @@
 package runtime
 
 import (
-	"github.com/accurics/terrascan/pkg/policy/opa"
 	"sort"
+
+	"github.com/accurics/terrascan/pkg/policy/opa"
 
 	"go.uber.org/zap"
 
@@ -159,6 +160,7 @@ func (e *Executor) initPolicyEngines() (err error) {
 		// initialize the engine
 		if err := engine.Init(policyPath, preloadFilter); err != nil {
 			zap.S().Errorf("failed to initialize policy engine for path %s, error: %s", policyPath, err)
+			zap.S().Error("perform 'terrascan init' command and then try running the scan command again")
 			return err
 		}
 		e.policyEngines = append(e.policyEngines, engine)

--- a/test/e2e/help/golden/help_scan.txt
+++ b/test/e2e/help/golden/help_scan.txt
@@ -15,7 +15,7 @@ Flags:
       --iac-version string        iac version (arm: v1, cft: v1, docker: v1, helm: v3, k8s: v1, kustomize: v3, terraform: v12, v13, v14, v15, tfplan: v1)
       --non-recursive             do not scan directories and modules recursively
   -p, --policy-path stringArray   policy path directory
-  -t, --policy-type strings       policy type (all, aws, azure, gcp, github, k8s) (default [all])
+  -t, --policy-type strings       policy type (all, aws, azure, docker, gcp, github, k8s) (default [all])
   -r, --remote-type string        type of remote backend (git, s3, gcs, http, terraform-registry)
   -u, --remote-url string         url pointing to remote IaC repository
       --scan-rules strings        one or more rules to scan (example: --scan-rules="ruleID1,ruleID2")


### PR DESCRIPTION
After registering docker as a cloud provider docker policies will be loaded in the policy engine when using `terrascan scan` command.