### PR TITLE
Fix notification webhook flow

### DIFF
--- a/pkg/notifications/webhook/webhook.go
+++ b/pkg/notifications/webhook/webhook.go
@@ -79,8 +79,7 @@ func (w *Webhook) SendNotification(data interface{}) error {
 
 	// validate http response
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-
-		zap.S().Errorf("failed to webhook notification. Incorrect status code: '%v'", resp.StatusCode)
+		zap.S().Errorf("failed to send webhook notification, status code: '%v'", resp.StatusCode)
 		return fmt.Errorf("webhook notification failed")
 	}
 

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -257,11 +257,6 @@ func (e *Executor) Execute(configOnly bool) (results Output, err error) {
 	// add other summary details after policies are evaluated
 	results.Violations.ViolationStore.AddSummary(e.iacType, resourcePath)
 
-	// send notifications, if configured
-	if err = e.SendNotifications(results); err != nil {
-		return results, err
-	}
-
 	// we want to display the dir scan errors with all the iac providers
 	// that support sub folder scanning, which includes 'all' iac scan
 	if err := merr.ErrorOrNil(); err != nil {
@@ -269,6 +264,9 @@ func (e *Executor) Execute(configOnly bool) (results Output, err error) {
 		sort.Sort(merr)
 		results.Violations.ViolationStore.AddLoadDirErrors(merr.WrappedErrors())
 	}
+
+	// send notifications, if configured
+	e.SendNotifications(results)
 
 	// successful
 	return results, nil

--- a/pkg/runtime/executor_test.go
+++ b/pkg/runtime/executor_test.go
@@ -165,15 +165,6 @@ func TestExecute(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "test SendNofitications mock error",
-			executor: Executor{
-				iacProviders:  []iacProvider.IacProvider{MockIacProvider{err: nil}},
-				notifiers:     []notifications.Notifier{&MockNotifier{err: errMockNotifier}},
-				policyEngines: []policy.Engine{MockPolicyEngine{err: nil}},
-			},
-			wantErr: errMockNotifier,
-		},
-		{
 			name: "test policy enginer no error",
 			executor: Executor{
 				iacProviders:  []iacProvider.IacProvider{MockIacProvider{err: nil}},


### PR DESCRIPTION
* Added Terrascan errors in Notification web-hook data
* now terrascan do not error out even if web hook responds with non 2xx status codes