### PR TITLE
Prevent adding both skipped and failure elements

### DIFF
--- a/pkg/writer/junit_xml.go
+++ b/pkg/writer/junit_xml.go
@@ -164,18 +164,24 @@ func violationsToTestCases(violations []*results.Violation, isSkipped bool) []JU
 	for _, v := range violations {
 		var testCase JUnitTestCase
 		if isSkipped {
-			testCase = JUnitTestCase{Failure: new(JUnitFailure), SkipMessage: new(JUnitSkipMessage)}
-			testCase.SkipMessage.Message = v.Comment
+			testCase = JUnitTestCase{SkipMessage: new(JUnitSkipMessage)}
+			// since junitXML doesn't contain the attributes we want to show as violations
+			// we would add details of violations in the skip message, with any provided skip comment
+			if v.Comment == "" {
+				testCase.SkipMessage.Message = getViolationString(*v)
+			} else {
+				testCase.SkipMessage.Message = fmt.Sprintf("(skip comment: %s) %s", v.Comment, getViolationString(*v))
+			}
 		} else {
 			testCase = JUnitTestCase{Failure: new(JUnitFailure)}
+			// since junitXML doesn't contain the attributes we want to show as violations
+			// we would add details of violations in the failure message
+			testCase.Failure.Message = getViolationString(*v)
 		}
 		testCase.Classname = v.File
 		testCase.Name = fmt.Sprintf(testNameFormatFailed, v.ResourceName, v.LineNumber, v.RuleID)
 		testCase.Severity = v.Severity
 		testCase.Category = v.Category
-		// since junitXML doesn't contain the attributes we want to show as violations
-		// we would add details of violations in the failure message
-		testCase.Failure.Message = getViolationString(*v)
 		testCases = append(testCases, testCase)
 	}
 	return testCases

--- a/pkg/writer/junit_xml.go
+++ b/pkg/writer/junit_xml.go
@@ -167,10 +167,8 @@ func violationsToTestCases(violations []*results.Violation, isSkipped bool) []JU
 			testCase = JUnitTestCase{SkipMessage: new(JUnitSkipMessage)}
 			// since junitXML doesn't contain the attributes we want to show as violations
 			// we would add details of violations in the skip message, with any provided skip comment
-			if v.Comment == "" {
-				testCase.SkipMessage.Message = getViolationString(*v)
-			} else {
-				testCase.SkipMessage.Message = fmt.Sprintf("(skip comment: %s) %s", v.Comment, getViolationString(*v))
+			if v.Comment != "" {
+				testCase.SkipMessage.Message = v.Comment
 			}
 		} else {
 			testCase = JUnitTestCase{Failure: new(JUnitFailure)}

--- a/pkg/writer/junit_xml_test.go
+++ b/pkg/writer/junit_xml_test.go
@@ -38,7 +38,7 @@ func TestJUnitXMLWriter(t *testing.T) {
       <failure message="Description: S3 bucket Access is allowed to all AWS Account Users., File: modules/m1/main.tf, Line: 20, Severity: HIGH, Rule Name: s3EnforceUserACL, Rule ID: AWS.S3Bucket.DS.High.1043, Resource Name: bucket, Resource Type: aws_s3_bucket, Category: S3" type=""></failure>
     </testcase>
     <testcase classname="modules/m1/main.tf" name="[ERROR] resource: &#34;bucket&#34; at line: 20, violates: RULE - AWS.S3Bucket.DS.High.1043" severity="HIGH" category="S3">
-      <skipped message="Description: S3 bucket Access is allowed to all AWS Account Users., File: modules/m1/main.tf, Line: 20, Severity: HIGH, Rule Name: s3EnforceUserACL, Rule ID: AWS.S3Bucket.DS.High.1043, Resource Name: bucket, Resource Type: aws_s3_bucket, Category: S3"></skipped>
+      <skipped message=""></skipped>
     </testcase>
   </testsuite>
 </testsuites>

--- a/pkg/writer/junit_xml_test.go
+++ b/pkg/writer/junit_xml_test.go
@@ -38,8 +38,7 @@ func TestJUnitXMLWriter(t *testing.T) {
       <failure message="Description: S3 bucket Access is allowed to all AWS Account Users., File: modules/m1/main.tf, Line: 20, Severity: HIGH, Rule Name: s3EnforceUserACL, Rule ID: AWS.S3Bucket.DS.High.1043, Resource Name: bucket, Resource Type: aws_s3_bucket, Category: S3" type=""></failure>
     </testcase>
     <testcase classname="modules/m1/main.tf" name="[ERROR] resource: &#34;bucket&#34; at line: 20, violates: RULE - AWS.S3Bucket.DS.High.1043" severity="HIGH" category="S3">
-      <skipped message=""></skipped>
-      <failure message="Description: S3 bucket Access is allowed to all AWS Account Users., File: modules/m1/main.tf, Line: 20, Severity: HIGH, Rule Name: s3EnforceUserACL, Rule ID: AWS.S3Bucket.DS.High.1043, Resource Name: bucket, Resource Type: aws_s3_bucket, Category: S3" type=""></failure>
+      <skipped message="Description: S3 bucket Access is allowed to all AWS Account Users., File: modules/m1/main.tf, Line: 20, Severity: HIGH, Rule Name: s3EnforceUserACL, Rule ID: AWS.S3Bucket.DS.High.1043, Resource Name: bucket, Resource Type: aws_s3_bucket, Category: S3"></skipped>
     </testcase>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
This is a potential fix to prevent both `skipped` and `failure` elements on a skipped violation in JUnit output format

Fixes: #1122