### PR TITLE
methodsetting typo fix

### DIFF
--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -21,7 +21,7 @@ var ResourceTypes = map[string]string{
 	"AWS::DocDB::DBCluster":                    AwsDocDBCluster,
 	"AWS::ApiGatewayV2::Stage":                 AwsAPIGatewayV2Stage,
 	"AWS::ApiGateway::Stage":                   AwsAPIGatewayStage,
-	"AWS::ApiGateway::Stage.MethodSettings":    AwsAPIGatewayStageMethodSettings,
+	"AWS::ApiGateway::Stage.MethodSetting":     AwsAPIGatewayStageMethodSettings,
 	"AWS::ApiGateway::RestApi":                 AwsAPIGatewayRestAPI,
 	"AWS::ECS::Service":                        AwsEcsService,
 	"AWS::Logs::LogGroup":                      AwsLogGroup,


### PR DESCRIPTION
fixed a typo in `store.go` file

changed `AWS::ApiGateway::Stage.MethodSettings` to `AWS::ApiGateway::Stage.MethodSetting` 

CFT uses singular form of the name