### PR TITLE
Updates CloudFormation mapper to support additional resources

### DIFF
--- a/pkg/mapper/iac-providers/cft/cft.go
+++ b/pkg/mapper/iac-providers/cft/cft.go
@@ -19,8 +19,11 @@ package cft
 import (
 	"errors"
 
+	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
 	"github.com/awslabs/goformation/v4/cloudformation/cloudfront"
 	"github.com/awslabs/goformation/v4/cloudformation/cloudtrail"
+	"github.com/awslabs/goformation/v4/cloudformation/sns"
+	"github.com/awslabs/goformation/v4/cloudformation/sqs"
 
 	cf "github.com/awslabs/goformation/v4/cloudformation/cloudformation"
 	cnf "github.com/awslabs/goformation/v4/cloudformation/config"
@@ -214,6 +217,16 @@ func (m cftMapper) mapConfigForResource(r cloudformation.Resource) []config.AWSR
 		return config.GetS3BucketConfig(resource)
 	case *s3.BucketPolicy:
 		return config.GetS3BucketPolicyConfig(resource)
+	case *sqs.Queue:
+		return config.GetSqsQueueConfig(resource)
+	case *sqs.QueuePolicy:
+		return config.GetSqsQueuePolicyConfig(resource)
+	case *sns.Topic:
+		return config.GetSnsTopicConfig(resource)
+	case *sns.TopicPolicy:
+		return config.GetSnsTopicPolicyConfig(resource)
+	case *autoscaling.LaunchConfiguration:
+		return config.GetAutoScalingLaunchConfigurationConfig(resource)
 	default:
 	}
 	return []config.AWSResourceConfig{}

--- a/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
+++ b/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
@@ -22,16 +22,19 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
 )
 
+// EbsBlockDeviceBlock hold config for EbsBlockDevice
 type EbsBlockDeviceBlock struct {
 	DeviceName string `json:"device_name"`
 	Encrypted  bool   `json:"encrypted"`
 }
 
+// MetadataOptionsBlock hold config for MetadataOptions
 type MetadataOptionsBlock struct {
 	HttpEndpoint string `json:"http_endpoint"`
 	HttpTokens   string `json:"http_tokens"`
 }
 
+// AutoScalingLaunchConfigurationConfig hold config for AutoScalingLaunchConfiguration
 type AutoScalingLaunchConfigurationConfig struct {
 	Config
 	EnableMonitoring bool                  `json:"enable_monitoring"`
@@ -40,6 +43,7 @@ type AutoScalingLaunchConfigurationConfig struct {
 	EbsBlockDevice   []EbsBlockDeviceBlock `json:"ebs_block_device"`
 }
 
+// GetAutoScalingLaunchConfigurationConfig returns config for AutoScalingLaunchConfiguration
 func GetAutoScalingLaunchConfigurationConfig(l *autoscaling.LaunchConfiguration) []AWSResourceConfig {
 	userDataBase64 := base64.StdEncoding.EncodeToString([]byte(l.UserData))
 

--- a/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
+++ b/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/base64"
+
+	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
+)
+
+type EbsBlockDeviceBlock struct {
+	DeviceName string `json:"device_name"`
+	Encrypted  bool   `json:"encrypted"`
+}
+
+type MetadataOptionsBlock struct {
+	HttpEndpoint string `json:"http_endpoint"`
+	HttpTokens   string `json:"http_tokens"`
+}
+
+type AutoScalingLaunchConfigurationConfig struct {
+	Config
+	EnableMonitoring bool                  `json:"enable_monitoring"`
+	UserDataBase64   string                `json:"user_data_base64"`
+	MetadataOptions  MetadataOptionsBlock  `json:"metadata_options"`
+	EbsBlockDevice   []EbsBlockDeviceBlock `json:"ebs_block_device"`
+}
+
+func GetAutoScalingLaunchConfigurationConfig(l *autoscaling.LaunchConfiguration) []AWSResourceConfig {
+	userDataBase64 := base64.StdEncoding.EncodeToString([]byte(l.UserData))
+
+	ebsBlockDevice := make([]EbsBlockDeviceBlock, len(l.BlockDeviceMappings))
+
+	for i := range l.BlockDeviceMappings {
+		if l.BlockDeviceMappings[i].Ebs != nil {
+			ebsBlockDevice[i].Encrypted = l.BlockDeviceMappings[i].Ebs.Encrypted
+		}
+		ebsBlockDevice[i].DeviceName = l.BlockDeviceMappings[i].DeviceName
+	}
+
+	var metadataOptions MetadataOptionsBlock
+	metadataOptions.HttpEndpoint = l.MetadataOptions.HttpEndpoint
+	metadataOptions.HttpTokens = l.MetadataOptions.HttpTokens
+
+	cf := AutoScalingLaunchConfigurationConfig{
+		Config: Config{
+			Name: l.LaunchConfigurationName,
+		},
+		EnableMonitoring: l.InstanceMonitoring,
+		UserDataBase64:   userDataBase64,
+		MetadataOptions:  metadataOptions,
+		EbsBlockDevice:   ebsBlockDevice,
+	}
+
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: l.AWSCloudFormationMetadata,
+	}}
+}

