### PR TITLE
Network interface policies

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_network_interface/NP_AWS_0001.json
+++ b/pkg/policies/opa/rego/aws/aws_network_interface/NP_AWS_0001.json
@@ -1,0 +1,16 @@
+{
+    "name": "checkNetworkInterfaces",
+    "file": "unusedNetInterfaces.rego",
+    "policy_type": "aws",
+    "resource_type": "aws_network_interface",
+    "template_args": {
+        "prefix": "",
+        "suffix": "",
+        "name" : "checkNetworkInterfaces"
+    },
+    "severity": "MEDIUM",
+    "description": "Ensure unused AWS network interfaces are removed",
+    "category": "Infrastructure Security",
+    "version": 1,
+    "id": "NP_AWS_0001"
+}

--- a/pkg/policies/opa/rego/aws/aws_network_interface/unusedNetInterfaces.rego
+++ b/pkg/policies/opa/rego/aws/aws_network_interface/unusedNetInterfaces.rego
@@ -1,0 +1,14 @@
+package accurics
+
+{{.prefix}}{{.suffix}}{{.name}}[netInterface.id]{
+   netInterface := input.aws_network_interface[_] 
+   config := netInterface.config	
+   object.get(config, "attachment", "undefined") == "undefined"
+}
+
+{{.prefix}}{{.suffix}}{{.name}}[netInterface.id]{
+   netInterface := input.aws_network_interface[_] 
+   config := netInterface.config.attachment[_]
+   config.instance == ""
+}
+


### PR DESCRIPTION
This pr includes a AWS network interface policy that checks for dangling network interface.