### PR TITLE
Feature/ec2 cog lambda acm cft

### DIFF
--- a/pkg/mapper/iac-providers/cft/cft.go
+++ b/pkg/mapper/iac-providers/cft/cft.go
@@ -20,8 +20,11 @@ import (
 	"errors"
 
 	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
+	"github.com/awslabs/goformation/v4/cloudformation/certificatemanager"
 	"github.com/awslabs/goformation/v4/cloudformation/cloudfront"
 	"github.com/awslabs/goformation/v4/cloudformation/cloudtrail"
+	"github.com/awslabs/goformation/v4/cloudformation/cognito"
+	"github.com/awslabs/goformation/v4/cloudformation/lambda"
 	"github.com/awslabs/goformation/v4/cloudformation/sns"
 	"github.com/awslabs/goformation/v4/cloudformation/sqs"
 
@@ -227,6 +230,14 @@ func (m cftMapper) mapConfigForResource(r cloudformation.Resource) []config.AWSR
 		return config.GetSnsTopicPolicyConfig(resource)
 	case *autoscaling.LaunchConfiguration:
 		return config.GetAutoScalingLaunchConfigurationConfig(resource)
+	case *ec2.Instance:
+		return config.GetEC2InstanceConfig(resource)
+	case *cognito.UserPool:
+		return config.GetCognitoUserPoolConfig(resource)
+	case *lambda.Function:
+		return config.GetLambdaFunctionConfig(resource)
+	case *certificatemanager.Certificate:
+		return config.GetCertificateManagerCertificateConfig(resource)
 	default:
 	}
 	return []config.AWSResourceConfig{}