--- a/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
+++ b/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
@@ -30,8 +30,8 @@ type EbsBlockDeviceBlock struct {
 
 // MetadataOptionsBlock hold config for MetadataOptions
 type MetadataOptionsBlock struct {
-	HttpEndpoint string `json:"http_endpoint"`
-	HttpTokens   string `json:"http_tokens"`
+	HTTPEndpoint string `json:"http_endpoint"`
+	HTTPTokens   string `json:"http_tokens"`
 }
 
 // AutoScalingLaunchConfigurationConfig hold config for AutoScalingLaunchConfiguration
@@ -57,8 +57,8 @@ func GetAutoScalingLaunchConfigurationConfig(l *autoscaling.LaunchConfiguration)
 	}
 
 	var metadataOptions MetadataOptionsBlock
-	metadataOptions.HttpEndpoint = l.MetadataOptions.HttpEndpoint
-	metadataOptions.HttpTokens = l.MetadataOptions.HttpTokens
+	metadataOptions.HTTPEndpoint = l.MetadataOptions.HttpEndpoint
+	metadataOptions.HTTPTokens = l.MetadataOptions.HttpTokens
 
 	cf := AutoScalingLaunchConfigurationConfig{
 		Config: Config{

--- a/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
+++ b/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
@@ -25,8 +25,9 @@ import (
 
 // EbsBlockDeviceBlock hold config for EbsBlockDevice
 type EbsBlockDeviceBlock struct {
-	DeviceName string `json:"device_name"`
-	Encrypted  bool   `json:"encrypted"`
+	DeviceName          string `json:"device_name"`
+	Encrypted           bool   `json:"encrypted"`
+	DeleteOnTermination bool   `json:"delete_on_termination"`
 }
 
 // MetadataOptionsBlock hold config for MetadataOptions
@@ -52,6 +53,7 @@ func GetAutoScalingLaunchConfigurationConfig(l *autoscaling.LaunchConfiguration)
 	for i := range l.BlockDeviceMappings {
 		if l.BlockDeviceMappings[i].Ebs != nil {
 			ebsBlockDevice[i].Encrypted = l.BlockDeviceMappings[i].Ebs.Encrypted
+			ebsBlockDevice[i].DeleteOnTermination = l.BlockDeviceMappings[i].Ebs.DeleteOnTermination
 		}
 		ebsBlockDevice[i].DeviceName = l.BlockDeviceMappings[i].DeviceName
 	}
@@ -75,7 +77,7 @@ func GetAutoScalingLaunchConfigurationConfig(l *autoscaling.LaunchConfiguration)
 	datastr := string(data)
 
 	if isASCII(datastr) && err == nil {
-		cf.UserDataBase64 = datastr
+		cf.UserDataBase64 = l.UserData
 	} else {
 		cf.UserData = l.UserData
 	}

--- a/pkg/mapper/iac-providers/cft/config/sns-topic-policy.go
+++ b/pkg/mapper/iac-providers/cft/config/sns-topic-policy.go
@@ -22,12 +22,14 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/sns"
 )
 
+// SnsTopicPolicyConfig hold config for SnsTopicPolicy
 type SnsTopicPolicyConfig struct {
 	Config
 	ARN    string `json:"arn"`
 	Policy string `json:"policy"`
 }
 
+// GetSnsTopicPolicyConfig returns config for SnsTopicPolicy
 func GetSnsTopicPolicyConfig(p *sns.TopicPolicy) []AWSResourceConfig {
 	policyDoc, _ := json.Marshal(p.PolicyDocument)
 

--- a/pkg/mapper/iac-providers/cft/config/sns-topic-policy.go
+++ b/pkg/mapper/iac-providers/cft/config/sns-topic-policy.go
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/awslabs/goformation/v4/cloudformation/sns"
+)
+
+type SnsTopicPolicyConfig struct {
+	Config
+	ARN    string `json:"arn"`
+	Policy string `json:"policy"`
+}
+
+func GetSnsTopicPolicyConfig(p *sns.TopicPolicy) []AWSResourceConfig {
+	policyDoc, _ := json.Marshal(p.PolicyDocument)
+
+	cflist := make([]SnsTopicPolicyConfig, len(p.Topics))
+	resourcelist := make([]AWSResourceConfig, len(p.Topics))
+
+	for i := range p.Topics {
+		cflist[i].Config.Name = p.Topics[i]
+		cflist[i].ARN = p.Topics[i]
+		cflist[i].Policy = string(policyDoc)
+
+		resourcelist[i].Resource = cflist[i]
+		resourcelist[i].Metadata = p.AWSCloudFormationMetadata
+	}
+
+	return resourcelist
+}

--- a/pkg/mapper/iac-providers/cft/config/sns-topic.go
+++ b/pkg/mapper/iac-providers/cft/config/sns-topic.go
@@ -1,0 +1,39 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import "github.com/awslabs/goformation/v4/cloudformation/sns"
+
+type SnsTopicConfig struct {
+	Config
+	Name        string `json:"name"`
+	KmsMasterID string `json:"kms_master_id"`
+}
+
+func GetSnsTopicConfig(t *sns.Topic) []AWSResourceConfig {
+	cf := SnsTopicConfig{
+		Config: Config{
+			Name: t.TopicName,
+		},
+		Name:        t.TopicName,
+		KmsMasterID: t.KmsMasterKeyId,
+	}
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: t.AWSCloudFormationMetadata,
+	}}
+}

