### PR TITLE
Fix gcp policy AC_GCP_0014 - dnsStateIsNotOn (#1033)

### DIFF
--- a/pkg/policies/opa/rego/gcp/google_dns_managed_zone/dnsStateIsNotOn.rego
+++ b/pkg/policies/opa/rego/gcp/google_dns_managed_zone/dnsStateIsNotOn.rego
@@ -2,5 +2,6 @@ package accurics
 
 dnsStateIsNotOn[dnsconfig.id] {
   dnsconfig := input.google_dns_managed_zone[_]
-  state := dnsconfig.config.dnssec_config[_].state != "on"
+  dnssec_config := dnsconfig.config.dnssec_config[_]
+  dnssec_config.state != "on"
 }


### PR DESCRIPTION
Unroll the data structure in two steps and fix the actual state
comparison.