--- a/pkg/mapper/iac-providers/cft/cft.go
+++ b/pkg/mapper/iac-providers/cft/cft.go
@@ -88,7 +88,7 @@ func (m cftMapper) Map(resource interface{}, params ...map[string]interface{}) (
 		return nil, errors.New(errUnsupportedDoc)
 	}
 	for name, untypedRes := range template.Resources {
-		for _, resourceConfig := range m.mapConfigForResource(untypedRes) {
+		for _, resourceConfig := range m.mapConfigForResource(name, untypedRes) {
 			if resourceConfig.Resource != nil {
 				config := output.ResourceConfig{
 					Name:      name,
@@ -128,7 +128,7 @@ func (m cftMapper) Map(resource interface{}, params ...map[string]interface{}) (
 	return configs, nil
 }
 
-func (m cftMapper) mapConfigForResource(r cloudformation.Resource) []config.AWSResourceConfig {
+func (m cftMapper) mapConfigForResource(rscname string, r cloudformation.Resource) []config.AWSResourceConfig {
 	switch resource := r.(type) {
 	case *docdb.DBCluster:
 		return config.GetDocDBConfig(resource)
@@ -231,7 +231,7 @@ func (m cftMapper) mapConfigForResource(r cloudformation.Resource) []config.AWSR
 	case *autoscaling.LaunchConfiguration:
 		return config.GetAutoScalingLaunchConfigurationConfig(resource)
 	case *ec2.Instance:
-		return config.GetEC2InstanceConfig(resource)
+		return config.GetEC2InstanceConfig(rscname, resource)
 	case *cognito.UserPool:
 		return config.GetCognitoUserPoolConfig(resource)
 	case *lambda.Function:

--- a/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
+++ b/pkg/mapper/iac-providers/cft/config/autoscaling-launch-configuration.go
@@ -23,20 +23,20 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/autoscaling"
 )
 
-// EbsBlockDeviceBlock hold config for EbsBlockDevice
+// EbsBlockDeviceBlock holds config for EbsBlockDevice
 type EbsBlockDeviceBlock struct {
 	DeviceName          string `json:"device_name"`
 	Encrypted           bool   `json:"encrypted"`
 	DeleteOnTermination bool   `json:"delete_on_termination"`
 }
 
-// MetadataOptionsBlock hold config for MetadataOptions
+// MetadataOptionsBlock holds config for MetadataOptions
 type MetadataOptionsBlock struct {
 	HTTPEndpoint string `json:"http_endpoint"`
 	HTTPTokens   string `json:"http_tokens"`
 }
 
-// AutoScalingLaunchConfigurationConfig hold config for AutoScalingLaunchConfiguration
+// AutoScalingLaunchConfigurationConfig holds config for AutoScalingLaunchConfiguration
 type AutoScalingLaunchConfigurationConfig struct {
 	Config
 	EnableMonitoring bool                  `json:"enable_monitoring"`

--- a/pkg/mapper/iac-providers/cft/config/certificatemanager-certificate.go
+++ b/pkg/mapper/iac-providers/cft/config/certificatemanager-certificate.go
@@ -1,0 +1,42 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import "github.com/awslabs/goformation/v4/cloudformation/certificatemanager"
+
+// CertificateManagerCertificateConfig holds config for CertificateManagerCertificate
+type CertificateManagerCertificateConfig struct {
+	Config
+	DomainName       string `json:"domain_name"`
+	ValidationMethod string `json:"validation_method"`
+}
+
+// GetCertificateManagerCertificateConfig returns config for CertificateManagerCertificate
+func GetCertificateManagerCertificateConfig(c *certificatemanager.Certificate) []AWSResourceConfig {
+	cf := CertificateManagerCertificateConfig{
+		Config: Config{
+			Tags: c.Tags,
+		},
+		DomainName:       c.DomainName,
+		ValidationMethod: c.ValidationMethod,
+	}
+
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: c.AWSCloudFormationMetadata,
+	}}
+}

--- a/pkg/mapper/iac-providers/cft/config/cognito-user-pool.go
+++ b/pkg/mapper/iac-providers/cft/config/cognito-user-pool.go
@@ -1,0 +1,61 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANT IES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import "github.com/awslabs/goformation/v4/cloudformation/cognito"
+
+type PasswordPolicyBlock struct {
+	MinimumLength                 int  `json:"minimum_length"`
+	RequireLowercase              bool `json:"require_lowercase"`
+	RequireUppercase              bool `json:"require_uppercase"`
+	RequireNumbers                bool `json:"require_numbers"`
+	RequireSymbols                bool `json:"require_symbols"`
+	TemporaryPasswordValidityDays int  `json:"temporary_password_validity_days"`
+}
+
+// CognitoUserPoolConfig holds config for CognitoUserPool
+type CognitoUserPoolConfig struct {
+	Config
+	Name           string                `json:"name"`
+	PasswordPolicy []PasswordPolicyBlock `json:"password_policy"`
+}
+
+// GetCognitoUserPoolConfig returns config for CognitoUserPool
+func GetCognitoUserPoolConfig(u *cognito.UserPool) []AWSResourceConfig {
+	passwordPolicy := make([]PasswordPolicyBlock, 1)
+	if u.Policies != nil && u.Policies.PasswordPolicy != nil {
+		passwordPolicy[0].MinimumLength = u.Policies.PasswordPolicy.MinimumLength
+		passwordPolicy[0].RequireLowercase = u.Policies.PasswordPolicy.RequireLowercase
+		passwordPolicy[0].RequireUppercase = u.Policies.PasswordPolicy.RequireUppercase
+		passwordPolicy[0].RequireNumbers = u.Policies.PasswordPolicy.RequireNumbers
+		passwordPolicy[0].RequireSymbols = u.Policies.PasswordPolicy.RequireSymbols
+		passwordPolicy[0].TemporaryPasswordValidityDays = u.Policies.PasswordPolicy.TemporaryPasswordValidityDays
+	}
+
+	cf := CognitoUserPoolConfig{
+		Config: Config{
+			Name: u.UserPoolName,
+		},
+		Name:           u.UserPoolName,
+		PasswordPolicy: passwordPolicy,
+	}
+
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: u.AWSCloudFormationMetadata,
+	}}
+}

--- a/pkg/mapper/iac-providers/cft/config/ec2-instance.go
+++ b/pkg/mapper/iac-providers/cft/config/ec2-instance.go
@@ -1,0 +1,105 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"fmt"
+	"strconv"
+
+	"github.com/awslabs/goformation/v4/cloudformation/ec2"
+)
+
+// NetworkInterfaceBlock holds config for NetworkInterface
+type NetworkInterfaceBlock struct {
+	NetworkInterfaceID  string `json:"network_interface_id"`
+	DeviceIndex         int    `json:"device_index"`
+	DeleteOnTermination bool   `json:"delete_on_termination"`
+}
+
+// TagBlock holds config for Tag
+type TagBlock struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// EC2InstanceConfig holds config for EC2Instance
+type EC2InstanceConfig struct {
+	Config
+	AMI                      string                  `json:"ami"`
+	InstanceType             string                  `json:"instance_type"`
+	EBSOptimized             bool                    `json:"ebs_optimized"`
+	Hibernation              bool                    `json:"hibernation"`
+	Monitoring               bool                    `json:"monitoring"`
+	IAMInstanceProfile       string                  `json:"iam_instance_profile"`
+	VPCSecurityGroupIDs      []string                `json:"vpc_security_group_ids"`
+	AssociatePublicIPAddress bool                    `json:"associate_public_ip_address"`
+	NetworkInterface         []NetworkInterfaceBlock `json:"network_interface"`
+	Tags                     []TagBlock              `json:"tags"`
+}
+
+// GetEC2InstanceConfig returns config for EC2Instance
+func GetEC2InstanceConfig(i *ec2.Instance) []AWSResourceConfig {
+	name := fmt.Sprintf("aws_instance_%s", getname(10))
+
+	var publicIp bool
+	nics := make([]NetworkInterfaceBlock, len(i.NetworkInterfaces))
+	for index := range i.NetworkInterfaces {
+		nics[index].NetworkInterfaceID = i.NetworkInterfaces[index].NetworkInterfaceId
+		nics[index].DeviceIndex, _ = strconv.Atoi(i.NetworkInterfaces[index].DeviceIndex)
+		nics[index].DeleteOnTermination = i.NetworkInterfaces[index].DeleteOnTermination
+
+		publicIp = i.NetworkInterfaces[index].AssociatePublicIpAddress
+	}
+
+	tags := make([]TagBlock, len(i.Tags))
+	for index := range i.Tags {
+		tags[index].Key = i.Tags[index].Key
+		tags[index].Value = i.Tags[index].Value
+	}
+
+	cf := EC2InstanceConfig{
+		Config: Config{
+			Name: name,
+		},
+		AMI:                      i.ImageId,
+		InstanceType:             i.InstanceType,
+		EBSOptimized:             i.EbsOptimized,
+		Hibernation:              i.HibernationOptions.Configured,
+		Monitoring:               i.Monitoring,
+		IAMInstanceProfile:       i.IamInstanceProfile,
+		VPCSecurityGroupIDs:      i.SecurityGroupIds,
+		AssociatePublicIPAddress: publicIp,
+		NetworkInterface:         nics,
+		Tags:                     tags,
+	}
+
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: i.AWSCloudFormationMetadata,
+	}}
+}
+
+func getname(length int) string {
+	randomBytes := make([]byte, 32)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		panic(err)
+	}
+	return base32.StdEncoding.EncodeToString(randomBytes)[:length]
+}