--- a/pkg/mapper/iac-providers/cft/config/sns-topic.go
+++ b/pkg/mapper/iac-providers/cft/config/sns-topic.go
@@ -18,12 +18,14 @@ package config
 
 import "github.com/awslabs/goformation/v4/cloudformation/sns"
 
+// SnsTopicConfig hold config for SnsTopic
 type SnsTopicConfig struct {
 	Config
 	Name        string `json:"name"`
 	KmsMasterID string `json:"kms_master_id"`
 }
 
+// GetSnsTopicConfig returns config for SnsTopic
 func GetSnsTopicConfig(t *sns.Topic) []AWSResourceConfig {
 	cf := SnsTopicConfig{
 		Config: Config{

--- a/pkg/mapper/iac-providers/cft/config/sqs-queue-policy.go
+++ b/pkg/mapper/iac-providers/cft/config/sqs-queue-policy.go
@@ -25,7 +25,7 @@ import (
 // SqsQueuePolicyConfig holds config for SqsQueuePolicy
 type SqsQueuePolicyConfig struct {
 	Config
-	QueueUrl string `json:"queue_url"`
+	QueueURL string `json:"queue_url"`
 	Policy   string `json:"policy"`
 }
 
@@ -38,7 +38,7 @@ func GetSqsQueuePolicyConfig(p *sqs.QueuePolicy) []AWSResourceConfig {
 
 	for i := range cflist {
 		cflist[i].Config.Name = p.Queues[i]
-		cflist[i].QueueUrl = p.Queues[i]
+		cflist[i].QueueURL = p.Queues[i]
 		cflist[i].Policy = string(policyDoc)
 
 		resourcelist[i].Resource = cflist[i]

--- a/pkg/mapper/iac-providers/cft/config/sqs-queue-policy.go
+++ b/pkg/mapper/iac-providers/cft/config/sqs-queue-policy.go
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+
+	"github.com/awslabs/goformation/v4/cloudformation/sqs"
+)
+
+type SqsQueuePolicyConfig struct {
+	Config
+	QueueUrl string `json:"queue_url"`
+	Policy   string `json:"policy"`
+}
+
+func GetSqsQueuePolicyConfig(p *sqs.QueuePolicy) []AWSResourceConfig {
+	policyDoc, _ := json.Marshal(p.PolicyDocument)
+
+	cflist := make([]SqsQueuePolicyConfig, len(p.Queues))
+	resourcelist := make([]AWSResourceConfig, len(p.Queues))
+
+	for i := range cflist {
+		cflist[i].Config.Name = p.Queues[i]
+		cflist[i].QueueUrl = p.Queues[i]
+		cflist[i].Policy = string(policyDoc)
+
+		resourcelist[i].Resource = cflist[i]
+		resourcelist[i].Metadata = p.AWSCloudFormationMetadata
+	}
+
+	return resourcelist
+}

--- a/pkg/mapper/iac-providers/cft/config/sqs-queue-policy.go
+++ b/pkg/mapper/iac-providers/cft/config/sqs-queue-policy.go
@@ -22,12 +22,14 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/sqs"
 )
 
+// SqsQueuePolicyConfig holds config for SqsQueuePolicy
 type SqsQueuePolicyConfig struct {
 	Config
 	QueueUrl string `json:"queue_url"`
 	Policy   string `json:"policy"`
 }
 
+// GetSqsQueuePolicyConfig returns config for SqsQueuePolicy
 func GetSqsQueuePolicyConfig(p *sqs.QueuePolicy) []AWSResourceConfig {
 	policyDoc, _ := json.Marshal(p.PolicyDocument)
 

--- a/pkg/mapper/iac-providers/cft/config/sqs-queue.go
+++ b/pkg/mapper/iac-providers/cft/config/sqs-queue.go
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/awslabs/goformation/v4/cloudformation/sqs"
+)
+
+type SqsQueueConfig struct {
+	Config
+	Name                         string `json:"name"`
+	KmsMasterKeyID               string `json:"kms_master_key_id"`
+	KmsDataKeyReusePeriodSeconds int    `json:"kms_data_key_reuse_period_seconds"`
+	MessageRetentionSeconds      int    `json:"message_retention_seconds"`
+}
+
+func GetSqsQueueConfig(q *sqs.Queue) []AWSResourceConfig {
+	cf := SqsQueueConfig{
+		Config: Config{
+			Name: q.QueueName,
+		},
+		Name:                         q.QueueName,
+		KmsMasterKeyID:               q.KmsMasterKeyId,
+		KmsDataKeyReusePeriodSeconds: q.KmsDataKeyReusePeriodSeconds,
+		MessageRetentionSeconds:      q.MessageRetentionPeriod,
+	}
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: q.AWSCloudFormationMetadata,
+	}}
+}

--- a/pkg/mapper/iac-providers/cft/config/sqs-queue.go
+++ b/pkg/mapper/iac-providers/cft/config/sqs-queue.go
@@ -20,6 +20,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/sqs"
 )
 
+// SqsQueueConfig holds config for SqsQueue
 type SqsQueueConfig struct {
 	Config
 	Name                         string `json:"name"`
@@ -28,6 +29,7 @@ type SqsQueueConfig struct {
 	MessageRetentionSeconds      int    `json:"message_retention_seconds"`
 }
 
+// GetSqsQueueConfig returns config for SqsQueue
 func GetSqsQueueConfig(q *sqs.Queue) []AWSResourceConfig {
 	cf := SqsQueueConfig{
 		Config: Config{

--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -73,6 +73,6 @@ var ResourceTypes = map[string]string{
 	"AWS::SQS::Queue":                          AwsSqsQueue,
 	"AWS::SQS::QueuePolicy":                    AwsSqsQueuePolicy,
 	"AWS::SNS::Topic":                          AwsSnsTopic,
-	"AWS:SNS::TopicPolicy":                     AwsSnsTopicPolicy,
+	"AWS::SNS::TopicPolicy":                    AwsSnsTopicPolicy,
 	"AWS::AutoScaling::LaunchConfiguration":    AwsLaunchConfiguration,
 }

--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -21,7 +21,7 @@ var ResourceTypes = map[string]string{
 	"AWS::DocDB::DBCluster":                    AwsDocDBCluster,
 	"AWS::ApiGatewayV2::Stage":                 AwsAPIGatewayV2Stage,
 	"AWS::ApiGateway::Stage":                   AwsAPIGatewayStage,
-	"AWS::ApiGateway::Stage.MethodSetting":     AwsAPIGatewayStageMethodSettings,
+	"AWS::ApiGateway::Stage.MethodSettings":    AwsAPIGatewayStageMethodSettings,
 	"AWS::ApiGateway::RestApi":                 AwsAPIGatewayRestAPI,
 	"AWS::ECS::Service":                        AwsEcsService,
 	"AWS::Logs::LogGroup":                      AwsLogGroup,

--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -21,7 +21,7 @@ var ResourceTypes = map[string]string{
 	"AWS::DocDB::DBCluster":                    AwsDocDBCluster,
 	"AWS::ApiGatewayV2::Stage":                 AwsAPIGatewayV2Stage,
 	"AWS::ApiGateway::Stage":                   AwsAPIGatewayStage,
-	"AWS::ApiGateway::Stage.MethodSettings":    AwsAPIGatewayStageMethodSettings,
+	"AWS::ApiGateway::Stage.MethodSetting":     AwsAPIGatewayStageMethodSettings,
 	"AWS::ApiGateway::RestApi":                 AwsAPIGatewayRestAPI,
 	"AWS::ECS::Service":                        AwsEcsService,
 	"AWS::Logs::LogGroup":                      AwsLogGroup,

--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -70,4 +70,9 @@ var ResourceTypes = map[string]string{
 	"AWS::S3::Bucket":                          AwsS3Bucket,
 	"AWS::S3::Bucket.PublicAccessBlock":        AwsS3BucketPublicAccessBlock,
 	"AWS::S3::BucketPolicy":                    AwsS3BucketPolicy,
+	"AWS::SQS::Queue":                          AwsSqsQueue,
+	"AWS::SQS::QueuePolicy":                    AwsSqsQueuePolicy,
+	"AWS::SNS::Topic":                          AwsSnsTopic,
+	"AWS:SNS::TopicPolicy":                     AwsSnsTopicPolicy,
+	"AWS::AutoScaling::LaunchConfiguration":    AwsLaunchConfiguration,
 }

--- a/pkg/mapper/iac-providers/cft/store/types.go
+++ b/pkg/mapper/iac-providers/cft/store/types.go
@@ -70,4 +70,9 @@ const (
 	AwsS3Bucket                      = "aws_s3_bucket"
 	AwsS3BucketPublicAccessBlock     = "aws_s3_bucket_public_access_block"
 	AwsS3BucketPolicy                = "aws_s3_bucket_policy"
+	AwsSqsQueue                      = "aws_sqs_queue"
+	AwsSqsQueuePolicy                = "aws_sqs_queue_policy"
+	AwsSnsTopic                      = "aws_sns_topic"
+	AwsSnsTopicPolicy                = "aws_sns_topic_policy"
+	AwsLaunchConfiguration           = "aws_launch_configuration"
 )


### PR DESCRIPTION
## Update CFT - TF Mapper
This update brings in following resources into CFT - TF Mapper

- AWS Autoscaling Launch Configuration
- AWS SQS Queue
- AWS SQS Queue Policy
- AWS SNS Topic
- AWS SNS Topic Policy

The update also fixes a typo in one of the existing maps:

```go
"AWS::ApiGateway::Stage.MethodSetting":     AwsAPIGatewayStageMethodSettings
```

Name of resource in CFT uses the singular word `setting`