--- a/pkg/mapper/iac-providers/cft/config/lambda-function.go
+++ b/pkg/mapper/iac-providers/cft/config/lambda-function.go
@@ -1,0 +1,107 @@
+/*
+    Copyright (C) 2022 Accurics, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"io/ioutil"
+
+	"github.com/awslabs/goformation/v4/cloudformation/lambda"
+)
+
+// TracingConfigBlock holds config for TracingConfig
+type TracingConfigBlock struct {
+	Mode string `json:"mode"`
+}
+
+// VPCConfigBlock holds config for VPCConfig
+type VPCConfigBlock struct {
+	SecurityGroupIDs []string `json:"security_group_ids"`
+	SubnetIDs        []string `json:"subnet_ids"`
+}
+
+type EnvironmentBlock struct {
+	Variables map[string]string `json:"variables"`
+}
+
+// LambdaFunctionConfig holds config for LambdaFunction
+type LambdaFunctionConfig struct {
+	Config
+	FileName                     string               `json:"filename"`
+	FunctionName                 string               `json:"function_name"`
+	Role                         string               `json:"role"`
+	Handler                      string               `json:"handler"`
+	SourceCodeHash               string               `json:"source_code_hash"`
+	MemorySize                   int                  `json:"memory_size"`
+	ReservedConcurrentExecutions int                  `json:"reserved_concurrent_executions"`
+	Runtime                      string               `json:"runtime"`
+	Timeout                      int                  `json:"timeout"`
+	TracingConfig                []TracingConfigBlock `json:"tracing_config"`
+	VPCConfig                    []VPCConfigBlock     `json:"vpc_config"`
+	Environment                  []EnvironmentBlock   `json:"environment"`
+	KMSKeyARN                    string               `json:"kms_key_arn"`
+}
+
+// GetLambdaFunctionConfig returns config for LambdaFunction
+func GetLambdaFunctionConfig(f *lambda.Function) []AWSResourceConfig {
+	tracingConfig := make([]TracingConfigBlock, 1)
+	if f.TracingConfig != nil {
+		tracingConfig[0].Mode = f.TracingConfig.Mode
+	}
+
+	vpcConfig := make([]VPCConfigBlock, 1)
+	if f.VpcConfig != nil {
+		vpcConfig[0].SecurityGroupIDs = f.VpcConfig.SecurityGroupIds
+		vpcConfig[0].SubnetIDs = f.VpcConfig.SubnetIds
+	}
+
+	environment := make([]EnvironmentBlock, 1)
+	if f.Environment != nil {
+		environment[0].Variables = f.Environment.Variables
+	}
+
+	cf := LambdaFunctionConfig{
+		Config: Config{
+			Name: f.FunctionName,
+		},
+		FileName:                     f.Code.ZipFile,
+		FunctionName:                 f.FunctionName,
+		Role:                         f.Role,
+		Handler:                      f.Handler,
+		SourceCodeHash:               gethash(f.Code.ZipFile),
+		MemorySize:                   f.MemorySize,
+		ReservedConcurrentExecutions: f.ReservedConcurrentExecutions,
+		Runtime:                      f.Runtime,
+		Timeout:                      f.Timeout,
+		TracingConfig:                tracingConfig,
+		VPCConfig:                    vpcConfig,
+		Environment:                  environment,
+		KMSKeyARN:                    f.KmsKeyArn,
+	}
+
+	return []AWSResourceConfig{{
+		Resource: cf,
+		Metadata: f.AWSCloudFormationMetadata,
+	}}
+}
+
+func gethash(codefile string) string {
+	data, _ := ioutil.ReadFile(codefile)
+	hash := sha256.Sum256(data)
+	return base64.StdEncoding.EncodeToString(hash[:])
+}

--- a/pkg/mapper/iac-providers/cft/config/sns-topic-policy.go
+++ b/pkg/mapper/iac-providers/cft/config/sns-topic-policy.go
@@ -22,7 +22,7 @@ import (
 	"github.com/awslabs/goformation/v4/cloudformation/sns"
 )
 
-// SnsTopicPolicyConfig hold config for SnsTopicPolicy
+// SnsTopicPolicyConfig holds config for SnsTopicPolicy
 type SnsTopicPolicyConfig struct {
 	Config
 	ARN    string `json:"arn"`

--- a/pkg/mapper/iac-providers/cft/config/sns-topic.go
+++ b/pkg/mapper/iac-providers/cft/config/sns-topic.go
@@ -18,7 +18,7 @@ package config
 
 import "github.com/awslabs/goformation/v4/cloudformation/sns"
 
-// SnsTopicConfig hold config for SnsTopic
+// SnsTopicConfig holds config for SnsTopic
 type SnsTopicConfig struct {
 	Config
 	Name        string `json:"name"`

--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -75,4 +75,8 @@ var ResourceTypes = map[string]string{
 	"AWS::SNS::Topic":                          AwsSnsTopic,
 	"AWS::SNS::TopicPolicy":                    AwsSnsTopicPolicy,
 	"AWS::AutoScaling::LaunchConfiguration":    AwsLaunchConfiguration,
+	"AWS::EC2::Instance":                       AwsEc2Instance,
+	"AWS::Cognito::UserPool":                   AwsCognitoUserPool,
+	"AWS::Lambda::Function":                    AwsLambdaFunction,
+	"AWS::CertificateManager::Certificate":     AwsAcmCertificate,
 }

--- a/pkg/mapper/iac-providers/cft/store/store.go
+++ b/pkg/mapper/iac-providers/cft/store/store.go
@@ -76,6 +76,7 @@ var ResourceTypes = map[string]string{
 	"AWS::SNS::TopicPolicy":                    AwsSnsTopicPolicy,
 	"AWS::AutoScaling::LaunchConfiguration":    AwsLaunchConfiguration,
 	"AWS::EC2::Instance":                       AwsEc2Instance,
+	"AWS::EC2::Instance.NetworkInterface":      AwsEc2NetworkInterface,
 	"AWS::Cognito::UserPool":                   AwsCognitoUserPool,
 	"AWS::Lambda::Function":                    AwsLambdaFunction,
 	"AWS::CertificateManager::Certificate":     AwsAcmCertificate,

--- a/pkg/mapper/iac-providers/cft/store/types.go
+++ b/pkg/mapper/iac-providers/cft/store/types.go
@@ -75,4 +75,8 @@ const (
 	AwsSnsTopic                      = "aws_sns_topic"
 	AwsSnsTopicPolicy                = "aws_sns_topic_policy"
 	AwsLaunchConfiguration           = "aws_launch_configuration"
+	AwsEc2Instance                   = "aws_instance"
+	AwsCognitoUserPool               = "aws_cognito_user_pool"
+	AwsLambdaFunction                = "aws_lambda_function"
+	AwsAcmCertificate                = "aws_acm_certificate"
 )

--- a/pkg/mapper/iac-providers/cft/store/types.go
+++ b/pkg/mapper/iac-providers/cft/store/types.go
@@ -76,6 +76,7 @@ const (
 	AwsSnsTopicPolicy                = "aws_sns_topic_policy"
 	AwsLaunchConfiguration           = "aws_launch_configuration"
 	AwsEc2Instance                   = "aws_instance"
+	AwsEc2NetworkInterface           = "aws_network_interface"
 	AwsCognitoUserPool               = "aws_cognito_user_pool"
 	AwsLambdaFunction                = "aws_lambda_function"
 	AwsAcmCertificate                = "aws_acm_certificate"


### PR DESCRIPTION
Add support for following resources:

1. aws_instance
2. aws_network_interface
3. aws_lambda_function
4. aws_cognito_user_pool
5. aws_acm_certificate

Updated signature of function `mapConfigForResource` to account for edge cases where resources may require their names to generate IDs while generating configurations