### PR TITLE
add rule id to docs

### DIFF
--- a/docs/policies/aws.md
+++ b/docs/policies/aws.md
@@ -1,420 +1,670 @@
 
 ### aws_iam_role_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1189 | AC_AWS_0147 |
+| Identity and Access Management | AIRP | HIGH | Ensure IAM roles do not have any policies attached that may cause privilege escalation. | AWS.AIRP.IAM.HIGH.0051 | AC_AWS_0473 |
 
 
 ### aws_route53_record
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| DNS Management | Route53HostedZone | HIGH | Route53HostedZone should have recordSets. | AWS.Route53HostedZone.DNSManagement.High.0422 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | Route53HostedZone | HIGH | Route53HostedZone should have recordSets. | AWS.Route53HostedZone.DNSManagement.High.0422 | AC_AWS_0205 |
+
+
+### aws_elasticsearch_domain_policy
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | AEDP | HIGH | Ensure Elasticsearch domains do not have wildcard policies. | AWS.AEDP.IAM.HIGH.0060 | AC_AWS_0469 |
+
+
+### aws_lb_target_group
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | ALTG | MEDIUM | Ensure Target Group use HTTPs to ensure end to end encryption | AWS.ALTG.IS.MEDIUM.0042 | AC_AWS_0492 |
 
 
 ### aws_api_gateway_method_settings
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | API Gateway | MEDIUM | Enable Detailed CloudWatch Metrics for APIs | AWS.API Gateway.Logging.Medium.0569 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | API Gateway | MEDIUM | Enable Detailed CloudWatch Metrics for APIs | AWS.APIGateway.Logging.Medium.0569 | AC_AWS_0007 |
+
+
+### aws_workspaces_workspace
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | AWW | MEDIUM | Ensure user volume for Workspaces is Encrypted | AWS.AWW.DP.MEDIUM.041 | AC_AWS_0504 |
+| Data Protection | AWW | MEDIUM | Ensure root volume for Workspaces is Encrypted | AWS.AWW.DP.MEDIUM.040 | AC_AWS_0503 |
 
 
 ### aws_vpc
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | VPC | MEDIUM | Avoid creating resources in default VPC | AWS.VPC.Logging.Medium.0471 |
-| Logging | VPC | MEDIUM | Ensure VPC flow logging is enabled in all VPCs | AWS.VPC.Logging.Medium.0470 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | VPC | MEDIUM | Avoid creating resources in default VPC | AWS.VPC.Logging.Medium.0471 | AC_AWS_0370 |
+| Logging and Monitoring | VPC | LOW | Ensure VPC flow logging is enabled in all VPCs | AWS.VPC.Logging.Medium.0470 | AC_AWS_0369 |
 
 
 ### aws_iam_account_password_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| IAM | Iam | MEDIUM | Lower case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0454 |
-| IAM | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0458 |
-| IAM | Iam | LOW | It is recommended that the password policy prevent the reuse of passwords.Preventing password reuse increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0539 |
-| IAM | Iam | MEDIUM | Number not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0455 |
-| IAM | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0495 |
-| IAM | Iam | MEDIUM | Special symbols not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0456 |
-| IAM | Iam | MEDIUM | Upper case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0457 |
-| IAM | Iam | LOW | Reducing the password lifetime increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0540 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Compliance Validation | Iam | LOW | Lower case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0454 | AC_AWS_0134 |
+| Compliance Validation | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0458 | AC_AWS_0142 |
+| Compliance Validation | Iam | LOW | It is recommended that the password policy prevent the reuse of passwords.Preventing password reuse increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0539 | AC_AWS_0472 |
+| Compliance Validation | Iam | MEDIUM | Number not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0455 | AC_AWS_0136 |
+| Compliance Validation | Iam | MEDIUM | Setting a lengthy password increases account resiliency against brute force login attempts | AWS.Iam.IAM.Medium.0495 | AC_AWS_0141 |
+| Compliance Validation | Iam | MEDIUM | Special symbols not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0456 | AC_AWS_0137 |
+| Compliance Validation | Iam | MEDIUM | Upper case alphabet not present in the Password, Password Complexity is not high. Increased Password complexity increases resiliency against brute force attack | AWS.Iam.IAM.Medium.0457 | AC_AWS_0135 |
+| Compliance Validation | Iam | LOW | Reducing the password lifetime increases account resiliency against brute force login attempts | AWS.Iam.IAM.Low.0540 | AC_AWS_0138 |
 
 
 ### aws_mq_broker
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | ElasticSearch | MEDIUM | Publicly Accessible MQ Brokers | AWS.ElasticSearch.NetworkSecurity.Medium.0887 |
-| Logging | ElasticSearch | MEDIUM | Enable AWS MQ Log Exports | AWS.ElasticSearch.Logging.Medium.0885 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | ElasticSearch | MEDIUM | Publicly Accessible MQ Brokers | AWS.ElasticSearch.NetworkSecurity.Medium.0887 | AC_AWS_0175 |
+| Logging and Monitoring | ElasticSearch | LOW | Enable AWS MQ Log Exports | AWS.ElasticSearch.Logging.Medium.0885 | AC_AWS_0174 |
 
 
 ### aws_db_instance
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | AWS RDS | HIGH | RDS Instance publicly_accessible flag is true | AWS.AWS RDS.NS.High.0101 |
-| Data Security | RDS | HIGH | Ensure Certificate used in RDS instance is updated | AWS.RDS.DS.High.1042 |
-| Data Security | RDS | HIGH | Ensure that your RDS database has IAM Authentication enabled. | AWS.RDS.DataSecurity.High.0577 |
-| Data Security | RDS | HIGH | RDS Instance Auto Minor Version Upgrade flag disabled | AWS.RDS.DS.High.1041 |
-| Data Security | RDS | HIGH | Ensure that your RDS database instances have automated backups enabled for point-in-time recovery. To back up your database instances, AWS RDS take automatically a full daily snapshot of your data (with transactions logs) during the specified backup window and keeps the backups for a limited period of time (known as retention period) defined by the instance owner. | AWS.RDS.DataSecurity.High.0414 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | RDS | HIGH | Ensure Certificate used in RDS instance is updated | AWS.RDS.DS.High.1042 | AC_AWS_0057 |
+| Logging and Monitoring | ADI | MEDIUM | Ensure AWS RDS instances have logging enabled. | AWS.ADI.LM.MEDIUM.0076 | AC_AWS_0454 |
+| Data Protection | RDS | MEDIUM | Ensure that your RDS database has IAM Authentication enabled. | AWS.RDS.DataSecurity.High.0577 | AC_AWS_0053 |
+| Infrastructure Security | RDS | HIGH | RDS Instance publicly_accessible flag is true | AWS.RDS.NS.High.0101 | AC_AWS_0054 |
+| Data Protection | RDS | HIGH | RDS Instance Auto Minor Version Upgrade flag disabled | AWS.RDS.DS.High.1041 | AC_AWS_0056 |
+| Data Protection | RDS | HIGH | Ensure that your RDS database instances encrypt the underlying storage. Encrypted RDS instances use the industry standard AES-256 encryption algorithm to encrypt data on the server that hosts RDS DB instances. After data is encrypted, RDS handles authentication of access and descryption of data transparently with minimal impact on performance. | AWS.RDS.DataSecurity.High.0414 | AC_AWS_0058 |
+
+
+### aws_secretsmanager_secret_policy
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | ASSP | HIGH | Ensure secrets manager do not wildcard policies attached | AWS.ASSP.IAM.HIGH.0066 | AC_AWS_0501 |
 
 
 ### aws_ebs_volume
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | EcsCluster | HIGH | Ensure that AWS EBS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS EBS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 |
-| Encryption and Key Management | EBS | HIGH | Enable AWS EBS Snapshot Encryption | AWS.EBS.EKM.Medium.0682 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | EcsCluster | HIGH | Ensure that AWS EBS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS EBS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 | AC_AWS_0460 |
+| Data Protection | EBS | HIGH | Enable AWS EBS Snapshot Encryption | AWS.EBS.EKM.Medium.0682 | AC_AWS_0459 |
 
 
 ### aws_api_gateway_rest_api
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-|   | APIGateway | MEDIUM | Enable Content Encoding | AWS.APIGateway.Medium.0568 |
-| Network Security | APIGateway | MEDIUM | API Gateway Private Endpoints | AWS.APIGateway.Network Security.Medium.0570 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | APIGateway | MEDIUM | Enable Content Encoding | AWS.APIGateway.Medium.0568 | AC_AWS_0010 |
+| Infrastructure Security | APIGateway | MEDIUM | API Gateway Private Endpoints | AWS.APIGateway.NetworkSecurity.Medium.0570 | AC_AWS_0011 |
 
 
 ### aws_iam_role
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1188 | AC_AWS_0146 |
+
+
+### aws_iam_user_policy_attachment
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | AIUPA | MEDIUM | Ensure IAM permissions are not given directly to users | AWS.AIUPA.IAM.MEDIUM.0050 | AC_AWS_0476 |
 
 
 ### aws_ebs_encryption_by_default
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | EBS | HIGH | Ensure that the AWS EBS that hold sensitive and critical data is encrypted by default to fulfill compliance requirements for data-at-rest encryption. | AWS.EBS.DataSecurity.High.0580 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | EBS | HIGH | Ensure that the AWS EBS that hold sensitive and critical data is encrypted by default to fulfill compliance requirements for data-at-rest encryption. | AWS.EBS.DataSecurity.High.0580 | AC_AWS_0079 |
 
 
 ### aws_sns_topic
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | SNS | MEDIUM | Ensure SNS Topic is Publicly Accessible For Subscription | AWS.SNS.NS.Medium.1044 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Compliance Validation | SNS | HIGH | Ensure SNS Topic is Publicly Accessible For Subscription | AWS.SNS.NS.Medium.1044 | AC_AWS_0385 |
+| Data Protection | AST | MEDIUM | Ensure SNS topic is Encrypted using KMS master key | AWS.AST.DP.MEDIUM.0037 | AC_AWS_0502 |
 
 
 ### aws_apigatewayv2_api
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| AccessControl | ApiGatewayV2Api | Medium | Insecure Cross-Origin Resource Sharing Configuration allowing all domains | AWS.ApiGatewayV2Api.AccessControl.0630 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | ApiGatewayV2Api | Medium | Insecure Cross-Origin Resource Sharing Configuration allowing all domains | AWS.ApiGatewayV2Api.AccessControl.0630 | AC_AWS_0441 |
 
 
 ### aws_efs_file_system
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0409 |
-| Encryption and Key Management | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0410 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0409 | AC_AWS_0097 |
+| Data Protection | EFS | HIGH | Enable encryption of your EFS file systems in order to protect your data and metadata from breaches or unauthorized access and fulfill compliance requirements for data-at-rest encryption within your organization. | AWS.EFS.EncryptionandKeyManagement.High.0410 | AC_AWS_0098 |
+
+
+### aws_lb_listener
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | ALL | MEDIUM | Ensure there is a listener configured on HTTPs or with a port 443 | AWS.ALL.IS.MEDIUM.0046 | AC_AWS_0491 |
 
 
 ### aws_sqs_queue
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | SQS | HIGH | Identify any publicly accessible SQS queues available in your AWS account and update their permissions in order to protect against unauthorized users. | AWS.SQS.NetworkSecurity.High.0569 |
-| Network Security | SQS | HIGH | Ensure that your Amazon Simple Queue Service (SQS) queues are protecting the contents of their messages using Server-Side Encryption (SSE). The SQS service uses an AWS KMS Customer Master Key (CMK) to generate data keys required for the encryption/decryption process of SQS messages. There is no additional charge for using SQS Server-Side Encryption, however, there is a charge for using AWS KMS | AWS.SQS.NetworkSecurity.High.0570 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | SQS | HIGH | Identify any publicly accessible SQS queues available in your AWS account and update their permissions in order to protect against unauthorized users. | AWS.SQS.NetworkSecurity.High.0569 | AC_AWS_0365 |
+| Security Best Practices | SQS | HIGH | Ensure that your Amazon Simple Queue Service (SQS) queues are protecting the contents of their messages using Server-Side Encryption (SSE). The SQS service uses an AWS KMS Customer Master Key (CMK) to generate data keys required for the encryption/decryption process of SQS messages. There is no additional charge for using SQS Server-Side Encryption, however, there is a charge for using AWS KMS | AWS.SQS.NetworkSecurity.High.0570 | AC_AWS_0366 |
+
+
+### aws_docdb_cluster
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ADC | MEDIUM | Ensure DocDb is encrypted at rest | AWS.ADC.DP.MEDIUM.0022 | AC_AWS_0455 |
+| Logging and Monitoring | ADC | MEDIUM | Ensure DocDb clusters have log exports enabled. | AWS.ADC.LM.MEDIUM.0069 | AC_AWS_0456 |
+
+
+### aws_cloudwatch_log_group
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | ACLG | MEDIUM | Ensure AWS Cloudwatch log group has retention policy set. | AWS.ACLG.LM.MEDIUM.0068 | AC_AWS_0452 |
 
 
 ### aws_instance
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | MEDIUM | EC2 instances should disable IMDS or require IMDSv2 | AC-AWS-NS-IN-M-1172 |
-| Network Security | Instance | MEDIUM | Instance should be configured in vpc. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations. | AWS.Instance.NetworkSecurity.Medium.0506 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | EC2 instances should disable IMDS or require IMDSv2 as this can be related to the weaponization phase of kill chain | AC-AWS-NS-IN-M-1172 | AC_AWS_0479 |
+| Identity and Access Management | json | HIGH | Ensure that instance launched follows the least privilege principle as this can be related to delivery-exploitation-Installation phases of kill  chain | AC-AW-IA-LC-H-0442 | AC_AWS_0477 |
+| Logging and Monitoring | AI | HIGH | Ensure that detailed monitoring is enabled for EC2 instances. | AWS.AI.LM.HIGH.0070 | AC_AWS_0480 |
+| Infrastructure Security | json | HIGH | Security group attached to launch configuration is wide open to internet and this can be related to reconnaissance phase | AC-AW-IS-LC-H-0443 | AC_AWS_0478 |
+| Infrastructure Security | json | MEDIUM | Ensure that your AWS application is not deployed within the default Virtual Private Cloud in order to follow security best practices | AC-AW-IS-IN-M-0144 | AC_AWS_0153 |
 
 
 ### aws_config
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | Config | MEDIUM | Ensure AWS Config Rule is enabled for Encrypted Volumes | AWS.Config.Encryption&KeyManagement.Medium.0660 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | Config | MEDIUM | Ensure AWS Config Rule is enabled for Encrypted Volumes | AWS.Config.EncryptionandKeyManagement.Medium.0660 | AC_AWS_0048 |
 
 
 ### aws_cloudformation_stack
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-|   | CloudFormation | MEDIUM | AWS CloudFormation Not In Use | AWS.CloudFormation.Medium.0599 |
-|   | CloudFormation | MEDIUM | AWS CloudFormation Stack Policy | AWS.CloudFormation.Medium.0604 |
-|   | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Termination Protection | AWS.CloudFormation.Medium.0605 |
-|   | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Notifications | AWS.CloudFormation.Medium.0603 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | CloudFormation | MEDIUM | AWS CloudFormation Not In Use | AWS.CloudFormation.Medium.0599 | AC_AWS_0444 |
+| Security Best Practices | CloudFormation | MEDIUM | AWS CloudFormation Stack Policy | AWS.CloudFormation.Medium.0604 | AC_AWS_0445 |
+| Security Best Practices | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Termination Protection | AWS.CloudFormation.Medium.0605 | AC_AWS_0022 |
+| Security Best Practices | CloudFormation | MEDIUM | Enable AWS CloudFormation Stack Notifications | AWS.CloudFormation.Medium.0603 | AC_AWS_0021 |
 
 
 ### aws_iam_user_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
-| Identity and Access Management | IamUser | HIGH | Ensure Hardware MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0387 |
-| Identity and Access Management | IamUser | HIGH | Ensure Virtual MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0388 |
-| Identity and Access Management | IamUser | HIGH | It is recommended that MFA be enabled for all accounts that have a console password. Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential | AWS.IamUser.IAM.High.0389 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Compliance Validation | IamUser | HIGH | Ensure Hardware MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0387 | AC_AWS_0150 |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1190 | AC_AWS_0474 |
+| Identity and Access Management | AIUP | MEDIUM | Ensure IAM policies are attached only to groups or roles | AWS.AIUP.IAM.MEDIUM.0049 | AC_AWS_0475 |
+| Compliance Validation | IamUser | HIGH | Ensure Virtual MFA device is enabled for the "root" account | AWS.IamUser.IAM.High.0388 | AC_AWS_0149 |
+| Compliance Validation | IamUser | HIGH | It is recommended that MFA be enabled for all accounts that have a console password. Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential | AWS.IamUser.IAM.High.0389 | AC_AWS_0151 |
 
 
 ### aws_ecs_task_definition
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | EcsCluster | HIGH | Like any other EC2 instance it is recommended to place ECS instance within a VPC. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations | AWS.EcsCluster.NetworkSecurity.High.0104 |
-| Data Security | LaunchConfiguration | HIGH | Sensitive Information Disclosure | AWS.LaunchConfiguration.DataSecurity.High.0101 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | EcsCluster | HIGH | Like any other EC2 instance it is recommended to place ECS instance within a VPC. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations | AWS.EcsCluster.NetworkSecurity.High.0104 | AC_AWS_0088 |
+| Infrastructure Security | AETD | MEDIUM | Ensure EFS volume used for ECS task defination has in transit encryption enabled | AWS.AETD.IS.MEDIUM.0043 | AC_AWS_0463 |
+| Data Protection | LaunchConfiguration | HIGH | Sensitive Information Disclosure | AWS.LaunchConfiguration.DataSecurity.High.0101 | AC_AWS_0095 |
 
 
 ### aws_ecr_repository_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | ECR | HIGH | Identify any exposed Amazon ECR image repositories available within your AWS account and update their permissions in order to protect against unauthorized access. Amazon Elastic Container Registry (ECR) is a managed Docker registry service that makes it easy for DevOps teams to store, manage and deploy Docker container images. An ECR repository is a collection of Docker images available on AWS cloud. | AWS.ECR.DataSecurity.High.0579 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | ECR | HIGH | Identify any exposed Amazon ECR image repositories available within your AWS account and update their permissions in order to protect against unauthorized access. Amazon Elastic Container Registry (ECR) is a managed Docker registry service that makes it easy for DevOps teams to store, manage and deploy Docker container images. An ECR repository is a collection of Docker images available on AWS cloud. | AWS.ECR.DataSecurity.High.0579 | AC_AWS_0084 |
 
 
 ### aws_iam_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-1187 | AC_AWS_0144 |
+
+
+### aws_dynamodb_table
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Resilience | DynamoDb | MEDIUM | Ensure Point In Time Recovery is enabled for DynamoDB Tables | AWS.DynamoDb.Logging.Medium.007 | AC_AWS_0458 |
+| Data Protection | ADT | MEDIUM | Ensure DynamoDb is encrypted at rest | AWS.ADT.DP.MEDIUM.0025 | AC_AWS_0457 |
 
 
 ### aws_apigatewayv2_stage
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | ApiGatewayV2Stage | Low | AWS API Gateway V2 Stage is missing access logs | AWS.ApiGatewayV2Stage.Logging.0630 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | ApiGatewayV2Stage | Low | AWS API Gateway V2 Stage is missing access logs | AWS.ApiGatewayV2Stage.Logging.0630 | AC_AWS_0442 |
 
 
 ### aws_ecr_repository
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | ECR | MEDIUM | Unscanned images may contain vulnerabilities | AWS.ECR.DataSecurity.High.0578 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | AER | MEDIUM | Ensure ECR repository is encrypted at rest | AWS.AER.DP.MEDIUM.0026 | AC_AWS_0461 |
+| Configuration and Vulnerability Analysis | ECR | MEDIUM | Unscanned images may contain vulnerabilities | AWS.ECR.DataSecurity.High.0578 | AC_AWS_0083 |
+| Identity and Access Management | AER | MEDIUM | Ensure ECR repository has policy attached. | AWS.AER.DP.MEDIUM.0058 | AC_AWS_0462 |
 
 
 ### aws_cloudfront_distribution
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | CloudFront | HIGH | Secure ciphers are not used in CloudFront distribution | AWS.CloudFront.EncryptionandKeyManagement.High.0408 |
-| Network Security | CloudFront | LOW | Ensure that geo restriction is enabled for your Amazon CloudFront CDN distribution to whitelist or blacklist a country in order to allow or restrict users in specific locations from accessing web application content. | AWS.CloudFront.Network Security.Low.0568 |
-| Encryption and Key Management | CloudFront | HIGH | Use encrypted connection between CloudFront and origin server | AWS.CloudFront.EncryptionandKeyManagement.High.0407 |
-| Logging | CloudFront | MEDIUM | Ensure that your AWS Cloudfront distributions have the Logging feature enabled in order to track all viewer requests for the content delivered through the Content Delivery Network (CDN). | AWS.CloudFront.Logging.Medium.0567 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | CloudFront | HIGH | Secure ciphers are not used in CloudFront distribution | AWS.CloudFront.EncryptionandKeyManagement.High.0408 | AC_AWS_0023 |
+| Infrastructure Security | json | LOW | Ensure that geo restriction is enabled for your Amazon CloudFront CDN distribution to whitelist or blacklist a country in order to allow or restrict users in specific locations from accessing web application content. | AC-AW-IS-CD-M-0026 | AC_AWS_0026 |
+| Infrastructure Security | json | Medium | Ensure that cloud-front has web application firewall enabled | AC-AW-IS-CD-M-1186 | AC_AWS_0032 |
+| Data Protection | CloudFront | HIGH | Use encrypted connection between CloudFront and origin server | AWS.CloudFront.EncryptionandKeyManagement.High.0407 | AC_AWS_0024 |
+| Logging and Monitoring | CloudFront | MEDIUM | Ensure that your AWS Cloudfront distributions have the Logging feature enabled in order to track all viewer requests for the content delivered through the Content Delivery Network (CDN). | AWS.CloudFront.Logging.Medium.0567 | AC_AWS_0025 |
 
 
 ### aws_cloudwatch
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | CloudWatch | MEDIUM | App-Tier CloudWatch Log Group Retention Period | AWS.CloudWatch.Logging.Medium.0631 |
-| Encryption and Key Management | CloudWatch | HIGH | AWS CloudWatch log group is not encrypted with a KMS CMK | AWS.CloudWatch.EncryptionandKeyManagement.High.0632 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | CloudWatch | MEDIUM | App-Tier CloudWatch Log Group Retention Period | AWS.CloudWatch.Logging.Medium.0631 | AC_AWS_0041 |
+| Data Protection | CloudWatch | HIGH | AWS CloudWatch log group is not encrypted with a KMS CMK | AWS.CloudWatch.EncryptionandKeyManagement.High.0632 | AC_AWS_0451 |
 
 
 ### aws_ami_launch_permission
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | AMI | MEDIUM | Limit access to AWS AMIs | AWS.AMI.NS.Medium.1040 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | AMI | MEDIUM | Limit access to AWS AMIs | AWS.AMI.NS.Medium.1040 | AC_AWS_0006 |
 
 
 ### aws_launch_configuration
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | EcsCluster | HIGH | Ensure that AWS ECS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS ECS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 |
-| Data Security | LaunchConfiguration | HIGH | Avoid using base64 encoded private keys as part of config | AWS.LaunchConfiguration.DataSecurity.High.0102 |
-| Data Security | LaunchConfiguration | HIGH | Avoid using base64 encoded shell script as part of config | AWS.LaunchConfiguration.DataSecurity.High.0101 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | EcsCluster | HIGH | Ensure that AWS ECS clusters are encrypted. Data encryption at rest, prevents unauthorized users from accessing sensitive data on your AWS ECS clusters and associated cache storage systems. | AWS.EcsCluster.EncryptionandKeyManagement.High.0413 | AC_AWS_0167 |
+| Identity and Access Management | json | HIGH | Ensure that launch configuration launched follows the least privilege principle | AC-AW-IA-LC-H-0441 | AC_AWS_0488 |
+| Data Protection | LaunchConfiguration | HIGH | Avoid using base64 encoded private keys as part of config | AWS.LaunchConfiguration.DataSecurity.High.0102 | AC_AWS_0168 |
+| Data Protection | LaunchConfiguration | HIGH | Avoid using base64 encoded shell script as part of config | AWS.LaunchConfiguration.DataSecurity.High.0101 | AC_AWS_0170 |
+| Logging and Monitoring | json | Medium | It is important to enable cloudWatch monitoring incase monitoring the activity | AC-AW-LM-LC-M-0440 | AC_AWS_0490 |
+| Configuration and Vulnerability Analysis | json | HIGH | Launch configuration uses IMDSv1 which vulnerable to SSRF | AC-AW-CA-LC-H-0439 | AC_AWS_0487 |
+| Infrastructure Security | json | HIGH | Security group attached to launch configuration is wide open to internet  | AC-AW-IS-LC-H-0438 | AC_AWS_0489 |
+
+
+### aws_athena_database
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ADB | MEDIUM | Ensure Athena Database is encrypted at rest | AWS.ADB.DP.MEDIUM.016 | AC_AWS_0443 |
 
 
 ### aws_api_gateway_stage
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | API Gateway | MEDIUM | Enable SSL Client Certificate | AWS.API Gateway.Network Security.Medium.0565 |
-| Logging | API Gateway | MEDIUM | Ensure that AWS CloudWatch logs are enabled for all your APIs created with Amazon API Gateway service in order to track and analyze execution behavior at the API stage level. | AWS.API Gateway.Logging.Medium.0572 |
-| Logging | API Gateway | MEDIUM | Enable Active Tracing | AWS.API Gateway.Logging.Medium.0571 |
-| Logging | API Gateway | MEDIUM | Enable AWS CloudWatch Logs for APIs | AWS.API Gateway.Logging.Medium.0567 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | API Gateway | MEDIUM | Enable SSL Client Certificate | AWS.APIGateway.NetworkSecurity.Medium.0565 | AC_AWS_0013 |
+| Logging and Monitoring | API Gateway | MEDIUM | Ensure that AWS CloudWatch logs are enabled for all your APIs created with Amazon API Gateway service in order to track and analyze execution behavior at the API stage level. | AWS.APIGateway.Logging.Medium.0572 | AC_AWS_0012 |
+| Logging and Monitoring | API Gateway | LOW | Ensure AWS API Gateway has active xray tracing enabled | AWS.APIGateway.Logging.Medium.0571 | AC_AWS_0015 |
+| Logging and Monitoring | API Gateway | MEDIUM | Enable AWS CloudWatch Logs for APIs | AWS.APIGateway.Logging.Medium.0567 | AC_AWS_0014 |
 
 
 ### aws_elasticsearch_domain
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | ElasticSearch | MEDIUM | Enable AWS ElasticSearch Encryption At Rest | AWS.ElasticSearch.EKM.Medium.0778 |
-| Encryption and Key Management | ElasticSearch | MEDIUM | ElasticSearch Domain Encrypted with KMS CMKs | AWS.ElasticSearch.EKM.Medium.0768 |
-| Logging | Elasticsearch | MEDIUM | Ensure that your AWS Elasticsearch clusters have enabled the support for publishing slow logs to AWS CloudWatch Logs. This feature enables you to publish slow logs from the indexing and search operations performed on your ES clusters and gain full insight into the performance of these operations. | AWS.Elasticsearch.Logging.Medium.0573 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ElasticSearch | HIGH | Enable AWS ElasticSearch Encryption At Rest | AWS.ElasticSearch.EKM.Medium.0778 | AC_AWS_0112 |
+| Infrastructure Security | ElasticSearch | MEDIUM | Ensure Elasticsearch domains being created are set to be encrypted node-to-node | AWS.ElasticSearch.IS.MEDIUM.0045 | AC_AWS_0468 |
+| Data Protection | ElasticSearch | MEDIUM | ElasticSearch Domain Encrypted with KMS CMKs | AWS.ElasticSearch.EKM.Medium.0768 | AC_AWS_0111 |
+| Compliance Validation | Elasticsearch | MEDIUM | Ensure that your AWS Elasticsearch clusters have enabled the support for publishing slow logs to AWS CloudWatch Logs. This feature enables you to publish slow logs from the indexing and search operations performed on your ES clusters and gain full insight into the performance of these operations. | AWS.Elasticsearch.Logging.Medium.0573 | AC_AWS_0105 |
 
 
 ### aws_iam_user_login_profile
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | Iam | HIGH | Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are comprised of different character sets, have minimal length, rotation and history restrictions | AWS.Iam.IAM.High.0391 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Compliance Validation | Iam | HIGH | Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are comprised of different character sets, have minimal length, rotation and history restrictions | AWS.Iam.IAM.High.0391 | AC_AWS_0148 |
 
 
 ### aws_iam_group_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamPolicy | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AWS.IamPolicy.IAM.High.0392 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | json | HIGH | It is recommended and considered a standard security advice to grant least privileges that is, granting only the permissions required to perform a task. IAM policies are the means by which privileges are granted to users, groups, or roles. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of granting full administrative privileges. | AC-AW-IA-H-0392 | AC_AWS_0143 |
 
 
 ### aws_load_balancer_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | ELB | HIGH | Using insecure ciphers for your ELB Predefined or Custom Security Policy, could make the SSL connection between the client and the load balancer vulnerable to exploits. TLS 1.0 was recommended to be disabled by PCI Council after June 30, 2016 | AWS.ELB.EncryptionandKeyManagement.High.0401 |
-| Encryption and Key Management | ELB | HIGH | Remove insecure ciphers for your ELB Predefined or Custom Security Policy, to reduce the risk of the SSL connection between the client and the load balancer being exploited. | AWS.ELB.EncryptionandKeyManagement.High.0403 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | ELB | HIGH | Using insecure ciphers for your ELB Predefined or Custom Security Policy, could make the SSL connection between the client and the load balancer vulnerable to exploits. TLS 1.0 was recommended to be disabled by PCI Council after June 30, 2016 | AWS.ELB.EncryptionandKeyManagement.High.0401 | AC_AWS_0172 |
+| Infrastructure Security | ELB | HIGH | Remove insecure ciphers for your ELB Predefined or Custom Security Policy, to reduce the risk of the SSL connection between the client and the load balancer being exploited. | AWS.ELB.EncryptionandKeyManagement.High.0403 | AC_AWS_0171 |
 
 
 ### aws_s3_bucket
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0377 |
-| Network Security | S3Bucket | HIGH | Ensure that there are not any static websites being hosted on buckets you aren't aware of | AWS.S3Bucket.NetworkSecurity.High.0417 |
-| IAM | S3Bucket | HIGH | Enabling S3 versioning will enable easy recovery from both unintended user actions, like deletes and overwrites | AWS.S3Bucket.IAM.High.0370 |
-| S3 | S3Bucket | HIGH | S3 bucket Access is allowed to all AWS Account Users. | AWS.S3Bucket.DS.High.1043 |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0379 |
-| Encryption and Key Management | S3Bucket | HIGH | Ensure that S3 Buckets have server side encryption at rest enabled with KMS key to protect sensitive data. | AWS.S3Bucket.EncryptionandKeyManagement.High.0405 |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0378 |
-| IAM | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0381 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0377 | AC_AWS_0210 |
+| Identity and Access Management | S3Bucket | HIGH | Ensure S3 buckets do not have, a both public ACL on the bucket and a public access block. | AWS.S3Bucket.IAM.HIGH.0065 | AC_AWS_0496 |
+| Logging and Monitoring | S3Bucket | MEDIUM | Ensure S3 buckets have access logging enabled. | AWS.S3Bucket.LM.MEDIUM.0078 | AC_AWS_0497 |
+| Infrastructure Security | S3Bucket | LOW | Ensure that there are not any static websites being hosted on buckets you aren't aware of | AWS.S3Bucket.NetworkSecurity.High.0417 | AC_AWS_0208 |
+| Resilience | S3Bucket | HIGH | Enabling S3 versioning will enable easy recovery from both unintended user actions, like deletes and overwrites | AWS.S3Bucket.IAM.High.0370 | AC_AWS_0214 |
+| Identity and Access Management | S3Bucket | HIGH | S3 bucket Access is allowed to all AWS Account Users. | AWS.S3Bucket.DS.High.1043 | AC_AWS_0215 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0379 | AC_AWS_0212 |
+| Data Protection | S3Bucket | HIGH | Ensure that S3 Buckets have server side encryption at rest enabled with KMS key to protect sensitive data. | AWS.S3Bucket.EncryptionandKeyManagement.High.0405 | AC_AWS_0207 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0378 | AC_AWS_0211 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0381 | AC_AWS_0213 |
+
+
+### aws_eks_cluster
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | AEC | MEDIUM | Ensure EKS clusters have control plane logging enabled. | AWS.AEC.LM.MEDIUM.0071 | AC_AWS_0465 |
 
 
 ### aws_elb
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Ports Security | ELB | LOW | AWS ELB incoming traffic not encrypted | AWS.ELB.NetworkPortsSecurity.Low.0563 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | ELB | MEDIUM | Ensure AWS ELB has access logging enabled. | AWS.ELB.LM.MEDIUM.0072 | AC_AWS_0470 |
+| Infrastructure Security | ELB | LOW | AWS ELB incoming traffic not encrypted | AWS.ELB.NetworkPortsSecurity.Low.0563 | AC_AWS_0120 |
 
 
 ### aws_redshift_cluster
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | Redshift | HIGH | Ensure Redshift clusters are not publicly accessible to minimize security risks. | AWS.Redshift.NetworkSecurity.HIGH.0564 |
-| Logging | Redshift | MEDIUM | Ensure audit logging is enabled for Redshift clusters for security and troubleshooting purposes. | AWS.Redshift.Logging.Medium.0565 |
-| Encryption and Key Management | Redshift | HIGH | Use customer-managed KMS keys instead of AWS-managed keys, to have granular control over encrypting and encrypting data. Encrypt Redshift clusters with a Customer-managed KMS key. This is a recommended best practice. | AWS.Redshift.EncryptionandKeyManagement.High.0415 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | Redshift | HIGH | Ensure Redshift clusters are not publicly accessible to minimize security risks. | AWS.Redshift.NetworkSecurity.HIGH.0564 | AC_AWS_0199 |
+| Logging and Monitoring | Redshift | LOW | Ensure AWS Redshift cluster instances have logging enabled. | AWS.Redshift.Logging.Medium.0565 | AC_AWS_0200 |
+| Data Protection | Redshift | MEDIUM | Use customer-managed KMS keys instead of AWS-managed keys, to have granular control over encrypting and encrypting data. Encrypt Redshift clusters with a Customer-managed KMS key. This is a recommended best practice. | AWS.Redshift.EncryptionandKeyManagement.High.0415 | AC_AWS_0198 |
+
+
+### aws_elasticcache_replication_group
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | AERG | MEDIUM | Ensure Elastic Cache Replication Group is encrypted at rest | AWS.AERG.DP.MEDIUM.0027 | AC_AWS_0466 |
+| Data Protection | AERG | MEDIUM | Ensure Elastic Cache Replication Group is encrypted in transit | AWS.AERG.DP.MEDIUM.0044 | AC_AWS_0467 |
 
 
 ### aws_kinesis_stream
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | Kinesis | HIGH | Kinesis Streams and metadata are not protected | AWS.Kinesis.EncryptionandKeyManagement.High.0412 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | Kinesis | HIGH | Ensure Kinesis Stream is encrypted | AWS.Kinesis.EncryptionandKeyManagement.High.0412 | AC_AWS_0157 |
 
 
 ### aws_config_configuration_aggregator
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | Config | HIGH | Ensure AWS Config is enabled in all regions | AWS.Config.Logging.HIGH.0590 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | Config | HIGH | Ensure AWS Config is enabled in all regions | AWS.Config.Logging.HIGH.0590 | AC_AWS_0049 |
 
 
-### aws_organizations_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| IAM | Organizations | MEDIUM | Ensure that All Features is enabled within your Amazon Organizations to achieve full control over the use of AWS services and actions across multiple AWS accounts using Service Control Policies (SCPs). | AWS.Organizations.IAM.MEDIUM.0590 |
+### aws_s3_bucket_object
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ASBO | MEDIUM | Ensure S3 object is Encrypted | AWS.ASBO.DP.MEDIUM.0034 | AC_AWS_0498 |
 
 
 ### aws_route53_query_log
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | Route53 query logs | MEDIUM | Ensure CloudWatch logging is enabled for Route53 hosted zones. | AWS.Route53 query logs.Logging.Medium.0574 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | Route53 query logs | MEDIUM | Ensure CloudWatch logging is enabled for Route53 hosted zones. | AWS.Route53querylogs.Logging.Medium.0574 | AC_AWS_0204 |
+
+
+### aws_secretsmanager_secret
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | SecretsManagerSecret | MEDIUM | Ensure SecretsManager Secrets are Encrypted using KMS key | AWS.SecretsManagerSecret.DP.MEDIUM.0036 | AC_AWS_0500 |
 
 
 ### aws_iam_access_key
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | IamUser | HIGH | The root account is the most privileged user in an AWS account. AWS Access Keys provide programmatic access to a given AWS account. It is recommended that all access keys associated with the root account be removed. Removing access keys associated with the root account limits vectors by which the account can be compromised. Additionally, removing the root access keys encourages the creation and use of role based accounts that are least privileged. | AWS.IamUser.IAM.High.0390 |
-| Identity and Access Management | IamUser | MEDIUM | Ensure that there are no exposed Amazon IAM access keys in order to protect your AWS resources against unapproved access | AWS.IamUser.IAM.High.0391 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | IamUser | HIGH | The root account is the most privileged user in an AWS account. AWS Access Keys provide programmatic access to a given AWS account. It is recommended that all access keys associated with the root account be removed. Removing access keys associated with the root account limits vectors by which the account can be compromised. Additionally, removing the root access keys encourages the creation and use of role based accounts that are least privileged. | AWS.IamUser.IAM.High.0390 | AC_AWS_0132 |
+| Identity and Access Management | IamUser | MEDIUM | Ensure that there are no exposed Amazon IAM access keys in order to protect your AWS resources against unapproved access | AWS.IamUser.IAM.High.0391 | AC_AWS_0133 |
+
+
+### aws_neptune_cluster
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ANC | MEDIUM | Ensure Neptune Cluster is Encrypted | AWS.ANC.DP.MEDIUM.0030 | AC_AWS_0493 |
+| Logging and Monitoring | ANC | MEDIUM | Ensure AWS Neptune clusters have logging enabled. | AWS.ANC.LM.MEDIUM.0075 | AC_AWS_0494 |
+
+
+### aws_dax_cluster
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ADC | MEDIUM | Ensure server-side encryption is enabled for AWS DAX Cluster | AWS.ADC.DP.MEDIUM.0021 | AC_AWS_0375 |
 
 
 ### aws_guardduty_detector
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | GuardDuty Enabled | MEDIUM | Ensure that Amazon GuardDuty service is currently enabled in all regions in order to protect your AWS environment and infrastructure (AWS accounts and resources, IAM credentials, guest operating systems, applications, etc) against security threats. AWS GuardDuty is a managed threat detection service that continuously monitors your VPC flow logs, AWS CloudTrail event logs and DNS logs for malicious or unauthorized behavior. The service monitors for activity such as unusual API calls, potentially compromised EC2 instances or potentially unauthorized deployments that indicate a possible AWS account compromise. AWS GuardDuty operates entirely on Amazon Web Services infrastructure and does not affect the performance or reliability of your applications. The service does not require any software agents, sensors or network appliances. | AWS.GuardDuty Enabled.Security.Medium.0575 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | GuardDuty Enabled | MEDIUM | Ensure that Amazon GuardDuty service is currently enabled in all regions in order to protect your AWS environment and infrastructure (AWS accounts and resources, IAM credentials, guest operating systems, applications, etc) against security threats. AWS GuardDuty is a managed threat detection service that continuously monitors your VPC flow logs, AWS CloudTrail event logs and DNS logs for malicious or unauthorized behavior. The service monitors for activity such as unusual API calls, potentially compromised EC2 instances or potentially unauthorized deployments that indicate a possible AWS account compromise. AWS GuardDuty operates entirely on Amazon Web Services infrastructure and does not affect the performance or reliability of your applications. The service does not require any software agents, sensors or network appliances. | AWS.GuardDutyEnabled.Security.Medium.0575 | AC_AWS_0131 |
 
 
 ### aws_db_security_group
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | RDS | HIGH | RDS should not be defined with public interface. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0101 |
-| Network Security | RDS | HIGH | RDS should not be open to a large scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0103 |
-| Network Security | RDS | HIGH | RDS should not be open to a public scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0102 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | RDS | HIGH | RDS should not be defined with public interface. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0101 | AC_AWS_0066 |
+| Infrastructure Security | RDS | HIGH | RDS should not be open to a large scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0103 | AC_AWS_0065 |
+| Infrastructure Security | RDS | HIGH | RDS should not be open to a public scope. Firewall and router configurations should be used to restrict connections between untrusted networks and any system components in the cloud environment. | AWS.RDS.NetworkSecurity.High.0102 | AC_AWS_0067 |
 
 
 ### aws_s3_bucket_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0371 |
-| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0376 |
-| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0375 |
-| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0374 |
-| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0372 |
-| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0373 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0371 | AC_AWS_0217 |
+| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0376 | AC_AWS_0224 |
+| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0375 | AC_AWS_0221 |
+| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0374 | AC_AWS_0220 |
+| Identity and Access Management | S3Bucket | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.S3Bucket.IAM.High.0372 | AC_AWS_0218 |
+| Identity and Access Management | IamPolicy | HIGH | Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion | AWS.IamPolicy.IAM.High.0373 | AC_AWS_0219 |
 
 
 ### aws_ami
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & KeyManagement | EC2 | MEDIUM | Enable AWS AMI Encryption | AWS.EC2.Encryption&KeyManagement.Medium.0688 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | EC2 | MEDIUM | Enable AWS AMI Encryption | AWS.EC2.EncryptionandKeyManagement.Medium.0688 | AC_AWS_0005 |
 
 
 ### aws_elasticache_cluster
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Data Security | ElastiCache | HIGH | ElastiCache for Redis version is not compliant with AWS PCI DSS requirements | AWS.ElastiCache.DataSecurity.High.0425 |
-| Data Security | ElastiCache | HIGH | ElastiCache for Memcached is not in use in AWS PCI DSS environments | AWS.ElastiCache.DataSecurity.High.0424 |
-| High Availability | ElastiCache | MEDIUM | AWS ElastiCache Multi-AZ | AWS.ElastiCache.HighAvailability.Medium.0757 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Compliance Validation | ElastiCache | HIGH | ElastiCache for Redis version is not compliant with AWS PCI DSS requirements | AWS.ElastiCache.DataSecurity.High.0425 | AC_AWS_0102 |
+| Compliance Validation | ElastiCache | HIGH | ElastiCache for Memcached is not in use in AWS PCI DSS environments | AWS.ElastiCache.DataSecurity.High.0424 | AC_AWS_0103 |
+| Resilience | ElastiCache | MEDIUM | AWS ElastiCache Multi-AZ | AWS.ElastiCache.HighAvailability.Medium.0757 | AC_AWS_0104 |
 
 
 ### aws_kinesis_firehose_delivery_stream
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | Kinesis | HIGH | AWS Kinesis Server data at rest has server side encryption (SSE) | AWS.Kinesis.EncryptionandKeyManagement.High.0411 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | Kinesis | HIGH | AWS Kinesis Server data at rest has server side encryption (SSE) | AWS.Kinesis.EncryptionandKeyManagement.High.0411 | AC_AWS_0156 |
 
 
 ### aws_rds_cluster
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | RDS | HIGH | Encrypt Amazon RDS instances and snapshots at rest, by enabling the encryption option for your Amazon RDS DB instance | AWS.RDS.EncryptionandKeyManagement.High.0414 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Resilience | RDS | MEDIUM | Ensure backup retention period is set for rds cluster | AWS.RDS.RE.MEDIUM.0013 | AC_AWS_0495 |
+| Data Protection | RDS | HIGH | Encrypt Amazon RDS instances and snapshots at rest, by enabling the encryption option for your Amazon RDS DB instance | AWS.RDS.EncryptionandKeyManagement.High.0414 | AC_AWS_0186 |
 
 
 ### aws_cloudtrail
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | CloudTrail | HIGH | Cloud Trail Log Not Enabled | AWS.CloudTrail.Logging.High.0399 |
-| Logging | CloudTrail | MEDIUM | Cloud Trail Multi Region not enabled | AWS.CloudTrail.Logging.Medium.0460 |
-| Logging | CloudTrail | MEDIUM | Ensure appropriate subscribers to each SNS topic | AWS.CloudTrail.Logging.Low.0559 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | CloudTrail | HIGH | Ensure CloudTrail logs are encrypted using KMS | AWS.CloudTrail.Logging.High.0399 | AC_AWS_0033 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Cloud Trail Multi Region not enabled | AWS.CloudTrail.Logging.Medium.004 | AC_AWS_0448 |
+| Security Best Practices | CloudTrail | MEDIUM | Ensure that EC2 is EBS optimized | AWS.CloudTrail.Logging.Medium.008 | AC_AWS_0449 |
+| Security Best Practices | CloudTrail | LOW | ECR should have an image tag be immutable | AWS.CloudTrail.Logging.Low.009 | AC_AWS_0447 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Cloud Trail Multi Region not enabled | AWS.CloudTrail.Logging.Medium.0460 | AC_AWS_0034 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Ensure CloudTrail has log file validation enabled. | AWS.CloudTrail.LM.MEDIUM.0087 | AC_AWS_0446 |
+| Logging and Monitoring | CloudTrail | MEDIUM | Ensure appropriate subscribers to each SNS topic | AWS.CloudTrail.Logging.Low.0559 | AC_AWS_0035 |
+| Logging and Monitoring | Config | Medium | Ensure AWS Config is enabled in all regions | AWS.Config.Logging.Medium.0590 | AC_AWS_0450 |
+
+
+### aws_sagemaker_notebook_instance
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | ASNI | MEDIUM | Ensure SageMaker Instance is Encrypted | AWS.ASNI.DP.MEDIUM.0035 | AC_AWS_0499 |
 
 
 ### aws_lambda_function
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | LambdaFunction | Low | Lambda function does not include a VPC configuration. | AWS.LambdaFunction.Logging.0472 |
-| Logging | LambdaFunction | LOW | Lambda tracing is not enabled. | AWS.LambdaFunction.Logging.0470 |
-| Encryption and Key Management | LambdaFunction | High | Lambda does not use KMS CMK key to protect environment variables. | AWS.LambdaFunction.EncryptionandKeyManagement.0471 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | LambdaFunction | MEDIUM | Ensure AWS Lambda function has policy attached. | AWS.LambdaFunction.LM.MEIDUM.0063 | AC_AWS_0484 |
+| Infrastructure Security | LambdaFunction | Low | Lambda function does not include a VPC configuration. | AWS.LambdaFunction.Logging.0472 | AC_AWS_0486 |
+| Logging and Monitoring | LambdaFunction | LOW | Lambda tracing is not enabled. | AWS.LambdaFunction.Logging.0470 | AC_AWS_0485 |
+| Data Protection | LambdaFunction | High | Lambda does not use KMS CMK key to protect environment variables. | AWS.LambdaFunction.EncryptionandKeyManagement.0471 | AC_AWS_0483 |
+| Logging and Monitoring | LambdaFunction | LOW | Lambda tracing is not enabled. | AWS.LambdaFunction.Logging.0470 | AC_AWS_0163 |
 
 
 ### aws_kms_key
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | KMS | HIGH | Ensure rotation for customer created CMKs is enabled | AWS.KMS.Logging.High.0400 |
-| Network Security | KMS | HIGH | Identify any publicly accessible AWS Key Management Service master keys and update their access policy in order to stop any unsigned requests made to these resources. | AWS.KMS.NetworkSecurity.High.0566 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | AKK | HIGH | Ensure IAM policies do not have 'Principal' element missing from the policy statement. | AWS.AKK.IAM.HIGH.0012 | AC_AWS_0481 |
+| Identity and Access Management | KMS | HIGH | Identify any publicly accessible AWS Key Management Service master keys and update their access policy in order to stop any unsigned requests made to these resources. | AWS.KMS.NetworkSecurity.High.0566 | AC_AWS_0162 |
+| Data Protection | AKK | HIGH | Ensure rotation for customer created CMKs is enabled | AWS.AKK.DP.HIGH.0012 | AC_AWS_0160 |
+| Identity and Access Management | AKK | HIGH | Ensure KMS key policy does not have wildcard policies attached. | AWS.AKK.IAM.HIGH.0082 | AC_AWS_0482 |
 
 
 ### aws_security_group
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Debugger' (TCP:135) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0236 |
-| Network Ports Security | ALB | MEDIUM | 'Cassandra OpsCenter agent port' (TCP:61621) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0220 |
-| Network Ports Security | SecurityGroup | HIGH | remote desktop port open to internet | AWS.SecurityGroup.NetworkPortsSecurity.Low.0562 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (TCP:11214) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0240 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Datagram Service' (TCP:138) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0256 |
-| Network Ports Security | ALB | MEDIUM | 'SNMP' (UDP:161) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0276 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Session Service' (TCP:139) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0260 |
-| Network Ports Security | ALB | MEDIUM | 'LDAP SSL ' (TCP:636) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0230 |
-| Network Ports Security | ALB | MEDIUM | 'Known internal web port' (TCP:8000) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0226 |
-| Network Ports Security | ALB | MEDIUM | 'Postgres SQL' (UDP:5432) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0270 |
-| Network Ports Security | SecurityGroup | HIGH | It is recommended that no security group allows unrestricted ingress access | AWS.SecurityGroup.NPS.High.1045 |
-| Network Ports Security | ALB | MEDIUM | 'Oracle DB SSL' (UDP:2484) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0266 |
-| Network Ports Security | SecurityGroup | HIGH | A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic. Configuring the default security group to restrict all traffic will encourage least privilege security group development and mindful placement of AWS resource into security groups which will in-turn reduce the exposure of those resources. | AWS.SecurityGroup.NetworkSecurity.High.0097 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (UDP:11215) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0246 |
-| Network Ports Security | ALB | MEDIUM | 'SaltStack Master' (TCP:4505) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0196 |
-| Network Ports Security | ALB | MEDIUM | 'MySQL' (TCP:3306) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0250 |
-| Network Ports Security | ALB | MEDIUM | 'Known internal web port' (TCP:8080) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0228 |
-| Network Ports Security | SecurityGroup | HIGH |  It is recommended that no security group allows unrestricted ingress access | AWS.SecurityGroup.NetworkSecurity.High.0094 |
-| Network Ports Security | ALB | MEDIUM | 'Hadoop Name Node' (TCP:9000) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0224 |
-| Network Ports Security | SecurityGroup | HIGH | Unknown Port is exposed to the entire internet | AWS.SecurityGroup.NPS.High.1046 |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Admin' (TCP:1434) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0232 |
-| Network Ports Security | ALB | MEDIUM | 'Mongo Web Portal' (TCP:27018) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0248 |
-| Network Ports Security | ALB | MEDIUM | 'Oracle DB SSL' (TCP:2484) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0264 |
-| Network Ports Security | ALB | MEDIUM | 'Prevalent known internal port' (TCP:3000) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0272 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Name Service' (TCP:137) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0252 |
-| Network Ports Security | ALB | HIGH | 'SSH' (TCP:22) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0194 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (UDP:11214) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0244 |
-| Network Ports Security | ALB | MEDIUM | 'Postgres SQL' (TCP:5432) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0268 |
-| Network Ports Security | ALB | MEDIUM | 'Cassandra' (TCP:7001) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0222 |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Browser Service' (UDP:1434) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0234 |
-| Network Ports Security | ALB | MEDIUM | 'CIFS / SMB' (TCP:3020) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0218 |
-| Network Ports Security | ALB | MEDIUM | 'SQL Server Analysis Services' (TCP:2383) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0280 |
-| Network Ports Security | ALB | MEDIUM | 'MSSQL Server' (TCP:1433) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0238 |
-| Network Ports Security | SecurityGroup | HIGH | ssh port open to internet | AWS.SecurityGroup.NetworkPortsSecurity.Low.0560 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Name Service' (UDP:137) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0254 |
-| Network Ports Security | SecurityGroup | HIGH | http port open to internet | AWS.SecurityGroup.NetworkPortsSecurity.Low.0561 |
-| Network Ports Security | ALB | MEDIUM | 'Memcached SSL' (TCP:11215) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0242 |
-| Network Ports Security | ALB | MEDIUM | 'SQL Server Analysis Service browser' (TCP:2382) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0278 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Datagram Service' (UDP:138) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0258 |
-| Network Ports Security | ALB | MEDIUM | 'NetBIOS Session Service' (UDP:139) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0262 |
-| Network Ports Security | ALB | MEDIUM | 'Puppet Master' (TCP:8140) is accessible by a CIDR block range | AWS.ALB.NetworkPortsSecurity.High.0274 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP,11214) is not accessible by a public CIDR block range | AC_AWS_0292 | AC_AWS_0292 |
+| Infrastructure Security | json | LOW | Ensure Cassandra' (TCP,7001) is not exposed to private hosts more than 32 | AC_AWS_0338 | AC_AWS_0338 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP,8080) is not accessible by a CIDR block range | AC_AWS_0284 | AC_AWS_0284 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (TCP,2484) is not accessible by a public CIDR block range | AC_AWS_0302 | AC_AWS_0302 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Server (TCP,1433) | AC_AWS_0247 | AC_AWS_0247 |
+| Infrastructure Security | json | LOW | Ensure SNMP' (UDP,161) is not exposed to private hosts more than 32 | AC_AWS_0355 | AC_AWS_0355 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSNameService' (TCP,137) is not exposed to private hosts more than 32 | AC_AWS_0343 | AC_AWS_0343 |
+| Infrastructure Security | json | HIGH | Ensure SMTP (TCP,25) is not accessible by a public CIDR block range | AC_AWS_0314 | AC_AWS_0314 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (UDP,11215) | AC_AWS_0251 | AC_AWS_0251 |
+| Infrastructure Security | json | LOW | Ensure Elasticsearch' (TCP,9300) is not exposed to private hosts more than 32 | AC_AWS_0363 | AC_AWS_0363 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Telnet (TCP,23) | AC_AWS_0271 | AC_AWS_0271 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (UDP,11214) is not exposed to  private hosts more than 32 | AC_AWS_0334 | AC_AWS_0334 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SQL Server Analysis Service browser (TCP,2382) | AC_AWS_0267 | AC_AWS_0267 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Debugger (TCP,135) is not accessible by a public CIDR block range | AC_AWS_0288 | AC_AWS_0288 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports https (TCP,443) is not exposed to private hosts more than 32 | AC_AWS_0322 | AC_AWS_0322 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - remote desktop port (TCP,3389) | AC_AWS_0230 | AC_AWS_0230 |
+| Infrastructure Security | json | LOW | Ensure Telnet' (TCP,23) is not exposed to private hosts more than 32 | AC_AWS_0359 | AC_AWS_0359 |
+| Infrastructure Security | json | HIGH | Ensure Elasticsearch (TCP,9300) is not accessible by a public CIDR block range | AC_AWS_0318 | AC_AWS_0318 |
+| Infrastructure Security | json | LOW | Ensure SSH (TCP,22) is not accessible by a public CIDR block range | AC_AWS_0319 | AC_AWS_0319 |
+| Infrastructure Security | json | LOW | Ensure OracleDatabaseServer' (TCP,521) is not exposed to private hosts more than 32 | AC_AWS_0358 | AC_AWS_0358 |
+| Infrastructure Security | json | HIGH | Ensure no security groups allow ingress from 0.0.0.0/0 to ALL ports and protocols | AC_AWS_0231 | AC_AWS_0231 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SNMP (UDP,161) | AC_AWS_0266 | AC_AWS_0266 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Server (TCP,1433) is not accessible by a public CIDR block range | AC_AWS_0289 | AC_AWS_0289 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports remote desktop port (TCP,3389) is not exposed to private hosts more than 32 | AC_AWS_0323 | AC_AWS_0323 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Oracle Database Server (TCP,1521) | AC_AWS_0270 | AC_AWS_0270 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (UDP,11215) is not exposed to  private hosts more than 32 | AC_AWS_0335 | AC_AWS_0335 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - (SSH,22) | AC_AWS_0227 | AC_AWS_0227 |
+| Infrastructure Security | json | LOW | Ensure MongoDB' (TCP,27017) is not exposed to private hosts more than 32 | AC_AWS_0362 | AC_AWS_0362 |
+| Infrastructure Security | json | HIGH | Ensure CIFS for file/printer (TCP,445) is not accessible by a public CIDR block range | AC_AWS_0315 | AC_AWS_0315 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (UDP,11214) | AC_AWS_0250 | AC_AWS_0250 |
+| Infrastructure Security | json | LOW | Ensure MongoWebPortal' (TCP,27018) is not exposed to private hosts more than 32 | AC_AWS_0342 | AC_AWS_0342 |
+| Infrastructure Security | json | LOW | Ensure PuppetMaster' (TCP,8140) is not exposed to private hosts more than 32 | AC_AWS_0354 | AC_AWS_0354 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (UDP,2484) is not accessible by a public CIDR block range | AC_AWS_0303 | AC_AWS_0303 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Debugger (TCP,135) | AC_AWS_0246 | AC_AWS_0246 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP SSL (TCP,636) is not accessible by a public CIDR block range | AC_AWS_0285 | AC_AWS_0285 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP,11215) is not accessible by a public CIDR block range | AC_AWS_0293 | AC_AWS_0293 |
+| Infrastructure Security | json | LOW | Ensure HadoopNameNode' (TCP,9000) is not exposed to private hosts more than 32 | AC_AWS_0339 | AC_AWS_0339 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP,4505) is not accessible by a public CIDR block range | AC_AWS_0277 | AC_AWS_0277 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (TCP,11214) is not exposed to private hosts more than 32 | AC_AWS_0332 | AC_AWS_0332 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (TCP,138) is not accessible by a public CIDR block range | AC_AWS_0298 | AC_AWS_0298 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Oracle DB SSL (UDP,2484) | AC_AWS_0261 | AC_AWS_0261 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports Elasticsearch (TCP,9200) is not exposed to  private hosts more than 32 | AC_AWS_0324 | AC_AWS_0324 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SaltStack Master (TCP,4506) | AC_AWS_0236 | AC_AWS_0236 |
+| Infrastructure Security | json | MEDIUM | Ensure SNMP (UDP,161) is not accessible by a public CIDR block range | AC_AWS_0308 | AC_AWS_0308 |
+| Infrastructure Security | json | LOW | Ensure OracleDBSSL' (TCP,2484) is not exposed to private hosts more than 32 | AC_AWS_0349 | AC_AWS_0349 |
+| Infrastructure Security | json | MEDIUM | Ensure Mongo Web Portal (TCP,27018) is not accessible by a public CIDR block range | AC_AWS_0294 | AC_AWS_0294 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLAdmin (TCP,1434) is not exposed to private hosts more than 32 | AC_AWS_0328 | AC_AWS_0328 |
+| Infrastructure Security | json | MEDIUM | Ensure Hadoop Name Node (TCP,9000) is not accessible by a public CIDR block range | AC_AWS_0282 | AC_AWS_0282 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (TCP,5432) is not accessible by a public CIDR block range | AC_AWS_0304 | AC_AWS_0304 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Known internal web port (TCP,8000) | AC_AWS_0241 | AC_AWS_0241 |
+| Infrastructure Security | json | LOW | Ensure Prevalentknowninternalport' (TCP,3000) is not exposed to private hosts more than 32 | AC_AWS_0353 | AC_AWS_0353 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSNameService' (UDP,137) is not exposed to private hosts more than 32 | AC_AWS_0345 | AC_AWS_0345 |
+| Infrastructure Security | json | HIGH | Ensure Oracle Database Server (TCP,1521) is not accessible by a public CIDR block range | AC_AWS_0312 | AC_AWS_0312 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Datagram Service (UDP,138) | AC_AWS_0257 | AC_AWS_0257 |
+| Infrastructure Security | json | HIGH | Ensure Telnet (TCP,23) is not accessible by a public CIDR block range | AC_AWS_0313 | AC_AWS_0313 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Datagram Service (TCP,138) | AC_AWS_0256 | AC_AWS_0256 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSNameService' (UDP,137) is not exposed to private hosts more than 32 | AC_AWS_0344 | AC_AWS_0344 |
+| Infrastructure Security | json | LOW | Ensure PostgresSQL' (UDP,5432) is not exposed to private hosts more than 32 | AC_AWS_0352 | AC_AWS_0352 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (UDP,5432) is not accessible by a CIDR block range | AC_AWS_0305 | AC_AWS_0305 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Hadoop Name Node (TCP,9000) | AC_AWS_0240 | AC_AWS_0240 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLBrowserService (UDP,1434) is not exposed to private hosts more than 32 | AC_AWS_0329 | AC_AWS_0329 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP,8000) is not accessible by a public CIDR block range | AC_AWS_0283 | AC_AWS_0283 |
+| Infrastructure Security | json | MEDIUM | Ensure MySQL (TCP,3306) is not accessible by a public CIDR block range | AC_AWS_0295 | AC_AWS_0295 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSSessionService' (UDP,139) is not exposed to private hosts more than 32 | AC_AWS_0348 | AC_AWS_0348 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Service browser (TCP,2382) is not accessible by a public CIDR block range | AC_AWS_0309 | AC_AWS_0309 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - CIFS / SMB (TCP,3020) | AC_AWS_0237 | AC_AWS_0237 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Oracle DB SSL (TCP,2484) | AC_AWS_0260 | AC_AWS_0260 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports SaltStackMaster (TCP,4506) is not exposed to private hosts more than 32 | AC_AWS_0325 | AC_AWS_0325 |
+| Infrastructure Security | json | HIGH | Ensure Unknown Port is not exposed to the entire internet | AC_AWS_0276 | AC_AWS_0276 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MemcachedSSL (TCP,11215) is not exposed to private hosts more than 32 | AC_AWS_0333 | AC_AWS_0333 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (UDP,138) is not accessible by a public CIDR block range | AC_AWS_0299 | AC_AWS_0299 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Session Service (UDP,139) | AC_AWS_0259 | AC_AWS_0259 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Elasticsearch (TCP,9200) | AC_AWS_0234 | AC_AWS_0234 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports CassandraOpsCenteragent (TCP,61621) is not exposed to private hosts more than 32 | AC_AWS_0326 | AC_AWS_0326 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Postgres SQL (UDP,5432) | AC_AWS_0263 | AC_AWS_0263 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLDebugger (TCP,135) is not exposed to private hosts more than 32 | AC_AWS_0330 | AC_AWS_0330 |
+| Infrastructure Security | json | HIGH | Ensure no security groups is wide open to public, that is, allows traffic from 0.0.0.0/0 to ALL ports and protocols | AC_AWS_0275 | AC_AWS_0275 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Name Service (UDP,137) | AC_AWS_0255 | AC_AWS_0255 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Services (TCP,2383) is not accessible by a public CIDR block range | AC_AWS_0310 | AC_AWS_0310 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSSessionService' (TCP,139) is not exposed to private hosts more than 32 | AC_AWS_0347 | AC_AWS_0347 |
+| Infrastructure Security | json | LOW | Ensure PostgresSQL' (TCP,5432) is not exposed to private hosts more than 32 | AC_AWS_0351 | AC_AWS_0351 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - LDAP SSL (TCP,636) | AC_AWS_0243 | AC_AWS_0243 |
+| Infrastructure Security | json | MEDIUM | Ensure Prevalent known internal port (TCP,3000) is not accessible by a public CIDR block range | AC_AWS_0306 | AC_AWS_0306 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Cassandra OpsCenter agent (TCP,61621) | AC_AWS_0238 | AC_AWS_0238 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter agent port (TCP,61621) is not accessible by a public CIDR block range | AC_AWS_0280 | AC_AWS_0280 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (TCP,137) is not accessible by a public CIDR block range | AC_AWS_0296 | AC_AWS_0296 |
+| Infrastructure Security | json | MEDIUM | Ensure CIFS / SMB (TCP,3020) is not accessible by a public CIDR block range | AC_AWS_0279 | AC_AWS_0279 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (UDP,137) is not accessible by a public CIDR block range | AC_AWS_0297 | AC_AWS_0297 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP,4506) is not accessible by a public CIDR block range | AC_AWS_0278 | AC_AWS_0278 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra (TCP,7001) is not accessible by a public CIDR block range | AC_AWS_0281 | AC_AWS_0281 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Cassandra (TCP,7001) | AC_AWS_0239 | AC_AWS_0239 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Known internal web port (TCP,8080) | AC_AWS_0242 | AC_AWS_0242 |
+| Infrastructure Security | json | MEDIUM | Ensure Puppet Master (TCP:8140) is not accessible by a public CIDR block range | AC_AWS_0307 | AC_AWS_0307 |
+| Infrastructure Security | json | LOW | Ensure OracleDBSSL' (UDP,2484) is not exposed to private hosts more than 32 | AC_AWS_0350 | AC_AWS_0350 |
+| Infrastructure Security | json | LOW | Ensure NetBIOSDatagramService' (UDP,138) is not exposed to private hosts more than 32 | AC_AWS_0346 | AC_AWS_0346 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Name Service (TCP,137) | AC_AWS_0254 | AC_AWS_0254 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP,4505) is not accessible by a public CIDR block range | AC_AWS_0311 | AC_AWS_0311 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MSSQLServer (TCP,1433) is not exposed to private hosts more than 32 | AC_AWS_0331 | AC_AWS_0331 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MongoDB (TCP,27017) | AC_AWS_0274 | AC_AWS_0274 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports Knowninternalwebport (TCP,8080) is not exposed to private hosts more than 32 | AC_AWS_0327 | AC_AWS_0327 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Postgres SQL (TCP,5432) | AC_AWS_0262 | AC_AWS_0262 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Elasticsearch (TCP,9300) | AC_AWS_0235 | AC_AWS_0235 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - NetBIOS Session Service (TCP,139) | AC_AWS_0258 | AC_AWS_0258 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MySQL (TCP,3306) | AC_AWS_0253 | AC_AWS_0253 |
+| Infrastructure Security | json | HIGH | Ensure MongoDB (TCP,27017) is not accessible by a public CIDR block range | AC_AWS_0316 | AC_AWS_0316 |
+| Infrastructure Security | json | LOW | Ensure LDAPSSL' (TCP,636) is not exposed to private hosts more than 32 | AC_AWS_0341 | AC_AWS_0341 |
+| Infrastructure Security | json | LOW | Ensure SQLServerAnalysisServices' (TCP,2383) is not exposed to private hosts more than 32 | AC_AWS_0357 | AC_AWS_0357 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Browser Service (UDP,1434) | AC_AWS_0245 | AC_AWS_0245 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (TCP,139) is not accessible by a CIDR block range | AC_AWS_0300 | AC_AWS_0300 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Admin (TCP,1434) is not accessible by a public CIDR block range | AC_AWS_0286 | AC_AWS_0286 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SaltStack Master (TCP,4505) | AC_AWS_0269 | AC_AWS_0269 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP,11214) is not accessible by a public CIDR block range | AC_AWS_0290 | AC_AWS_0290 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - (HTTP,80) | AC_AWS_0228 | AC_AWS_0228 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (TCP,11215) | AC_AWS_0249 | AC_AWS_0249 |
+| Infrastructure Security | json | HIGH | Ensure no default security groups are used as they allow ingress from 0.0.0.0/0 to ALL ports and protocols | AC_AWS_0232 | AC_AWS_0232 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports SSH (TCP,22) is not exposed to private hosts more than 32 | AC_AWS_0320 | AC_AWS_0320 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Puppet Master (TCP,8140) | AC_AWS_0265 | AC_AWS_0265 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports MySQL (TCP,3306) is not exposed to private hosts more than 32 | AC_AWS_0336 | AC_AWS_0336 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - CIFS for file/printer (TCP,445) | AC_AWS_0273 | AC_AWS_0273 |
+| Infrastructure Security | json | LOW | Ensure CIFSforfile/printer' (TCP,445) is not exposed to private hosts more than 32 | AC_AWS_0361 | AC_AWS_0361 |
+| Infrastructure Security | json | LOW | Ensure SMTP' (TCP,25) is not exposed to private hosts more than 32 | AC_AWS_0360 | AC_AWS_0360 |
+| Infrastructure Security | json | LOW | Ensure CIFS/SMB' (TCP,3020) is not exposed to private hosts more than 32 | AC_AWS_0337 | AC_AWS_0337 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SMTP (TCP,25) | AC_AWS_0272 | AC_AWS_0272 |
+| Infrastructure Security | json | LOW | Ensure Security Groups Unrestricted Specific Ports http (TCP,80) is not exposed to private hosts more than 32 | AC_AWS_0321 | AC_AWS_0321 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Prevalent known internal port (TCP,3000) | AC_AWS_0264 | AC_AWS_0264 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SaltStack Master (TCP,4505) | AC_AWS_0233 | AC_AWS_0233 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Memcached SSL (TCP,11214) | AC_AWS_0248 | AC_AWS_0248 |
+| Infrastructure Security | json | LOW | Security Groups - Unrestricted Specific Ports - (HTTPS,443) | AC_AWS_0229 | AC_AWS_0229 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP,11215) is not accessible by a public CIDR block range | AC_AWS_0291 | AC_AWS_0291 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Browser Service (UDP,1434) is not accessible by a public CIDR block range | AC_AWS_0287 | AC_AWS_0287 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - SQL Server Analysis Services (TCP,2383) | AC_AWS_0268 | AC_AWS_0268 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - MSSQL Admin (TCP,1434) | AC_AWS_0244 | AC_AWS_0244 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (UDP,139) is not accessible by a CIDR block range | AC_AWS_0301 | AC_AWS_0301 |
+| Infrastructure Security | json | LOW | Ensure SQLServerAnalysisServicebrowser' (TCP,2382) is not exposed to private hosts more than 32 | AC_AWS_0356 | AC_AWS_0356 |
+| Infrastructure Security | json | LOW | Ensure Knowninternalwebport' (TCP,8000) not exposed to private hosts more than 32 | AC_AWS_0340 | AC_AWS_0340 |
+| Infrastructure Security | json | HIGH | Security Groups - Unrestricted Specific Ports - Mongo Web Portal (TCP,27018) | AC_AWS_0252 | AC_AWS_0252 |
+| Infrastructure Security | json | HIGH | Ensure Elasticsearch (TCP,9200) is not accessible by a public CIDR block range | AC_AWS_0317 | AC_AWS_0317 |
+
+
+### aws_api_gateway_method
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | APGM | LOW | Ensure there is no open access to back-end resources through API | AWS.APGM.IS.LOW.0056 | AC_AWS_0439 |
+
+
+### aws_efs_file_system_policy
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | AEFSP | HIGH | Ensure EFS file system does not use insecure wildcard policies. | AWS.AEFSP.IAM.HIGH.0059 | AC_AWS_0464 |
 
 
 ### aws_ecs_service
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | ECS | HIGH | Ensure there are no ECS services Admin roles | AWS.ECS.High.0436 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | ECS | HIGH | Ensure there are no ECS services Admin roles | AWS.ECS.High.0436 | AC_AWS_0087 |
+
+
+### aws_globalaccelerator_accelerator
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | AGA | LOW | Ensure Global Accelerator accelerator has flow logs enabled. | AWS.AGA.LM.LOW.0073 | AC_AWS_0471 |
+
+
+### aws_api_gateway_rest_api_policy
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | APGRAP | HIGH | Ensure use of API Gateway endpoint policy, and no action wildcards are being used. | AWS.APGRAP.IAM.HIGH.0064 | AC_AWS_0440 |
 
 

--- a/docs/policies/azure.md
+++ b/docs/policies/azure.md
@@ -1,402 +1,314 @@
 
-### azurerm_virtual_machine
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure that at least one Network Security Group is attached to all VMs and subnets that are public | accurics.azure.NS.18 |
-
-
 ### azurerm_storage_container
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | azure | HIGH | Anonymous, public read access to a container and its blobs can be enabled in Azure Blob storage. This is only recommended if absolutely necessary. | accurics.azure.IAM.368 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | azure | HIGH | Anonymous, public read access to a container and its blobs can be enabled in Azure Blob storage. This is only recommended if absolutely necessary. | accurics.azure.IAM.368 | AC_AZURE_0366 |
 
 
 ### azurerm_mysql_server
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for MySQL Database Server. | accurics.azure.NS.361 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for MySQL Database Server. | accurics.azure.NS.361 | AC_AZURE_0131 |
 
 
 ### azurerm_sql_firewall_rule
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Restrict Azure SQL Server accessibility to a minimal address range | accurics.azure.NS.169 |
-| Network Security | azure | HIGH | Ensure entire Azure infrastructure doesn't have access to Azure SQL ServerEnsure entire Azure infrastructure doesn't have access to Azure SQL Server | accurics.azure.NS.5 |
-| Network Security | azure | HIGH | Ensure that no SQL Server allows ingress from 0.0.0.0/0 (ANY IP) | accurics.azure.NS.21 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | MEDIUM | Restrict Azure SQL Server accessibility to a minimal address range | accurics.azure.NS.169 | AC_AZURE_0280 |
+| Infrastructure Security | azure | HIGH | Ensure entire Azure infrastructure doesn't have access to Azure SQL ServerEnsure entire Azure infrastructure doesn't have access to Azure SQL Server | accurics.azure.NS.5 | AC_AZURE_0381 |
+| Infrastructure Security | azure | MEDIUM | Ensure that no SQL Server allows ingress from 0.0.0.0/0 (ANY IP) | accurics.azure.NS.21 | AC_AZURE_0380 |
 
 
 ### azurerm_key_vault
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | MEDIUM | Ensure the key vault is recoverable - enable "Soft Delete" setting for a Key Vault | accurics.azure.EKM.164 |
-| Encryption and Key Management | azure | HIGH | Ensure that logging for Azure KeyVault is 'Enabled' | accurics.azure.EKM.20 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | azure | MEDIUM | Ensure the key vault is recoverable - enable "Soft Delete" setting for a Key Vault | accurics.azure.EKM.164 | AC_AZURE_0170 |
+| Logging and Monitoring | azure | HIGH | Ensure that logging for Azure KeyVault is 'Enabled' | accurics.azure.EKM.20 | AC_AZURE_0169 |
 
 
 ### azurerm_resource_group
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | LOW | Ensure that Azure Resource Group has resource lock enabled | accurics.azure.NS.272 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | azure | LOW | Ensure that Azure Resource Group has resource lock enabled | accurics.azure.NS.272 | AC_AZURE_0389 |
 
 
 ### azurerm_storage_account_network_rules
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure default network access rule for Storage Accounts is set to deny. | accurics.azure.NS.370 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | MEDIUM | Ensure default network access rule for Storage Accounts is set to deny. | accurics.azure.NS.370 | AC_AZURE_0309 |
 
 
 ### azurerm_storage_account
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure 'Trusted Microsoft Services' is enabled for Storage Account access | accurics.azure.NS.2 |
-| Network Security | azure | HIGH | Ensure default network access rule for Storage Accounts is not open to public | accurics.azure.NS.4 |
-| Encryption and Key Management | azure | HIGH | Ensure that 'Secure transfer required' is enabled for Storage Accounts | accurics.azure.EKM.7 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | HIGH | Ensure 'Trusted Microsoft Services' is enabled for Storage Account access | accurics.azure.NS.2 | AC_AZURE_0371 |
+| Infrastructure Security | azure | HIGH | Ensure default network access rule for Storage Accounts is not open to public | accurics.azure.NS.4 | AC_AZURE_0370 |
+| Data Protection | azure | HIGH | Ensure that 'Secure transfer required' is enabled for Storage Accounts | accurics.azure.EKM.7 | AC_AZURE_0373 |
 
 
 ### azurerm_sql_server
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for SQL servers | accurics.azure.MON.354 |
-| Identity and Access Management | azure | HIGH | Ensure that Azure Active Directory Admin is configured for SQL Server | accurics.azure.IAM.10 |
-| Identity and Access Management | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server admin account login | accurics.azure.IAM.138 |
-| Logging | azure | MEDIUM | Ensure that 'Auditing' Retention is 'greater than 90 days' for SQL servers. | accurics.azure.LOG.356 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for SQL servers | accurics.azure.MON.354 | AC_AZURE_0376 |
+| Identity and Access Management | azure | HIGH | Ensure that Azure Active Directory Admin is configured for SQL Server | accurics.azure.IAM.10 | AC_AZURE_0378 |
+| Compliance Validation | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server admin account login | accurics.azure.IAM.138 | AC_AZURE_0377 |
+| Compliance Validation | azure | LOW | Ensure that 'Auditing' Retention is 'greater than 90 days' for SQL servers. | accurics.azure.LOG.356 | AC_AZURE_0375 |
 
 
 ### azurerm_postgresql_configuration
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_duration' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.154 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server | accurics.azure.LOG.155 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_connections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.152 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.364 |
-| Logging | azure | MEDIUM | Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.153 |
-| Logging | azure | MEDIUM | Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.151 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_duration' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.154 | AC_AZURE_0411 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server | accurics.azure.LOG.155 | AC_AZURE_0410 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_connections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.152 | AC_AZURE_0413 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.364 | AC_AZURE_0409 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.153 | AC_AZURE_0412 |
+| Logging and Monitoring | azure | MEDIUM | Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server | accurics.azure.LOG.151 | AC_AZURE_0414 |
 
 
 ### azurerm_sql_database
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Threat Detection' is enabled for Azure SQL Database | accurics.azure.MON.157 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Threat Detection' is enabled for Azure SQL Database | accurics.azure.MON.157 | AC_AZURE_0383 |
 
 
 ### azurerm_redis_cache
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure that Redis is updated regularly with security and operational updates.Note this feature is only available to Premium tier Redis Caches. | accurics.azure.NS.13 |
-| Encryption and Key Management | azure | MEDIUM | Ensure that the Redis Cache accepts only SSL connections | accurics.azure.EKM.23 |
-| Network Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from other Azure sources | accurics.azure.NS.31 |
-| Network Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from the Internet | accurics.azure.NS.30 |
-| Network Security | azure | MEDIUM | Ensure there are no firewall rules allowing Redis Cache access for a large number of source IPs | accurics.azure.NS.166 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | azure | HIGH | Ensure that Redis is updated regularly with security and operational updates.Note this feature is only available to Premium tier Redis Caches. | accurics.azure.NS.13 | AC_AZURE_0393 |
+| Infrastructure Security | azure | MEDIUM | Ensure that the Redis Cache accepts only SSL connections | accurics.azure.EKM.23 | AC_AZURE_0394 |
+| Infrastructure Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from other Azure sources | accurics.azure.NS.31 | AC_AZURE_0391 |
+| Infrastructure Security | azure | HIGH | Ensure there are no firewall rules allowing unrestricted access to Redis from the Internet | accurics.azure.NS.30 | AC_AZURE_0392 |
+| Infrastructure Security | azure | MEDIUM | Ensure there are no firewall rules allowing Redis Cache access for a large number of source IPs | accurics.azure.NS.166 | AC_AZURE_0390 |
 
 
 ### azurerm_mssql_server
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for MSSQL servers | accurics.azure.MON.355 |
-| Monitoring | azure | MEDIUM | Ensure that 'Auditing' Retention is 'greater than 90 days' for MSSQL servers. | accurics.azure.LOG.357 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Auditing' is set to 'On' for MSSQL servers | accurics.azure.MON.355 | AC_AZURE_0137 |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Auditing' Retention is 'greater than 90 days' for MSSQL servers. | accurics.azure.LOG.357 | AC_AZURE_0136 |
 
 
 ### azurerm_kubernetes_cluster
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure Kube Dashboard is disabled | accurics.azure.NS.383 |
-| Network Security | azure | MEDIUM | Ensure AKS cluster has Network Policy configured. | accurics.azure.NS.382 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | MEDIUM | Ensure Kube Dashboard is disabled | accurics.azure.NS.383 | AC_AZURE_0161 |
+| Infrastructure Security | azure | MEDIUM | Ensure AKS cluster has Network Policy configured. | accurics.azure.NS.382 | AC_AZURE_0158 |
 
 
 ### azurerm_managed_disk
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | MEDIUM | Ensure that 'OS disk' are encrypted | accurics.azure.EKM.156 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | azure | MEDIUM | Ensure that 'Unattached disks' are encrypted in Azure Managed Disk | accurics.azure.EKM.156 | AC_AZURE_0143 |
 
 
 ### azurerm_network_watcher_flow_log
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Network Security Group Flow Logs should be enabled and the retention period is set to greater than or equal to 90 days. Flow logs enable capturing information about IP traffic flowing in and out of network security groups. Logs can be used to check for anomalies and give insight into suspected breaches. | accurics.azure.NS.342 |
-| Network Security | azure | HIGH | Enable Network Watcher for Azure subscriptions. Network diagnostic and visualization tools available with Network Watcher help users understand, diagnose, and gain insights to the network in Azure. | accurics.azure.NS.11 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Resilience | azure | MEDIUM | Ensure that Network Security Group Flow Log retention period is 'greater than 90 days' for Azure Network Watcher Flow Log | accurics.azure.NS.342 | AC_AZURE_0419 |
+| Logging and Monitoring | azure | HIGH | Enable Network Watcher for Azure subscriptions. Network diagnostic and visualization tools available with Network Watcher help users understand, diagnose, and gain insights to the network in Azure. | accurics.azure.NS.11 | AC_AZURE_0418 |
 
 
 ### azurerm_key_vault_secret
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Key Management | azure | HIGH | Ensure that the expiration date is set on all secrets | accurics.azure.EKM.26 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | azure | HIGH | Ensure that the expiration date is set on all secrets | accurics.azure.EKM.26 | AC_AZURE_0163 |
 
 
 ### azurerm_key_vault_key
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Key Management | azure | HIGH | Ensure that the expiration date is set on all keys | accurics.azure.EKM.25 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | azure | HIGH | Ensure that the expiration date is set on all keys | accurics.azure.EKM.25 | AC_AZURE_0164 |
 
 
 ### azurerm_security_center_contact
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | azure | MEDIUM | Ensure that 'Send email notification for high severity alerts' is set to 'On' | accurics.azure.MON.353 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | azure | MEDIUM | Ensure that 'Send email notification for high severity alerts' is set to 'On' | accurics.azure.MON.353 | AC_AZURE_0386 |
 
 
 ### azurerm_network_security_rule
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Ports Security | azure | LOW | VNC Listener (TCP:5500) is exposed to small Private network | accurics.azure.NPS.314 |
-| Network Ports Security | azure | MEDIUM | VNC Listener (TCP:5500) is exposed to small Public network | accurics.azure.NPS.251 |
-| Network Ports Security | azure | MEDIUM | Cassandra OpsCenter (TCP:61621) is exposed to wide Private network | accurics.azure.NPS.178 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11214) is exposed to small Public network | accurics.azure.NPS.197 |
-| Network Ports Security | azure | MEDIUM | Microsoft-DS (TCP:445) is exposed to wide Private network | accurics.azure.NPS.206 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (TCP:137) is exposed to wide Public network | accurics.azure.NPS.76 |
-| Network Ports Security | azure | HIGH | Prevalent known internal port (TCP:3000) is exposed to entire Public network | accurics.azure.NPS.99 |
-| Network Ports Security | azure | MEDIUM | MySQL (TCP:3306) is exposed to wide Private network | accurics.azure.NPS.210 |
-| Network Ports Security | azure | HIGH | MSSQL Server (TCP:1433) is exposed to wide Public network | accurics.azure.NPS.60 |
-| Network Ports Security | azure | LOW | POP3 (TCP:110) is exposed to small Private network | accurics.azure.NPS.302 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4506) is exposed to small Public network | accurics.azure.NPS.247 |
-| Network Ports Security | azure | HIGH | SSH (TCP:22) is exposed to the wide public internet | accurics.azure.NPS.37 |
-| Network Ports Security | azure | MEDIUM | Hadoop Name Node (TCP:9000) is exposed to small Public network | accurics.azure.NPS.181 |
-| Network Ports Security | azure | HIGH | Telnet (TCP:23) is exposed to entire Public network | accurics.azure.NPS.115 |
-| Network Ports Security | azure | LOW | MSSQL Browser (UDP:1434) is exposed to small Private network | accurics.azure.NPS.284 |
-| Network Ports Security | azure | LOW | Mongo Web Portal (TCP:27018) is exposed to small Private network | accurics.azure.NPS.292 |
-| Network Ports Security | azure | HIGH | SMTP (TCP:25) is exposed to entire Public network | accurics.azure.NPS.103 |
-| Network Ports Security | azure | MEDIUM | CIFS / SMB (TCP:3020) is exposed to wide Private network | accurics.azure.NPS.174 |
-| Network Ports Security | azure | HIGH | PostgreSQL (TCP:5432) is exposed to entire Public network | accurics.azure.NPS.95 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (UDP:138) is exposed to entire Public network | accurics.azure.NPS.83 |
-| Network Ports Security | azure | HIGH | VNC Server (TCP:5900) is exposed to entire Public network | accurics.azure.NPS.119 |
-| Network Ports Security | azure | HIGH | Cassandra (TCP:7001) is exposed to wide Public network | accurics.azure.NPS.40 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (TCP:5432) is exposed to wide Private network | accurics.azure.NPS.230 |
-| Network Ports Security | azure | LOW | Memcached SSL (TCP:11215) is exposed to small Private network | accurics.azure.NPS.288 |
-| Network Ports Security | azure | HIGH | MSSQL Browser (UDP:1434) is exposed to wide Public network | accurics.azure.NPS.56 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (UDP:2484) is exposed to wide Private network | accurics.azure.NPS.226 |
-| Network Ports Security | azure | MEDIUM | POP3 (TCP:110) is exposed to small Public network | accurics.azure.NPS.227 |
-| Network Ports Security | azure | HIGH | MSSQL Browser (UDP:1434) is exposed to entire Public network | accurics.azure.NPS.57 |
-| Network Ports Security | azure | LOW | Memcached SSL (UDP:11214) is exposed to small Private network | accurics.azure.NPS.289 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (UDP:5432) is exposed to small Public network | accurics.azure.NPS.231 |
-| Network Ports Security | azure | HIGH | VNC Server (TCP:5900) is exposed to wide Public network | accurics.azure.NPS.118 |
-| Network Ports Security | azure | HIGH | Cassandra (TCP:7001) is exposed to entire Public network | accurics.azure.NPS.41 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (UDP:138) is exposed to wide Public network | accurics.azure.NPS.82 |
-| Network Ports Security | azure | HIGH | PostgreSQL (TCP:5432) is exposed to wide Public network | accurics.azure.NPS.94 |
-| Network Ports Security | azure | MEDIUM | Cassandra (TCP:7001) is exposed to small Public network | accurics.azure.NPS.175 |
-| Network Ports Security | azure | HIGH | SMTP (TCP:25) is exposed to wide Public network | accurics.azure.NPS.102 |
-| Network Ports Security | azure | LOW | MySQL (TCP:3306) is exposed to small Private network | accurics.azure.NPS.293 |
-| Network Ports Security | azure | LOW | MSSQL Debugger (TCP:135) is exposed to small Private network | accurics.azure.NPS.285 |
-| Network Ports Security | azure | HIGH | Telnet (TCP:23) is exposed to wide Public network | accurics.azure.NPS.114 |
-| Network Ports Security | azure | HIGH | Remote Desktop (TCP:3389) is exposed to the wide public internet | accurics.azure.NPS.36 |
-| Network Ports Security | azure | MEDIUM | DNS (UDP:53) is exposed to wide Private network | accurics.azure.NPS.180 |
-| Network Ports Security | azure | LOW | PostgreSQL (TCP:5432) is exposed to small Private network | accurics.azure.NPS.303 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4505) is exposed to wide Private network | accurics.azure.NPS.246 |
-| Network Ports Security | azure | HIGH | MSSQL Server (TCP:1433) is exposed to entire Public network | accurics.azure.NPS.61 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (TCP:137) is exposed to small Public network | accurics.azure.NPS.211 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (TCP:137) is exposed to entire Public network | accurics.azure.NPS.77 |
-| Network Ports Security | azure | HIGH | Prevalent known internal port (TCP:3000) is exposed to wide Public network | accurics.azure.NPS.98 |
-| Network Ports Security | azure | MEDIUM | Mongo Web Portal (TCP:27018) is exposed to small Public network | accurics.azure.NPS.207 |
-| Network Ports Security | azure | MEDIUM | DNS (UDP:53) is exposed to small Public network | accurics.azure.NPS.179 |
-| Network Ports Security | azure | MEDIUM | MSSQL Server (TCP:1433) is exposed to wide Private network | accurics.azure.NPS.196 |
-| Network Ports Security | azure | LOW | VNC Server (TCP:5900) is exposed to small Private network | accurics.azure.NPS.315 |
-| Network Ports Security | azure | MEDIUM | Telnet (TCP:23) is exposed to wide Private network | accurics.azure.NPS.250 |
-| Network Ports Security | azure | HIGH | SSH (TCP:22) is exposed to the entire public internet | accurics.azure.NPS.172 |
-| Network Ports Security | azure | HIGH | POP3 (TCP:110) is exposed to entire Public network | accurics.azure.NPS.93 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (TCP:139) is exposed to entire Public network | accurics.azure.NPS.85 |
-| Network Ports Security | azure | LOW | SNMP (UDP:161) is exposed to small Private network | accurics.azure.NPS.308 |
-| Network Ports Security | azure | HIGH | Hadoop Name Node (TCP:9000) is exposed to wide Public network | accurics.azure.NPS.46 |
-| Network Ports Security | azure | MEDIUM | Puppet Master (TCP:8140) is exposed to wide Private network | accurics.azure.NPS.236 |
-| Network Ports Security | azure | LOW | Cassandra OpsCenter (TCP:61621) is exposed to small Private network | accurics.azure.NPS.277 |
-| Network Ports Security | azure | LOW | NetBIOS Session Service (TCP:139) is exposed to small Private network | accurics.azure.NPS.298 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2383) is exposed to entire Public network | accurics.azure.NPS.109 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8080) is exposed to wide Public network | accurics.azure.NPS.50 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (TCP:139) is exposed to wide Private network | accurics.azure.NPS.220 |
-| Network Ports Security | azure | LOW | SaltStack Master (TCP:4506) is exposed to small Private network | accurics.azure.NPS.312 |
-| Network Ports Security | azure | MEDIUM | MSSQL Browser (UDP:1434) is exposed to small Public network | accurics.azure.NPS.191 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11215) is exposed to wide Private network | accurics.azure.NPS.200 |
-| Network Ports Security | azure | HIGH | Microsoft-DS (TCP:445) is exposed to wide Public network | accurics.azure.NPS.70 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (TCP:138) is exposed to wide Private network | accurics.azure.NPS.216 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11214) is exposed to wide Public network | accurics.azure.NPS.66 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (TCP:2484) is exposed to entire Public network | accurics.azure.NPS.89 |
-| Network Ports Security | azure | LOW | PostgreSQL (UDP:5432) is exposed to small Private network | accurics.azure.NPS.304 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2382) is exposed to small Public network | accurics.azure.NPS.241 |
-| Network Ports Security | azure | MEDIUM | LDAP SSL (TCP:636) is exposed to small Public network | accurics.azure.NPS.187 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4506) is exposed to entire Public network | accurics.azure.NPS.113 |
-| Network Ports Security | azure | LOW | LDAP SSL (TCP:636) is exposed to small Private network | accurics.azure.NPS.282 |
-| Network Ports Security | azure | LOW | NetBIOS Name Service (TCP:137) is exposed to small Private network | accurics.azure.NPS.294 |
-| Network Ports Security | azure | HIGH | SNMP (UDP:161) is exposed to entire Public network | accurics.azure.NPS.105 |
-| Network Ports Security | azure | HIGH | SNMP (UDP:161) is exposed to wide Public network | accurics.azure.NPS.104 |
-| Network Ports Security | azure | LOW | NetBIOS Name Service (UDP:137) is exposed to small Private network | accurics.azure.NPS.295 |
-| Network Ports Security | azure | LOW | MSSQL Admin (TCP:1434) is exposed to small Private network | accurics.azure.NPS.283 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4506) is exposed to wide Public network | accurics.azure.NPS.112 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8080) is exposed to wide Private network | accurics.azure.NPS.186 |
-| Network Ports Security | azure | LOW | Prevalent known internal port (TCP:3000) is exposed to small Private network | accurics.azure.NPS.305 |
-| Network Ports Security | azure | MEDIUM | SNMP (UDP:161) is exposed to wide Private network | accurics.azure.NPS.240 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11214) is exposed to entire Public network | accurics.azure.NPS.67 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (TCP:2484) is exposed to wide Public network | accurics.azure.NPS.88 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (UDP:138) is exposed to small Public network | accurics.azure.NPS.217 |
-| Network Ports Security | azure | HIGH | Microsoft-DS (TCP:445) is exposed to entire Public network | accurics.azure.NPS.71 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11214) is exposed to small Public network | accurics.azure.NPS.201 |
-| Network Ports Security | azure | MEDIUM | MSSQL Admin (TCP:1434) is exposed to wide Private network | accurics.azure.NPS.190 |
-| Network Ports Security | azure | LOW | Telnet (TCP:23) is exposed to small Private network | accurics.azure.NPS.313 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (UDP:139) is exposed to small Public network | accurics.azure.NPS.221 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2383) is exposed to wide Public network | accurics.azure.NPS.108 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8080) is exposed to entire Public network | accurics.azure.NPS.51 |
-| Network Ports Security | azure | LOW | Cassandra (TCP:7001) is exposed to small Private network | accurics.azure.NPS.276 |
-| Network Ports Security | azure | LOW | NetBIOS Session Service (UDP:139) is exposed to small Private network | accurics.azure.NPS.299 |
-| Network Ports Security | azure | MEDIUM | SMTP (TCP:25) is exposed to small Public network | accurics.azure.NPS.237 |
-| Network Ports Security | azure | HIGH | Hadoop Name Node (TCP:9000) is exposed to entire Public network | accurics.azure.NPS.47 |
-| Network Ports Security | azure | LOW | SQL Server Analysis (TCP:2382) is exposed to small Private network | accurics.azure.NPS.309 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (TCP:139) is exposed to wide Public network | accurics.azure.NPS.84 |
-| Network Ports Security | azure | HIGH | POP3 (TCP:110) is exposed to wide Public network | accurics.azure.NPS.92 |
-| Network Ports Security | azure | MEDIUM | CIFS / SMB (TCP:3020) is exposed to small Public network | accurics.azure.NPS.173 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (UDP:139) is exposed to wide Private network | accurics.azure.NPS.222 |
-| Network Ports Security | azure | HIGH | LDAP SSL (TCP:636) is exposed to wide Public network | accurics.azure.NPS.52 |
-| Network Ports Security | azure | LOW | CIFS / SMB (TCP:3020) is exposed to small Private network | accurics.azure.NPS.275 |
-| Network Ports Security | azure | MEDIUM | Prevalent known internal port (TCP:3000) is exposed to wide Private network | accurics.azure.NPS.234 |
-| Network Ports Security | azure | HIGH | DNS (UDP:53) is exposed to wide Public network | accurics.azure.NPS.44 |
-| Network Ports Security | azure | MEDIUM | MSSQL Admin (TCP:1434) is exposed to small Public network | accurics.azure.NPS.189 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (UDP:138) is exposed to wide Private network | accurics.azure.NPS.218 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (UDP:139) is exposed to entire Public network | accurics.azure.NPS.87 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11215) is exposed to wide Public network | accurics.azure.NPS.68 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (UDP:2484) is exposed to entire Public network | accurics.azure.NPS.91 |
-| Network Ports Security | azure | HIGH | CiscoSecure, WebSM (TCP:9090) is exposed to the entire public internet | accurics.azure.NPS.170 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2382) is exposed to entire Public network | accurics.azure.NPS.107 |
-| Network Ports Security | azure | LOW | NetBIOS Datagram Service (TCP:138) is exposed to small Private network | accurics.azure.NPS.296 |
-| Network Ports Security | azure | LOW | Hadoop Name Node (TCP:9000) is exposed to small Private network | accurics.azure.NPS.279 |
-| Network Ports Security | azure | LOW |  Known internal web port (TCP:8000) is exposed to small Private network | accurics.azure.NPS.280 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8000) is exposed to wide Public network | accurics.azure.NPS.48 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4505) is exposed to entire Public network | accurics.azure.NPS.111 |
-| Network Ports Security | azure | MEDIUM | SMTP (TCP:25) is exposed to wide Private network | accurics.azure.NPS.238 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8080) is exposed to small Public network | accurics.azure.NPS.185 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2383) is exposed to small Public network | accurics.azure.NPS.243 |
-| Network Ports Security | azure | LOW | Puppet Master (TCP:8140) is exposed to small Private network | accurics.azure.NPS.306 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11215) is exposed to wide Public network | accurics.azure.NPS.64 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (UDP:137) is exposed to wide Private network | accurics.azure.NPS.214 |
-| Network Ports Security | azure | HIGH | Mongo Web Portal (TCP:27018) is exposed to wide Public network | accurics.azure.NPS.72 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11214) is exposed to wide Private network | accurics.azure.NPS.202 |
-| Network Ports Security | azure | MEDIUM | MSSQL Debugger (TCP:135) is exposed to small Public network | accurics.azure.NPS.193 |
-| Network Ports Security | azure | LOW | SQL Server Analysis (TCP:2383) is exposed to small Private network | accurics.azure.NPS.310 |
-| Network Ports Security | azure | MEDIUM | VNC Server (TCP:5900) is exposed to wide Private network | accurics.azure.NPS.254 |
-| Network Ports Security | azure | LOW | SaltStack Master (TCP:4505) is exposed to small Private network | accurics.azure.NPS.311 |
-| Network Ports Security | azure | MEDIUM | MSSQL Browser (UDP:1434) is exposed to wide Private network | accurics.azure.NPS.192 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11215) is exposed to small Public network | accurics.azure.NPS.203 |
-| Network Ports Security | azure | HIGH | Mongo Web Portal (TCP:27018) is exposed to entire Public network | accurics.azure.NPS.73 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Datagram Service (TCP:138) is exposed to small Public network | accurics.azure.NPS.215 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11215) is exposed to entire Public network | accurics.azure.NPS.65 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2382) is exposed to wide Private network | accurics.azure.NPS.242 |
-| Network Ports Security | azure | LOW | SMTP (TCP:25) is exposed to small Private network | accurics.azure.NPS.307 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8000) is exposed to wide Private network | accurics.azure.NPS.184 |
-| Network Ports Security | azure | MEDIUM | SNMP (UDP:161) is exposed to small Public network | accurics.azure.NPS.239 |
-| Network Ports Security | azure | HIGH |  Known internal web port (TCP:8000) is exposed to entire Public network | accurics.azure.NPS.49 |
-| Network Ports Security | azure | HIGH | SaltStack Master (TCP:4505) is exposed to wide Public network | accurics.azure.NPS.110 |
-| Network Ports Security | azure | LOW |  Known internal web port (TCP:8080) is exposed to small Private network | accurics.azure.NPS.281 |
-| Network Ports Security | azure | LOW | NetBIOS Datagram Service (UDP:138) is exposed to small Private network | accurics.azure.NPS.297 |
-| Network Ports Security | azure | LOW | DNS (UDP:53) is exposed to small Private network | accurics.azure.NPS.278 |
-| Network Ports Security | azure | HIGH | SQL Server Analysis (TCP:2382) is exposed to wide Public network | accurics.azure.NPS.106 |
-| Network Ports Security | azure | HIGH | Remote Desktop (TCP:3389) is exposed to the entire public internet | accurics.azure.NPS.171 |
-| Network Ports Security | azure | HIGH | Oracle DB SSL (UDP:2484) is exposed to wide Public network | accurics.azure.NPS.90 |
-| Network Ports Security | azure | HIGH | NetBIOS Session Service (UDP:139) is exposed to wide Public network | accurics.azure.NPS.86 |
-| Network Ports Security | azure | HIGH | Memcached SSL (UDP:11215) is exposed to entire Public network | accurics.azure.NPS.69 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Session Service (TCP:139) is exposed to small Public network | accurics.azure.NPS.219 |
-| Network Ports Security | azure | MEDIUM | LDAP SSL (TCP:636) is exposed to wide Private network | accurics.azure.NPS.188 |
-| Network Ports Security | azure | HIGH | DNS (UDP:53) is exposed to entire Public network | accurics.azure.NPS.45 |
-| Network Ports Security | azure | MEDIUM | Puppet Master (TCP:8140) is exposed to small Public network | accurics.azure.NPS.235 |
-| Network Ports Security | azure | HIGH | LDAP SSL (TCP:636) is exposed to entire Public network | accurics.azure.NPS.53 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (TCP:2484) is exposed to small Public network | accurics.azure.NPS.223 |
-| Network Ports Security | azure | HIGH | MSSQL Debugger (TCP:135) is exposed to wide Public network | accurics.azure.NPS.58 |
-| Network Ports Security | azure | HIGH | Puppet Master (TCP:8140) is exposed to entire Public network | accurics.azure.NPS.101 |
-| Network Ports Security | azure | MEDIUM | POP3 (TCP:110) is exposed to wide Private network | accurics.azure.NPS.228 |
-| Network Ports Security | azure | LOW | Memcached SSL (UDP:11215) is exposed to small Private network | accurics.azure.NPS.290 |
-| Network Ports Security | azure | LOW | MSSQL Server (TCP:1433) is exposed to small Private network | accurics.azure.NPS.286 |
-| Network Ports Security | azure | HIGH | VNC Listener (TCP:5500) is exposed to entire Public network | accurics.azure.NPS.117 |
-| Network Ports Security | azure | MEDIUM |  Known internal web port (TCP:8000) is exposed to small Public network | accurics.azure.NPS.183 |
-| Network Ports Security | azure | HIGH | CiscoSecure, WebSM (TCP:9090) is exposed to the wide public internet | accurics.azure.NPS.35 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4505) is exposed to small Public network | accurics.azure.NPS.245 |
-| Network Ports Security | azure | LOW | Oracle DB SSL (TCP:2484) is exposed to small Private network | accurics.azure.NPS.300 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11214) is exposed to wide Public network | accurics.azure.NPS.62 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (TCP:137) is exposed to wide Private network | accurics.azure.NPS.212 |
-| Network Ports Security | azure | HIGH | MySQL (TCP:3306) is exposed to wide Public network | accurics.azure.NPS.74 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (UDP:11215) is exposed to wide Private network | accurics.azure.NPS.204 |
-| Network Ports Security | azure | MEDIUM | MSSQL Server (TCP:1433) is exposed to small Public network | accurics.azure.NPS.195 |
-| Network Ports Security | azure | MEDIUM | VNC Server (TCP:5900) is exposed to small Public network | accurics.azure.NPS.253 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (TCP:2484) is exposed to wide Private network | accurics.azure.NPS.224 |
-| Network Ports Security | azure | HIGH | MSSQL Admin (TCP:1434) is exposed to wide Public network | accurics.azure.NPS.54 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (UDP:5432) is exposed to wide Private network | accurics.azure.NPS.232 |
-| Network Ports Security | azure | HIGH | Cassandra OpsCenter (TCP:61621) is exposed to wide Public network | accurics.azure.NPS.42 |
-| Network Ports Security | azure | MEDIUM | Telnet (TCP:23) is exposed to small Public network | accurics.azure.NPS.249 |
-| Network Ports Security | azure | HIGH | CIFS / SMB (TCP:3020) is exposed to entire Public network | accurics.azure.NPS.39 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (TCP:138) is exposed to entire Public network | accurics.azure.NPS.81 |
-| Network Ports Security | azure | MEDIUM | Mongo Web Portal (TCP:27018) is exposed to wide Private network | accurics.azure.NPS.208 |
-| Network Ports Security | azure | HIGH | PostgreSQL (UDP:5432) is exposed to entire Public network | accurics.azure.NPS.97 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (UDP:137) is exposed to wide Public network | accurics.azure.NPS.78 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11215) is exposed to small Public network | accurics.azure.NPS.199 |
-| Network Ports Security | azure | MEDIUM | Cassandra (TCP:7001) is exposed to wide Private network | accurics.azure.NPS.176 |
-| Network Ports Security | azure | MEDIUM | Memcached SSL (TCP:11214) is exposed to wide Private network | accurics.azure.NPS.198 |
-| Network Ports Security | azure | MEDIUM | Cassandra OpsCenter (TCP:61621) is exposed to small Public network | accurics.azure.NPS.177 |
-| Network Ports Security | azure | HIGH | PostgreSQL (UDP:5432) is exposed to wide Public network | accurics.azure.NPS.96 |
-| Network Ports Security | azure | HIGH | NetBIOS Name Service (UDP:137) is exposed to entire Public network | accurics.azure.NPS.79 |
-| Network Ports Security | azure | MEDIUM | MySQL (TCP:3306) is exposed to small Public network | accurics.azure.NPS.209 |
-| Network Ports Security | azure | HIGH | NetBIOS Datagram Service (TCP:138) is exposed to wide Public network | accurics.azure.NPS.80 |
-| Network Ports Security | azure | HIGH | CIFS / SMB (TCP:3020) is exposed to wide Public network | accurics.azure.NPS.38 |
-| Network Ports Security | azure | MEDIUM | SaltStack Master (TCP:4506) is exposed to wide Private network | accurics.azure.NPS.248 |
-| Network Ports Security | azure | HIGH | Cassandra OpsCenter (TCP:61621) is exposed to entire Public network | accurics.azure.NPS.43 |
-| Network Ports Security | azure | MEDIUM | Prevalent known internal port (TCP:3000) is exposed to small Public network | accurics.azure.NPS.233 |
-| Network Ports Security | azure | HIGH | MSSQL Admin (TCP:1434) is exposed to entire Public network | accurics.azure.NPS.55 |
-| Network Ports Security | azure | MEDIUM | Oracle DB SSL (UDP:2484) is exposed to small Public network | accurics.azure.NPS.225 |
-| Network Ports Security | azure | MEDIUM | VNC Listener (TCP:5500) is exposed to wide Private network | accurics.azure.NPS.252 |
-| Network Ports Security | azure | MEDIUM | MSSQL Debugger (TCP:135) is exposed to wide Private network | accurics.azure.NPS.194 |
-| Network Ports Security | azure | MEDIUM | Microsoft-DS (TCP:445) is exposed to small Public network | accurics.azure.NPS.205 |
-| Network Ports Security | azure | HIGH | MySQL (TCP:3306) is exposed to entire Public network | accurics.azure.NPS.75 |
-| Network Ports Security | azure | MEDIUM | NetBIOS Name Service (UDP:137) is exposed to small Public network | accurics.azure.NPS.213 |
-| Network Ports Security | azure | HIGH | Memcached SSL (TCP:11214) is exposed to entire Public network | accurics.azure.NPS.63 |
-| Network Ports Security | azure | MEDIUM | SQL Server Analysis (TCP:2383) is exposed to wide Private network | accurics.azure.NPS.244 |
-| Network Ports Security | azure | LOW | Oracle DB SSL (UDP:2484) is exposed to small Private network | accurics.azure.NPS.301 |
-| Network Ports Security | azure | MEDIUM | Hadoop Name Node (TCP:9000) is exposed to wide Private network | accurics.azure.NPS.182 |
-| Network Ports Security | azure | HIGH | VNC Listener (TCP:5500) is exposed to wide Public network | accurics.azure.NPS.116 |
-| Network Ports Security | azure | LOW | Memcached SSL (TCP:11214) is exposed to small Private network | accurics.azure.NPS.287 |
-| Network Ports Security | azure | LOW | Microsoft-DS (TCP:445) is exposed to small Private network | accurics.azure.NPS.291 |
-| Network Ports Security | azure | MEDIUM | PostgreSQL (TCP:5432) is exposed to small Public network | accurics.azure.NPS.229 |
-| Network Ports Security | azure | HIGH | MSSQL Debugger (TCP:135) is exposed to entire Public network | accurics.azure.NPS.59 |
-| Network Ports Security | azure | HIGH | Puppet Master (TCP:8140) is exposed to wide Public network | accurics.azure.NPS.100 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (Tcp:8000) is not exposed to public for Azure Network Security Rule | AC_AZURE_0528 | AC_AZURE_0528 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (Udp:137) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0482 | AC_AZURE_0482 |
+| Infrastructure Security | json | LOW | Ensure Microsoft-DS (Tcp:445) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0494 | AC_AZURE_0494 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Debugger (Tcp:135) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0512 | AC_AZURE_0512 |
+| Infrastructure Security | json | HIGH | Ensure PostgreSQL (Udp:5432) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0457 | AC_AZURE_0457 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Tcp:11215) is not exposed to public for Azure Network Security Rule | AC_AZURE_0504 | AC_AZURE_0504 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis (Tcp:2382) is not exposed to public for Azure Network Security Rule | AC_AZURE_0441 | AC_AZURE_0441 |
+| Infrastructure Security | json | LOW | Ensure POP3 (Tcp:110) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0461 | AC_AZURE_0461 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (Tcp:8080) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0524 | AC_AZURE_0524 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (Tcp:4505) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0436 | AC_AZURE_0436 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Datagram Service (Udp:138) is not exposed to public for Azure Network Security Rule | AC_AZURE_0477 | AC_AZURE_0477 |
+| Infrastructure Security | json | HIGH | Ensure Hadoop Name Node (Tcp:9000) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0532 | AC_AZURE_0532 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Udp:11215) is not exposed to public for Azure Network Security Rule | AC_AZURE_0498 | AC_AZURE_0498 |
+| Infrastructure Security | json | MEDIUM | Ensure CIFS / SMB (Tcp:3020) is not exposed to public for Azure Network Security Rule | AC_AZURE_0271 | AC_AZURE_0271 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Tcp:11214) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0508 | AC_AZURE_0508 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Server (Tcp:1433) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0509 | AC_AZURE_0509 |
+| Infrastructure Security | json | HIGH | Ensure CIFS / SMB (Tcp:3020) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0270 | AC_AZURE_0270 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Datagram Service (Udp:138) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0476 | AC_AZURE_0476 |
+| Infrastructure Security | json | LOW | Ensure DNS (Udp:53) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0533 | AC_AZURE_0533 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Udp:11215) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0499 | AC_AZURE_0499 |
+| Infrastructure Security | json | LOW | Ensure server is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0421 | AC_AZURE_0421 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis (Tcp:2383) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0437 | AC_AZURE_0437 |
+| Infrastructure Security | json | HIGH | Ensure PostgreSQL (Tcp:5432) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0460 | AC_AZURE_0460 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (Tcp:8080) is not exposed to public for Azure Network Security Rule | AC_AZURE_0525 | AC_AZURE_0525 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Tcp:11215) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0505 | AC_AZURE_0505 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis (Tcp:2382) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0440 | AC_AZURE_0440 |
+| Infrastructure Security | json | HIGH | Ensure SSH (Tcp:22) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0285 | AC_AZURE_0285 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Debugger (Tcp:135) is not exposed to public for Azure Network Security Rule | AC_AZURE_0513 | AC_AZURE_0513 |
+| Infrastructure Security | json | MEDIUM | Ensure PostgreSQL (Udp:5432) is not exposed to public for Azure Network Security Rule | AC_AZURE_0456 | AC_AZURE_0456 |
+| Infrastructure Security | json | MEDIUM | Ensure Microsoft-DS (Tcp:445) is not exposed to public for Azure Network Security Rule | AC_AZURE_0495 | AC_AZURE_0495 |
+| Infrastructure Security | json | HIGH | Ensure that RDP access is restricted from the internet for Azure Network Security Rule | AC_AZURE_0342 | AC_AZURE_0342 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (Tcp:8000) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0529 | AC_AZURE_0529 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (Udp:137) is not exposed to public for Azure Network Security Rule | AC_AZURE_0483 | AC_AZURE_0483 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (Tcp:2484) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0467 | AC_AZURE_0467 |
+| Infrastructure Security | json | LOW | Ensure MySQL (Tcp:3306) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0488 | AC_AZURE_0488 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP SSL (Tcp:636) is not exposed to public for Azure Network Security Rule | AC_AZURE_0522 | AC_AZURE_0522 |
+| Infrastructure Security | json | HIGH | Ensure Telnet (Tcp:23) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0430 | AC_AZURE_0430 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Listener (Tcp:5500) is not exposed to public for Azure Network Security Rule | AC_AZURE_0426 | AC_AZURE_0426 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Session Service (Udp:139) is not exposed to public for Azure Network Security Rule | AC_AZURE_0471 | AC_AZURE_0471 |
+| Infrastructure Security | json | MEDIUM | Ensure DNS (Udp:53) is not exposed to public for Azure Network Security Rule | AC_AZURE_0534 | AC_AZURE_0534 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Admin (Tcp:1434) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0518 | AC_AZURE_0518 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (Udp:137) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0484 | AC_AZURE_0484 |
+| Infrastructure Security | json | MEDIUM | Ensure Mongo Web Portal (Tcp:27018) is not exposed to public for Azure Network Security Rule | AC_AZURE_0492 | AC_AZURE_0492 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Debugger (Tcp:135) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0514 | AC_AZURE_0514 |
+| Infrastructure Security | json | HIGH | Ensure Puppet Master (Tcp:8140) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0451 | AC_AZURE_0451 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (Udp:11214) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0502 | AC_AZURE_0502 |
+| Infrastructure Security | json | MEDIUM | Ensure SMTP (Tcp:25) is not exposed to public for Azure Network Security Rule | AC_AZURE_0447 | AC_AZURE_0447 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Tcp:11215) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0503 | AC_AZURE_0503 |
+| Infrastructure Security | json | LOW | Ensure SMTP (Tcp:25) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0446 | AC_AZURE_0446 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Browser (Udp:1434) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0515 | AC_AZURE_0515 |
+| Infrastructure Security | json | MEDIUM | Ensure Puppet Master (Tcp:8140) is not exposed to public for Azure Network Security Rule | AC_AZURE_0450 | AC_AZURE_0450 |
+| Infrastructure Security | json | HIGH | Ensure Mongo Web Portal (Tcp:27018) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0493 | AC_AZURE_0493 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (Tcp:137) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0485 | AC_AZURE_0485 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter (Tcp:61621) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0276 | AC_AZURE_0276 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Admin (Tcp:1434) is not exposed to public for Azure Network Security Rule | AC_AZURE_0519 | AC_AZURE_0519 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Session Service (Udp:139) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0470 | AC_AZURE_0470 |
+| Infrastructure Security | json | HIGH | Ensure DNS (Udp:53) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0535 | AC_AZURE_0535 |
+| Infrastructure Security | json | HIGH | Ensure VNC Listener (Tcp:5500) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0427 | AC_AZURE_0427 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (Tcp:4506) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0431 | AC_AZURE_0431 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (Udp:2484) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0466 | AC_AZURE_0466 |
+| Infrastructure Security | json | MEDIUM | Ensure MySQL (Tcp:3306) is not exposed to public for Azure Network Security Rule | AC_AZURE_0489 | AC_AZURE_0489 |
+| Infrastructure Security | json | HIGH | Ensure LDAP SSL (Tcp:636) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0523 | AC_AZURE_0523 |
+| Infrastructure Security | json | LOW | Ensure Puppet Master (Tcp:8140) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0449 | AC_AZURE_0449 |
+| Infrastructure Security | json | LOW | Ensure Cassandra (Tcp:7001) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0275 | AC_AZURE_0275 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter (Tcp:61621) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0536 | AC_AZURE_0536 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Session Service (Tcp:139) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0473 | AC_AZURE_0473 |
+| Infrastructure Security | json | HIGH | Ensure VNC Server (Tcp:5900) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0424 | AC_AZURE_0424 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (Tcp:4506) is not exposed to public for Azure Network Security Rule | AC_AZURE_0432 | AC_AZURE_0432 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Admin (Tcp:1434) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0520 | AC_AZURE_0520 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (Udp:2484) is not exposed to public for Azure Network Security Rule | AC_AZURE_0465 | AC_AZURE_0465 |
+| Infrastructure Security | json | HIGH | Ensure SNMP (Udp:161) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0445 | AC_AZURE_0445 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Udp:11214) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0500 | AC_AZURE_0500 |
+| Infrastructure Security | json | MEDIUM | Ensure Prevalent known internal port (Tcp:3000) is not exposed to public for Azure Network Security Rule | AC_AZURE_0453 | AC_AZURE_0453 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Browser (Udp:1434) is not exposed to public for Azure Network Security Rule | AC_AZURE_0516 | AC_AZURE_0516 |
+| Infrastructure Security | json | HIGH | Ensure MySQL (Tcp:3306) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0490 | AC_AZURE_0490 |
+| Infrastructure Security | json | LOW | Ensure Telnet (Tcp:23) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0428 | AC_AZURE_0428 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (Tcp:137) is not exposed to public for Azure Network Security Rule | AC_AZURE_0486 | AC_AZURE_0486 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (Tcp:2484) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0469 | AC_AZURE_0469 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (Tcp:137) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0487 | AC_AZURE_0487 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (Tcp:2484) is not exposed to public for Azure Network Security Rule | AC_AZURE_0468 | AC_AZURE_0468 |
+| Infrastructure Security | json | MEDIUM | Ensure Telnet (Tcp:23) is not exposed to public for Azure Network Security Rule | AC_AZURE_0429 | AC_AZURE_0429 |
+| Infrastructure Security | json | LOW | Ensure Mongo Web Portal (Tcp:27018) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0491 | AC_AZURE_0491 |
+| Infrastructure Security | json | LOW | Ensure Prevalent known internal port (Tcp:3000) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0452 | AC_AZURE_0452 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Browser (Udp:1434) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0517 | AC_AZURE_0517 |
+| Infrastructure Security | json | MEDIUM | Ensure SNMP (Udp:161) is not exposed to public for Azure Network Security Rule | AC_AZURE_0444 | AC_AZURE_0444 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Udp:11214) is not exposed to public for Azure Network Security Rule | AC_AZURE_0501 | AC_AZURE_0501 |
+| Infrastructure Security | json | LOW | Ensure LDAP SSL (Tcp:636) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0521 | AC_AZURE_0521 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (Udp:2484) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0464 | AC_AZURE_0464 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (Tcp:4506) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0433 | AC_AZURE_0433 |
+| Infrastructure Security | json | LOW | Ensure VNC Listener (Tcp:5500) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0425 | AC_AZURE_0425 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter (Tcp:61621) is not exposed to public for Azure Network Security Rule | AC_AZURE_0537 | AC_AZURE_0537 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Session Service (Udp:139) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0472 | AC_AZURE_0472 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra (Tcp:7001) is not exposed to public for Azure Network Security Rule | AC_AZURE_0274 | AC_AZURE_0274 |
+| Infrastructure Security | json | HIGH | Ensure SMTP (Tcp:25) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0448 | AC_AZURE_0448 |
+| Infrastructure Security | json | LOW | Ensure SNMP (Udp:161) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0443 | AC_AZURE_0443 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Tcp:11214) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0506 | AC_AZURE_0506 |
+| Infrastructure Security | json | MEDIUM | Ensure SSH (Tcp:22) is not exposed to public for Azure Network Security Rule | AC_AZURE_0286 | AC_AZURE_0286 |
+| Infrastructure Security | json | LOW | Ensure PostgreSQL (Udp:5432) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0455 | AC_AZURE_0455 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Server (Tcp:1433) is not exposed to public for Azure Network Security Rule | AC_AZURE_0510 | AC_AZURE_0510 |
+| Infrastructure Security | json | HIGH | Ensure Microsoft-DS (Tcp:445) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0496 | AC_AZURE_0496 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Datagram Service (Tcp:138) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0479 | AC_AZURE_0479 |
+| Infrastructure Security | json | HIGH | Ensure that request initiated from all ports (*) for all destination ports (*) is restricted from the internet for Azure Network Security Rule | AC_AZURE_0357 | AC_AZURE_0357 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis (Tcp:2383) is not exposed to public for Azure Network Security Rule | AC_AZURE_0438 | AC_AZURE_0438 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Datagram Service (Tcp:138) is not exposed to public for Azure Network Security Rule | AC_AZURE_0480 | AC_AZURE_0480 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra (Tcp:7001) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0273 | AC_AZURE_0273 |
+| Infrastructure Security | json | MEDIUM | Ensure PostgreSQL (Tcp:5432) is not exposed to public for Azure Network Security Rule | AC_AZURE_0459 | AC_AZURE_0459 |
+| Infrastructure Security | json | LOW | Ensure Hadoop Name Node (Tcp:9000) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0530 | AC_AZURE_0530 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Session Service (Tcp:139) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0475 | AC_AZURE_0475 |
+| Infrastructure Security | json | LOW | Ensure VNC Server (Tcp:5900) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0422 | AC_AZURE_0422 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (Tcp:4505) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0434 | AC_AZURE_0434 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (Tcp:8080) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0526 | AC_AZURE_0526 |
+| Infrastructure Security | json | HIGH | Ensure POP3 (Tcp:110) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0463 | AC_AZURE_0463 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (Tcp:8000) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0527 | AC_AZURE_0527 |
+| Infrastructure Security | json | MEDIUM | Ensure POP3 (Tcp:110) is not exposed to public for Azure Network Security Rule | AC_AZURE_0462 | AC_AZURE_0462 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (Tcp:4505) is not exposed to public for Azure Network Security Rule | AC_AZURE_0435 | AC_AZURE_0435 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Server (Tcp:5900) is not exposed to public for Azure Network Security Rule | AC_AZURE_0423 | AC_AZURE_0423 |
+| Infrastructure Security | json | MEDIUM | Ensure Hadoop Name Node (Tcp:9000) is not exposed to public for Azure Network Security Rule | AC_AZURE_0531 | AC_AZURE_0531 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Session Service (Tcp:139) is not exposed to public for Azure Network Security Rule | AC_AZURE_0474 | AC_AZURE_0474 |
+| Infrastructure Security | json | LOW | Ensure PostgreSQL (Tcp:5432) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0458 | AC_AZURE_0458 |
+| Infrastructure Security | json | LOW | Ensure CIFS / SMB (Tcp:3020) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0272 | AC_AZURE_0272 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Datagram Service (Tcp:138) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0481 | AC_AZURE_0481 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis (Tcp:2383) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0439 | AC_AZURE_0439 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (Udp:11215) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0497 | AC_AZURE_0497 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Datagram Service (Udp:138) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0478 | AC_AZURE_0478 |
+| Infrastructure Security | json | HIGH | Ensure Prevalent known internal port (Tcp:3000) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0454 | AC_AZURE_0454 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Server (Tcp:1433) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0511 | AC_AZURE_0511 |
+| Infrastructure Security | json | LOW | Ensure SSH (Tcp:22) is not exposed to private hosts more than 32 for Azure Network Security Rule | AC_AZURE_0287 | AC_AZURE_0287 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis (Tcp:2382) is not exposed to entire internet for Azure Network Security Rule | AC_AZURE_0442 | AC_AZURE_0442 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (Tcp:11214) is not exposed to public for Azure Network Security Rule | AC_AZURE_0507 | AC_AZURE_0507 |
 
 
 ### azurerm_cosmosdb_account
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | HIGH | Ensure to filter source Ips for Cosmos DB Account | accurics.azure.NS.32 |
-| Cloud Assets Management | azure | MEDIUM | Ensure that Cosmos DB Account has an associated tag | accurics.azure.CAM.162 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | HIGH | Ensure to filter source Ips for Cosmos DB Account | accurics.azure.NS.32 | AC_AZURE_0184 |
+| Compliance Validation | azure | MEDIUM | Ensure that Cosmos DB Account has an associated tag | accurics.azure.CAM.162 | AC_AZURE_0277 |
 
 
 ### azurerm_security_center_subscription_pricing
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Operational Efficiency | azure | MEDIUM | Ensure that standard pricing tiers are selected | accurics.azure.OPS.349 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | azure | MEDIUM | Ensure that standard pricing tiers are selected | accurics.azure.OPS.349 | AC_AZURE_0385 |
 
 
 ### azurerm_sql_active_directory_administrator
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server Active Directory Administrator account | accurics.azure.IAM.137 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Compliance Validation | azure | MEDIUM | Avoid using names like 'Admin' for an Azure SQL Server Active Directory Administrator account | accurics.azure.IAM.137 | AC_AZURE_0384 |
 
 
 ### azurerm_container_registry
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | MEDIUM | Ensure that admin user is disabled for Container Registry | accurics.azure.EKM.164 |
-| Azure Container Services | azure | HIGH | Ensure Container Registry has locks | accurics.azure.AKS.3 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | azure | MEDIUM | Ensure that admin user is disabled for Container Registry | accurics.azure.EKM.164 | AC_AZURE_0186 |
+| Resilience | azure | HIGH | Ensure Container Registry has locks | accurics.azure.AKS.3 | AC_AZURE_0185 |
 
 
 ### azurerm_virtual_network
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure that Azure Virtual Network subnet is configured with a Network Security Group | accurics.azure.NS.161 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | MEDIUM | Ensure that Azure Virtual Network subnet is configured with a Network Security Group | accurics.azure.NS.161 | AC_AZURE_0356 |
 
 
 ### azurerm_role_assignment
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | azure | HIGH | Ensure that there are no guest users | accurics.azure.IAM.388 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | azure | HIGH | Ensure that there are no guest users | accurics.azure.IAM.388 | AC_AZURE_0388 |
 
 
 ### azurerm_application_gateway
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | azure | MEDIUM | Ensure Azure Application Gateway Web application firewall (WAF) is enabled | accurics.azure.NS.147 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | MEDIUM | Ensure Azure Application Gateway Web application firewall (WAF) is enabled | accurics.azure.NS.147 | AC_AZURE_0189 |
 
 
 ### azurerm_postgresql_server
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for PostgreSQL Database Server | accurics.azure.EKM.1 |
-| Backup and Disaster Recovery | azure | HIGH | Ensure that Geo Redundant Backups is enabled on PostgreSQL | accurics.azure.BDR.163 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | azure | HIGH | Ensure 'Enforce SSL connection' is set to 'ENABLED' for PostgreSQL Database Server | accurics.azure.EKM.1 | AC_AZURE_0408 |
+| Resilience | azure | MEDIUM | Ensure that Geo Redundant Backups is enabled on PostgreSQL | accurics.azure.BDR.163 | AC_AZURE_0407 |
 
 

--- a/docs/policies/docker.md
+++ b/docs/policies/docker.md
@@ -1,0 +1,63 @@
+
+### docker_from
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | Ensure platform flag with FROM command is not used for Docker file | AC_DOCKER_0041 | AC_DOCKER_0041 |
+| Infrastructure Security | json | MEDIUM | Ensure platform flag with FROM command is not used for Docker file | AC_DOCKER_0001 | AC_DOCKER_0001 |
+
+
+### docker_add
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | LOW | Ensure use Curl or Wget instead of Add to fetch packages from remote URLs, because using Add is strongly discouraged | AC_DOCKER_0035 | AC_DOCKER_0035 |
+| Infrastructure Security | json | LOW | Ensure use of COPY instead of ADD unless, running a tar file | AC_DOCKER_0032 | AC_DOCKER_0032 |
+
+
+### docker_expose
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | LOW | Ensure only the ports that your application needs are used and avoid exposing ports like SSH (22) | AC_DOCKER_0026 | AC_DOCKER_0026 |
+| Infrastructure Security | json | HIGH | Ensure range of ports is from 0 to 65535 | AC_DOCKER_0011 | AC_DOCKER_0011 |
+
+
+### docker_dockerfile
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | LOW | Ensure that HEALTHCHECK is being used. | AC_DOCKER_0047 | AC_DOCKER_0047 |
+| Infrastructure Security | json | MEDIUM | Ensure the command SHELL to override the default shell instead of the RUN command. | AC_DOCKER_0020 | AC_DOCKER_0020 |
+
+
+### docker_run
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | Ensure Pinned Pip Package Version | AC_DOCKER_0010 | AC_DOCKER_0010 |
+| Infrastructure Security | json | MEDIUM | Ensure when installing packages with pip, the '--no-cache-dir' flag should be set to make Docker images smaller | AC_DOCKER_0031 | AC_DOCKER_0031 |
+| Infrastructure Security | json | HIGH | Ensure to avoid RUN with sudo command | AC_DOCKER_0007 | AC_DOCKER_0007 |
+| Infrastructure Security | json | MEDIUM | Ensure WORKDIR command is getting used instead of proliferating instructions like RUN  | AC_DOCKER_0018 | AC_DOCKER_0018 |
+| Infrastructure Security | json | LOW | Ensure any apt-get installs don't use '--no-install-recommends' flag | AC_DOCKER_0014 | AC_DOCKER_0014 |
+| Infrastructure Security | json | MEDIUM | Ensure apt is not used with RUN command for Docker file | AC_DOCKER_0002 | AC_DOCKER_0002 |
+| Infrastructure Security | json | MEDIUM | Ensure apk upgrade is not being used. | AC_DOCKER_0039 | AC_DOCKER_0039 |
+| Infrastructure Security | json | MEDIUM | Ensure dnf Update is not used for Docker file | AC_DOCKER_0003 | AC_DOCKER_0003 |
+| Infrastructure Security | json | MEDIUM | Ensure that there is only be one CMD instruction in a Dockerfile. If you list more than one CMD then only the last CMD will take effect | AC_DOCKER_0053 | AC_DOCKER_0053 |
+| Infrastructure Security | json | MEDIUM | Ensure yum install allow manual input with RUN command for Docker file | AC_DOCKER_0004 | AC_DOCKER_0004 |
+| Infrastructure Security | json | MEDIUM | Ensure instruction 'RUN <package-manager> update' should always be followed by '<package-manager> install' in the same RUN statement | AC_DOCKER_0049 | AC_DOCKER_0049 |
+| Infrastructure Security | json | MEDIUM | Ensure package version is specified to avoid failures | AC_DOCKER_0033 | AC_DOCKER_0033 |
+| Infrastructure Security | json | MEDIUM | Ensure Cached package data should be cleaned after installation to reduce image size | AC_DOCKER_00025 | AC_DOCKER_00025 |
+| Infrastructure Security | json | MEDIUM | Ensure Yum Clean All is used after Yum Install | AC_DOCKER_0009 | AC_DOCKER_0009 |
+| Infrastructure Security | json | HIGH | Ensure Yum update is being used | AC_DOCKER_0029 | AC_DOCKER_0029 |
+| Infrastructure Security | json | MEDIUM | Ensure root with RUN command is not used for Docker file | AC_DOCKER_0005 | AC_DOCKER_0005 |
+| Infrastructure Security | json | HIGH | Ensure that Commands 'apt-get upgrade' and 'apt-get dist-upgrade' are not being used | AC_DOCKER_0052 | AC_DOCKER_0052 |
+
+
+### docker_workdir
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | HIGH | Ensure the use absolute paths for your WORKDIR. | AC_DOCKER_0013 | AC_DOCKER_0013 |
+
+
+### docker_copy
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | Ensure not to use --chown flag when user only needs execution permission | AC_DOCKER_00024 | AC_DOCKER_00024 |
+
+

--- a/docs/policies/document_policies.py
+++ b/docs/policies/document_policies.py
@@ -21,8 +21,8 @@ def dir_size(dir):
                                 severity = policy['severity']
                                 description = policy['description'].replace('\n','')
                                 reference_id = policy['reference_id']
-                                id = policy['id']
-                                f.write(f"| {category} | {resource} | {severity} | {description} | {reference_id} | {id} |\n")
+                                policy_id = policy['id']
+                                f.write(f"| {category} | {resource} | {severity} | {description} | {reference_id} | {policy_id} |\n")
                 f.write("\n\n")
 
 if __name__ == '__main__':

--- a/docs/policies/document_policies.py
+++ b/docs/policies/document_policies.py
@@ -3,12 +3,14 @@ import json
 
 def dir_size(dir):
     for policy_type in os.listdir(dir):
+        if not os.path.isdir(f"{dir}/{policy_type}"):
+            continue
         with open(f"docs/policies/{policy_type}.md", "w") as f:
             f.write(f"\n")
             for resource_type in os.listdir(os.path.join(dir,policy_type)):
                 f.write(f"### {resource_type}\n")
-                f.write("| Category | Resource | Severity | Description | Reference ID |\n")
-                f.write("| -------- | -------- | -------- | ----------- | ------------ |\n")
+                f.write("| Category | Resource | Severity | Description | Reference ID | ID |\n")
+                f.write("| -------- | -------- | -------- | ----------- | ------------ | -- |\n")
                 for (dirpath, dirs, files) in os.walk(os.path.join(dir, policy_type, resource_type)):
                     for filename in files:
                         if '.json' in filename:
@@ -19,7 +21,8 @@ def dir_size(dir):
                                 severity = policy['severity']
                                 description = policy['description'].replace('\n','')
                                 reference_id = policy['reference_id']
-                                f.write(f"| {category} | {resource} | {severity} | {description} | {reference_id} |\n")
+                                id = policy['id']
+                                f.write(f"| {category} | {resource} | {severity} | {description} | {reference_id} | {id} |\n")
                 f.write("\n\n")
 
 if __name__ == '__main__':

--- a/docs/policies/gcp.md
+++ b/docs/policies/gcp.md
@@ -1,151 +1,335 @@
 
 ### google_container_node_pool
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Operational Efficiency | gcp | HIGH | Ensure 'Automatic node upgrade' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.101 |
-| Operational Efficiency | gcp | HIGH | Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image. | accurics.gcp.OPS.114 |
-| Operational Efficiency | gcp | MEDIUM | Ensure 'Automatic node repair' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.144 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | gcp | LOW | Ensure 'Automatic node upgrade' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.101 | AC_GCP_0017 |
+| Compliance Validation | gcp | HIGH | Ensure Container-Optimized OS (cos) is used for Kubernetes Engine Clusters Node image. | accurics.gcp.OPS.114 | AC_GCP_0016 |
+| Security Best Practices | gcp | LOW | Ensure 'Automatic node repair' is enabled for Kubernetes Clusters. | accurics.gcp.OPS.144 | AC_GCP_0015 |
 
 
 ### github_repository
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Repository is Not Private. | accurics.gcp.IAM.145 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | MEDIUM | Repository is Not Private. | accurics.gcp.IAM.145 | AC_GCP_0231 |
 
 
 ### google_bigquery_dataset
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | HIGH | BigQuery datasets may be anonymously or publicly accessible. | accurics.gcp.IAM.106 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | HIGH | BigQuery datasets may be anonymously or publicly accessible. | accurics.gcp.IAM.106 | AC_GCP_0230 |
 
 
 ### google_compute_project_metadata
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Access Control | gcp | HIGH | Ensure oslogin is enabled for a Project | accurics.gcp.IAM.127 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | HIGH | Ensure oslogin is enabled for a Project | accurics.gcp.IAM.127 | AC_GCP_0291 |
 
 
 ### google_compute_subnetwork
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging  | gcp | MEDIUM | Ensure that VPC Flow Logs is enabled for every subnet in a VPC Network. | accurics.gcp.LOG.118 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | gcp | MEDIUM | Ensure that VPC Flow Logs is enabled for every subnet in a VPC Network. | accurics.gcp.LOG.118 | AC_GCP_0033 |
 
 
 ### google_project_iam_audit_config
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | gcp | HIGH | Ensure that Cloud Audit Logging is configured properly across all services and all users from a project. | accurics.gcp.LOG.010 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | gcp | LOW | Ensure that Cloud Audit Logging is configured properly across all services and all users from a project. | accurics.gcp.LOG.010 | AC_GCP_0009 |
 
 
 ### google_sql_database_instance
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Backup & Disaster Recovery | gcp | HIGH | Ensure all Cloud SQL database instance have backup configuration enabled. | accurics.gcp.BDR.105 |
-| Network Security | gcp | HIGH | Ensure that Cloud SQL database Instances are not open to the world. | accurics.gcp.NS.102 |
-| Encryption & Key Management | gcp | HIGH | Ensure that Cloud SQL database instance requires all incoming connections to use SSL | accurics.gcp.EKM.141 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Resilience | gcp | HIGH | Ensure all Cloud SQL database instance have backup configuration enabled. | accurics.gcp.BDR.105 | AC_GCP_0001 |
+| Infrastructure Security | gcp | HIGH | Ensure that Cloud SQL database Instances are not open to the world. | accurics.gcp.NS.102 | AC_GCP_0295 |
+| Infrastructure Security | gcp | HIGH | Ensure that Cloud SQL database instance requires all incoming connections to use SSL | accurics.gcp.EKM.141 | AC_GCP_0003 |
 
 
 ### google_compute_instance
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | gcp | MEDIUM | Ensure IP forwarding is not enabled on Instances. | accurics.gcp.NS.130 |
-| Network Security | gcp | MEDIUM | Ensure 'Block Project-wide SSH keys' is enabled for VM instances. | accurics.gcp.NS.126 |
-| Encryption & Key Management | gcp | MEDIUM | VM disks attached to a compute instance should be encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.132 |
-| Identity & Access Management | gcp | MEDIUM | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.IAM.124 |
-| Network Security | gcp | MEDIUM | Ensure 'Enable connecting to serial ports' is not enabled for VM instances. | accurics.gcp.NS.129 |
-| Network Security  | gcp | MEDIUM | Ensure Compute instances are launched with Shielded VM enabled. | accurics.gcp.NS.133 |
-| Identity & Access Management | gcp | MEDIUM | Ensure that no instance in the project overrides the project setting for enabling OSLogin | accurics.gcp.IAM.128 |
-| Access Control | gcp | HIGH | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.NS.125 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | gcp | MEDIUM | Ensure IP forwarding is not enabled on Instances. | accurics.gcp.NS.130 | AC_GCP_0232 |
+| Infrastructure Security | gcp | HIGH | Ensure 'Block Project-wide SSH keys' is enabled for VM instances. | accurics.gcp.NS.126 | AC_GCP_0039 |
+| Data Protection | gcp | MEDIUM | VM disks attached to a compute instance should be encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.132 | AC_GCP_0036 |
+| Identity and Access Management | gcp | HIGH | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.IAM.124 | AC_GCP_0040 |
+| Infrastructure Security | gcp | MEDIUM | Ensure 'Enable connecting to serial ports' is not enabled for VM instances. | accurics.gcp.NS.129 | AC_GCP_0037 |
+| Infrastructure Security | gcp | MEDIUM | Ensure Compute instances are launched with Shielded VM enabled. | accurics.gcp.NS.133 | AC_GCP_0035 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that no instance in the project overrides the project setting for enabling OSLogin | accurics.gcp.IAM.128 | AC_GCP_0038 |
+| Infrastructure Security | gcp | HIGH | Instances may have been configured to use the default service account with full access to all Cloud APIs | accurics.gcp.NS.125 | AC_GCP_0041 |
 
 
 ### google_storage_bucket_iam_binding
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Ensure that Cloud Storage bucket is not anonymously or publicly accessible. | accurics.gcp.IAM.121 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | MEDIUM | Ensure that Cloud Storage bucket is not anonymously or publicly accessible. | accurics.gcp.IAM.121 | AC_GCP_0237 |
 
 
 ### google_container_cluster
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Monitoring | gcp | HIGH | Ensure Stackdriver Monitoring is enabled on Kubernetes Engine Clusters. | accurics.gcp.MON.143 |
-| Network Security | gcp | HIGH | Ensure Kubernetes Cluster is created with Private cluster enabled. | accurics.gcp.NS.117 |
-| Operational Efficiency | gcp | HIGH | Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters. | accurics.gcp.OPS.116 |
-| Identity & Access Management | gcp | HIGH | Ensure GKE basic auth is disabled. | accurics.gcp.IAM.110 |
-| Network Security | gcp | HIGH | Ensure Master Authentication is set to enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.112 |
-| Operational Efficiency | gcp | HIGH | Ensure Kubernetes Cluster is created with Alias IP ranges enabled | accurics.gcp.OPS.115 |
-| Network Security | gcp | HIGH | Ensure GKE Control Plane is not public. | accurics.gcp.NS.109 |
-| Identity & Access Management | gcp | HIGH | Ensure Kubernetes Cluster is created with Client Certificate disabled. | accurics.gcp.IAM.104 |
-| Operational Efficiency | gcp | HIGH | Ensure Kubernetes Clusters are configured with Labels. | accurics.gcp.OPS.113 |
-| Identity & Access Management | gcp | HIGH | Ensure Legacy Authorization is set to disabled on Kubernetes Engine Clusters. | accurics.gcp.IAM.142 |
-| Logging | gcp | HIGH | Ensure Stackdriver Logging is enabled on Kubernetes Engine Clusters. | accurics.gcp.LOG.100 |
-| Network Security | gcp | HIGH | Ensure Network policy is enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.103 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | Medium | GKE Control Plane is exposed to few public IP addresses using master-authorized-network-config | AC-GC-IS-CC-M-0367 | AC_GCP_0292 |
+| Logging and Monitoring | gcp | HIGH | Ensure Stackdriver Monitoring is enabled on Kubernetes Engine Clusters. | accurics.gcp.MON.143 | AC_GCP_0029 |
+| Infrastructure Security | gcp | HIGH | Ensure Kubernetes Cluster is created with Private cluster enabled. | accurics.gcp.NS.117 | AC_GCP_0294 |
+| Compliance Validation | gcp | HIGH | Ensure PodSecurityPolicy controller is enabled on the Kubernetes Engine Clusters. | accurics.gcp.OPS.116 | AC_GCP_0022 |
+| Identity and Access Management | gcp | HIGH | Ensure GKE basic auth is disabled. | accurics.gcp.IAM.110 | AC_GCP_0021 |
+| Infrastructure Security | gcp | HIGH | Ensure Master Authentication is set to enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.112 | AC_GCP_0027 |
+| Compliance Validation | gcp | HIGH | Ensure Kubernetes Cluster is created with Alias IP ranges enabled | accurics.gcp.OPS.115 | AC_GCP_0025 |
+| Infrastructure Security | gcp | HIGH | Ensure GKE Control Plane is not public. | accurics.gcp.NS.109 | AC_GCP_0023 |
+| Identity and Access Management | gcp | MEDIUM | Ensure Kubernetes Cluster is created with Client Certificate disabled. | accurics.gcp.IAM.104 | AC_GCP_0024 |
+| Compliance Validation | gcp | HIGH | Ensure Kubernetes Clusters are configured with Labels. | accurics.gcp.OPS.113 | AC_GCP_0019 |
+| Identity and Access Management | gcp | HIGH | Ensure Legacy Authorization is set to disabled on Kubernetes Engine Clusters. | accurics.gcp.IAM.142 | AC_GCP_0028 |
+| Logging and Monitoring | gcp | HIGH | Ensure Stackdriver Logging is enabled on Kubernetes Engine Clusters. | accurics.gcp.LOG.100 | AC_GCP_0030 |
+| Infrastructure Security | gcp | HIGH | Ensure Network policy is enabled on Kubernetes Engine Clusters. | accurics.gcp.NS.103 | AC_GCP_0293 |
 
 
 ### google_project
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | gcp | MEDIUM | Ensure that the default network does not exist in a project. | accurics.gcp.NS.119 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | gcp | MEDIUM | Ensure that the default network does not exist in a project. | accurics.gcp.NS.119 | AC_GCP_0010 |
 
 
 ### google_compute_firewall
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | gcp | MEDIUM | Ensure that SSH access is restricted from the internet | accurics.gcp.NS.149 |
-| Network Security | gcp | MEDIUM | Ensure that SSH access is restricted from the internet | accurics.gcp.NS.148 |
-| Network Security  | gcp | MEDIUM | Ensure Google compute firewall ingress does not allow unrestricted rdp access. | accurics.gcp.NS.123 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | Ensure Puppet Master (TCP:8140) is not exposed to public for Google Compute Firewall | AC_GCP_0049 | AC_GCP_0049 |
+| Infrastructure Security | json | HIGH | Ensure Remote Desktop (TCP:3389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0225 | AC_GCP_0225 |
+| Infrastructure Security | json | HIGH | Ensure LDAP SSL (TCP:636) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0161 | AC_GCP_0161 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP:4506) is not exposed to public for Google Compute Firewall | AC_GCP_0073 | AC_GCP_0073 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra (TCP:7001) is not exposed to public for Google Compute Firewall | AC_GCP_0136 | AC_GCP_0136 |
+| Infrastructure Security | json | HIGH | Ensure VNC Listener (TCP:5500) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0065 | AC_GCP_0065 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (UDP:11215) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0120 | AC_GCP_0120 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB (TCP:1521) is not exposed to public for Google Compute Firewall | AC_GCP_0209 | AC_GCP_0209 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Internode Communication (TCP:7000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0198 | AC_GCP_0198 |
+| Infrastructure Security | json | LOW | Ensure Elastic Search (TCP:9300) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0177 | AC_GCP_0177 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (TCP:138) is not exposed to public for Google Compute Firewall | AC_GCP_0100 | AC_GCP_0100 |
+| Infrastructure Security | json | LOW | Ensure Mongo Web Portal (TCP:27018) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0045 | AC_GCP_0045 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Server (TCP:1433) is not exposed to public for Google Compute Firewall | AC_GCP_0157 | AC_GCP_0157 |
+| Infrastructure Security | json | LOW | Ensure Postgres SQL (TCP:5432) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0141 | AC_GCP_0141 |
+| Infrastructure Security | json | HIGH | Ensure Microsoft-DS (TCP:445) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0116 | AC_GCP_0116 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis Service browser (TCP:2382) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0053 | AC_GCP_0053 |
+| Infrastructure Security | json | HIGH | Ensure Elastic Search (TCP:9200) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0182 | AC_GCP_0182 |
+| Infrastructure Security | json | HIGH | Ensure LDAP (UDP:389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0213 | AC_GCP_0213 |
+| Infrastructure Security | json | LOW | Ensure NetBios Session Service (UDP:139) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0090 | AC_GCP_0090 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB (TCP:2483) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0205 | AC_GCP_0205 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (TCP:8000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0069 | AC_GCP_0069 |
+| Infrastructure Security | json | HIGH | Ensure DNS (UDP:53) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0086 | AC_GCP_0086 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Monitoring (TCP:7199) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0194 | AC_GCP_0194 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (TCP:8080) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0068 | AC_GCP_0068 |
+| Infrastructure Security | json | LOW | Ensure SNMP (UDP:161) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0087 | AC_GCP_0087 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB (UDP:2483) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0204 | AC_GCP_0204 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (UDP:139) is not exposed to public for Google Compute Firewall | AC_GCP_0091 | AC_GCP_0091 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP (UDP:389) is not exposed to public for Google Compute Firewall | AC_GCP_0212 | AC_GCP_0212 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Thrift (TCP:9160) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0183 | AC_GCP_0183 |
+| Infrastructure Security | json | LOW | Ensure Telnet (TCP:23) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0117 | AC_GCP_0117 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Service browser (TCP:2382) is not exposed to public for Google Compute Firewall | AC_GCP_0052 | AC_GCP_0052 |
+| Infrastructure Security | json | HIGH | Ensure Postgres SQL (UDP:5432) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0140 | AC_GCP_0140 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Server (TCP:1433) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0156 | AC_GCP_0156 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Datagram Service (TCP:138) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0101 | AC_GCP_0101 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter agent (TCP:61621) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0044 | AC_GCP_0044 |
+| Infrastructure Security | json | HIGH | Ensure SSH (TCP:20) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0228 | AC_GCP_0228 |
+| Infrastructure Security | json | LOW | Ensure Redis (TCP:6379) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0199 | AC_GCP_0199 |
+| Infrastructure Security | json | HIGH | Ensure Unencrypted Memcached Instances (TCP:11211) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0176 | AC_GCP_0176 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB (TCP:1521) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0208 | AC_GCP_0208 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Listener (TCP:5500) is not exposed to public for Google Compute Firewall | AC_GCP_0064 | AC_GCP_0064 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP:11215) is not exposed to public for Google Compute Firewall | AC_GCP_0121 | AC_GCP_0121 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (TCP:4506) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0072 | AC_GCP_0072 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra (TCP:7001) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0137 | AC_GCP_0137 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP SSL (TCP:636) is not exposed to public for Google Compute Firewall | AC_GCP_0160 | AC_GCP_0160 |
+| Infrastructure Security | json | MEDIUM | Ensure Remote Desktop (TCP:3389) is not exposed to public for Google Compute Firewall | AC_GCP_0224 | AC_GCP_0224 |
+| Infrastructure Security | json | LOW | Ensure Puppet Master (TCP:8140) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0048 | AC_GCP_0048 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (TCP:137) is not exposed to public for Google Compute Firewall | AC_GCP_0106 | AC_GCP_0106 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter agent (TCP:61621) is not exposed to public for Google Compute Firewall | AC_GCP_0043 | AC_GCP_0043 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (TCP:2484) is not exposed to public for Google Compute Firewall | AC_GCP_0151 | AC_GCP_0151 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (UDP:2484) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0147 | AC_GCP_0147 |
+| Infrastructure Security | json | HIGH | Ensure POP3 (TCP:110) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0110 | AC_GCP_0110 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Browser Service (UDP:1434) is not exposed to public for Google Compute Firewall | AC_GCP_0055 | AC_GCP_0055 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Thrift (TCP:9160) is not exposed to public for Google Compute Firewall | AC_GCP_0184 | AC_GCP_0184 |
+| Infrastructure Security | json | MEDIUM | Ensure LDAP (TCP:389) is not exposed to public for Google Compute Firewall | AC_GCP_0215 | AC_GCP_0215 |
+| Infrastructure Security | json | MEDIUM | Ensure CIFS / SMB (TCP:3020) is not exposed to public for Google Compute Firewall | AC_GCP_0079 | AC_GCP_0079 |
+| Infrastructure Security | json | LOW | Ensure NetBios Datagram Service (TCP:138) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0096 | AC_GCP_0096 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB (UDP:2483) is not exposed to public for Google Compute Firewall | AC_GCP_0203 | AC_GCP_0203 |
+| Infrastructure Security | json | HIGH | Ensure CIFS / SMB (TCP:3020) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0080 | AC_GCP_0080 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Monitoring (TCP:7199) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0192 | AC_GCP_0192 |
+| Infrastructure Security | json | LOW | Ensure Remote Desktop (TCP:3389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0223 | AC_GCP_0223 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Admin (TCP:1434) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0059 | AC_GCP_0059 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Client (TCP:9042) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0188 | AC_GCP_0188 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter Monitoring (TCP:61620) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0167 | AC_GCP_0167 |
+| Infrastructure Security | json | LOW | Ensure SaltStack Master (TCP:4505) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0075 | AC_GCP_0075 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP:11214) is not exposed to public for Google Compute Firewall | AC_GCP_0130 | AC_GCP_0130 |
+| Infrastructure Security | json | HIGH | Ensure CiscoSecure, Websm (TCP:9090) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0219 | AC_GCP_0219 |
+| Infrastructure Security | json | LOW | Ensure VNC Listener (TCP:5500) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0063 | AC_GCP_0063 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (UDP:11214) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0126 | AC_GCP_0126 |
+| Infrastructure Security | json | LOW | Ensure Unencrypted Memcached Instances (UDP:11211) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0171 | AC_GCP_0171 |
+| Infrastructure Security | json | HIGH | Ensure Unencrypted Mongo Instances (TCP:27017) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0170 | AC_GCP_0170 |
+| Infrastructure Security | json | HIGH | Ensure VNC Server (TCP:5900) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0062 | AC_GCP_0062 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (UDP:11214) is not exposed to public for Google Compute Firewall | AC_GCP_0127 | AC_GCP_0127 |
+| Infrastructure Security | json | MEDIUM | Ensure CiscoSecure, Websm (TCP:9090) is not exposed to public for Google Compute Firewall | AC_GCP_0218 | AC_GCP_0218 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (TCP:4506) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0074 | AC_GCP_0074 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (TCP:11214) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0131 | AC_GCP_0131 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter Website (TCP:8888) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0189 | AC_GCP_0189 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter Monitoring (TCP:61620) is not exposed to public for Google Compute Firewall | AC_GCP_0166 | AC_GCP_0166 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Admin (TCP:1434) is not exposed to public for Google Compute Firewall | AC_GCP_0058 | AC_GCP_0058 |
+| Infrastructure Security | json | HIGH | Ensure Hadoop Name Node (TCP:9000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0222 | AC_GCP_0222 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Monitoring (TCP:7199) is not exposed to public for Google Compute Firewall | AC_GCP_0193 | AC_GCP_0193 |
+| Infrastructure Security | json | LOW | Ensure Prevalent known internal port (TCP:3000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0081 | AC_GCP_0081 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB (UDP:2483) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0202 | AC_GCP_0202 |
+| Infrastructure Security | json | LOW | Ensure CIFS / SMB (TCP:3020) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0078 | AC_GCP_0078 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Datagram Service (TCP:138) is not exposed to public for Google Compute Firewall | AC_GCP_0097 | AC_GCP_0097 |
+| Infrastructure Security | json | LOW | Ensure LDAP (TCP:389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0214 | AC_GCP_0214 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra Thrift (TCP:9160) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0185 | AC_GCP_0185 |
+| Infrastructure Security | json | LOW | Ensure SMTP (TCP:25) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0111 | AC_GCP_0111 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Browser Service (UDP:1434) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0054 | AC_GCP_0054 |
+| Infrastructure Security | json | HIGH | Ensure MySQL (TCP:3306) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0146 | AC_GCP_0146 |
+| Infrastructure Security | json | LOW | Ensure Oracle DB SSL (TCP:2484) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0150 | AC_GCP_0150 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (TCP:137) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0107 | AC_GCP_0107 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter agent (TCP:61621) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0042 | AC_GCP_0042 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra OpsCenter Website (TCP:8888) is not exposed to public for Google Compute Firewall | AC_GCP_0190 | AC_GCP_0190 |
+| Infrastructure Security | json | MEDIUM | Ensure Prevalent known internal port (TCP:3000) is not exposed to public for Google Compute Firewall | AC_GCP_0082 | AC_GCP_0082 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (UDP:11214) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0128 | AC_GCP_0128 |
+| Infrastructure Security | json | HIGH | Ensure Redis (TCP:6379) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0201 | AC_GCP_0201 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBios Session Service (TCP:139) is not exposed to public for Google Compute Firewall | AC_GCP_0094 | AC_GCP_0094 |
+| Infrastructure Security | json | LOW | Ensure CiscoSecure, Websm (TCP:9090) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0217 | AC_GCP_0217 |
+| Infrastructure Security | json | MEDIUM | Ensure Unencrypted Mongo Instances (TCP:27017) is not exposed to public for Google Compute Firewall | AC_GCP_0169 | AC_GCP_0169 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Client (TCP:9042) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0186 | AC_GCP_0186 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Admin (TCP:1434) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0057 | AC_GCP_0057 |
+| Infrastructure Security | json | MEDIUM | Ensure SMTP (TCP:25) is not exposed to public for Google Compute Firewall | AC_GCP_0112 | AC_GCP_0112 |
+| Infrastructure Security | json | MEDIUM | Ensure MySQL (TCP:3306) is not exposed to public for Google Compute Firewall | AC_GCP_0145 | AC_GCP_0145 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis Services (TCP:2383) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0153 | AC_GCP_0153 |
+| Infrastructure Security | json | HIGH | Ensure NetBIOS Name Service (UDP:137) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0104 | AC_GCP_0104 |
+| Infrastructure Security | json | HIGH | Ensure Unencrypted Memcached Instances (UDP:11211) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0173 | AC_GCP_0173 |
+| Infrastructure Security | json | MEDIUM | Ensure Memcached SSL (TCP:11215) is not exposed to public for Google Compute Firewall | AC_GCP_0124 | AC_GCP_0124 |
+| Infrastructure Security | json | MEDIUM | Ensure VNC Server (TCP:5900) is not exposed to public for Google Compute Firewall | AC_GCP_0061 | AC_GCP_0061 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Datagram Service (TCP:138) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0098 | AC_GCP_0098 |
+| Infrastructure Security | json | LOW | Ensure Remote Desktop (TCP:3389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0132 | AC_GCP_0132 |
+| Infrastructure Security | json | HIGH | Ensure SaltStack Master (TCP:4505) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0077 | AC_GCP_0077 |
+| Infrastructure Security | json | LOW | Ensure Cassandra OpsCenter Monitoring (TCP:61620) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0165 | AC_GCP_0165 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (UDP:2484) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0149 | AC_GCP_0149 |
+| Infrastructure Security | json | MEDIUM | Ensure Hadoop Name Node (TCP:9000) is not exposed to public for Google Compute Firewall | AC_GCP_0221 | AC_GCP_0221 |
+| Infrastructure Security | json | LOW | Ensure POP3 (TCP:110) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0108 | AC_GCP_0108 |
+| Infrastructure Security | json | MEDIUM | Ensure POP3 (TCP:110) is not exposed to public for Google Compute Firewall | AC_GCP_0109 | AC_GCP_0109 |
+| Infrastructure Security | json | LOW | Ensure Hadoop Name Node (TCP:9000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0220 | AC_GCP_0220 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB SSL (UDP:2484) is not exposed to public for Google Compute Firewall | AC_GCP_0148 | AC_GCP_0148 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Debugger (TCP:135) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0164 | AC_GCP_0164 |
+| Infrastructure Security | json | LOW | Ensure NetBios Datagram Service (TCP:138) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0099 | AC_GCP_0099 |
+| Infrastructure Security | json | MEDIUM | Ensure Remote Desktop (TCP:3389) is not exposed to public for Google Compute Firewall | AC_GCP_0133 | AC_GCP_0133 |
+| Infrastructure Security | json | MEDIUM | Ensure SaltStack Master (TCP:4505) is not exposed to public for Google Compute Firewall | AC_GCP_0076 | AC_GCP_0076 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (TCP:11215) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0125 | AC_GCP_0125 |
+| Infrastructure Security | json | LOW | Ensure VNC Server (TCP:5900) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0060 | AC_GCP_0060 |
+| Infrastructure Security | json | MEDIUM | Ensure Unencrypted Memcached Instances (UDP:11211) is not exposed to public for Google Compute Firewall | AC_GCP_0172 | AC_GCP_0172 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (TCP:137) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0105 | AC_GCP_0105 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB SSL (TCP:2484) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0152 | AC_GCP_0152 |
+| Infrastructure Security | json | LOW | Ensure MySQL (TCP:3306) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0144 | AC_GCP_0144 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Browser Service (UDP:1434) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0056 | AC_GCP_0056 |
+| Infrastructure Security | json | HIGH | Ensure SMTP (TCP:25) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0113 | AC_GCP_0113 |
+| Infrastructure Security | json | LOW | Ensure Unencrypted Mongo Instances (TCP:27017) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0168 | AC_GCP_0168 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Client (TCP:9042) is not exposed to public for Google Compute Firewall | AC_GCP_0187 | AC_GCP_0187 |
+| Infrastructure Security | json | HIGH | Ensure LDAP (TCP:389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0216 | AC_GCP_0216 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Session Service (TCP:139) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0095 | AC_GCP_0095 |
+| Infrastructure Security | json | MEDIUM | Ensure Redis (TCP:6379) is not exposed to public for Google Compute Firewall | AC_GCP_0200 | AC_GCP_0200 |
+| Infrastructure Security | json | HIGH | Ensure Prevalent known internal port (TCP:3000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0083 | AC_GCP_0083 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (TCP:11214) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0129 | AC_GCP_0129 |
+| Infrastructure Security | json | HIGH | Ensure Cassandra OpsCenter Website (TCP:8888) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0191 | AC_GCP_0191 |
+| Infrastructure Security | json | MEDIUM | Ensure Unencrypted Memcached Instances (TCP:11211) is not exposed to public for Google Compute Firewall | AC_GCP_0175 | AC_GCP_0175 |
+| Infrastructure Security | json | HIGH | Ensure Memcached SSL (UDP:11215) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0122 | AC_GCP_0122 |
+| Infrastructure Security | json | MEDIUM | Ensure SNMP (UDP:161) is not exposed to public for Google Compute Firewall | AC_GCP_0088 | AC_GCP_0088 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP:8080) is not exposed to public for Google Compute Firewall | AC_GCP_0067 | AC_GCP_0067 |
+| Infrastructure Security | json | HIGH | Ensure Remote Desktop (TCP:3389) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0134 | AC_GCP_0134 |
+| Infrastructure Security | json | HIGH | Ensure Known internal web port (TCP:8000) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0071 | AC_GCP_0071 |
+| Infrastructure Security | json | MEDIUM | Ensure MSSQL Debugger (TCP:135) is not exposed to public for Google Compute Firewall | AC_GCP_0163 | AC_GCP_0163 |
+| Infrastructure Security | json | MEDIUM | Ensure Telnet (TCP:23) is not exposed to public for Google Compute Firewall | AC_GCP_0118 | AC_GCP_0118 |
+| Infrastructure Security | json | LOW | Ensure LDAP SSL (TCP:636) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0159 | AC_GCP_0159 |
+| Infrastructure Security | json | MEDIUM | Ensure SSH (TCP:20) is not exposed to public for Google Compute Firewall | AC_GCP_0227 | AC_GCP_0227 |
+| Infrastructure Security | json | HIGH | Ensure Elastic Search (TCP:9300) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0179 | AC_GCP_0179 |
+| Infrastructure Security | json | LOW | Ensure Cassandra Internode Communication (TCP:7000) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0196 | AC_GCP_0196 |
+| Infrastructure Security | json | LOW | Ensure DNS (UDP:53) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0084 | AC_GCP_0084 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB (TCP:2483) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0207 | AC_GCP_0207 |
+| Infrastructure Security | json | LOW | Ensure Postgres SQL (UDP:5432) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0138 | AC_GCP_0138 |
+| Infrastructure Security | json | HIGH | Ensure NetBios Session Service (UDP:139) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0092 | AC_GCP_0092 |
+| Infrastructure Security | json | LOW | Ensure LDAP (UDP:389) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0211 | AC_GCP_0211 |
+| Infrastructure Security | json | LOW | Ensure Elastic Search (TCP:9200) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0180 | AC_GCP_0180 |
+| Infrastructure Security | json | LOW | Ensure SQL Server Analysis Service browser (TCP:2382) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0051 | AC_GCP_0051 |
+| Infrastructure Security | json | LOW | Ensure Microsoft-DS (TCP:445) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0114 | AC_GCP_0114 |
+| Infrastructure Security | json | HIGH | Ensure Postgres SQL (TCP:5432) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0143 | AC_GCP_0143 |
+| Infrastructure Security | json | HIGH | Ensure SQL Server Analysis Services (TCP:2383) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0155 | AC_GCP_0155 |
+| Infrastructure Security | json | HIGH | Ensure Mongo Web Portal (TCP:27018) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0047 | AC_GCP_0047 |
+| Infrastructure Security | json | LOW | Ensure NetBIOS Name Service (UDP:137) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0102 | AC_GCP_0102 |
+| Infrastructure Security | json | MEDIUM | Ensure Mongo Web Portal (TCP:27018) is not exposed to public for Google Compute Firewall | AC_GCP_0046 | AC_GCP_0046 |
+| Infrastructure Security | json | MEDIUM | Ensure NetBIOS Name Service (UDP:137) is not exposed to public for Google Compute Firewall | AC_GCP_0103 | AC_GCP_0103 |
+| Infrastructure Security | json | MEDIUM | Ensure SQL Server Analysis Services (TCP:2383) is not exposed to public for Google Compute Firewall | AC_GCP_0154 | AC_GCP_0154 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (TCP:5432) is not exposed to public for Google Compute Firewall | AC_GCP_0142 | AC_GCP_0142 |
+| Infrastructure Security | json | HIGH | Ensure Puppet Master (TCP:8140) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0050 | AC_GCP_0050 |
+| Infrastructure Security | json | MEDIUM | Ensure Microsoft-DS (TCP:445) is not exposed to public for Google Compute Firewall | AC_GCP_0115 | AC_GCP_0115 |
+| Infrastructure Security | json | MEDIUM | Ensure Elastic Search (TCP:9200) is not exposed to public for Google Compute Firewall | AC_GCP_0181 | AC_GCP_0181 |
+| Infrastructure Security | json | HIGH | Ensure Oracle DB (TCP:1521) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0210 | AC_GCP_0210 |
+| Infrastructure Security | json | MEDIUM | Ensure Postgres SQL (UDP:5432) is not exposed to public for Google Compute Firewall | AC_GCP_0139 | AC_GCP_0139 |
+| Infrastructure Security | json | LOW | Ensure NetBios Session Service (TCP:139) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0093 | AC_GCP_0093 |
+| Infrastructure Security | json | MEDIUM | Ensure Oracle DB (TCP:2483) is not exposed to public for Google Compute Firewall | AC_GCP_0206 | AC_GCP_0206 |
+| Infrastructure Security | json | MEDIUM | Ensure DNS (UDP:53) is not exposed to public for Google Compute Firewall | AC_GCP_0085 | AC_GCP_0085 |
+| Infrastructure Security | json | MEDIUM | Ensure Elastic Search (TCP:9300) is not exposed to public for Google Compute Firewall | AC_GCP_0178 | AC_GCP_0178 |
+| Infrastructure Security | json | MEDIUM | Ensure Cassandra Internode Communication (TCP:7000) is not exposed to public for Google Compute Firewall | AC_GCP_0197 | AC_GCP_0197 |
+| Infrastructure Security | json | LOW | Ensure SSH (TCP:20) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0226 | AC_GCP_0226 |
+| Infrastructure Security | json | HIGH | Ensure MSSQL Server (TCP:1433) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0158 | AC_GCP_0158 |
+| Infrastructure Security | json | HIGH | Ensure Telnet (TCP:23) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0119 | AC_GCP_0119 |
+| Infrastructure Security | json | LOW | Ensure MSSQL Debugger (TCP:135) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0162 | AC_GCP_0162 |
+| Infrastructure Security | json | LOW | Ensure Cassandra (TCP:7001) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0135 | AC_GCP_0135 |
+| Infrastructure Security | json | MEDIUM | Ensure Known internal web port (TCP:8000) is not exposed to public for Google Compute Firewall | AC_GCP_0070 | AC_GCP_0070 |
+| Infrastructure Security | json | LOW | Ensure Memcached SSL (TCP:11215) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0123 | AC_GCP_0123 |
+| Infrastructure Security | json | HIGH | Ensure SNMP (UDP:161) is not exposed to entire internet for Google Compute Firewall | AC_GCP_0089 | AC_GCP_0089 |
+| Infrastructure Security | json | LOW | Ensure Known internal web port (TCP:8080) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0066 | AC_GCP_0066 |
+| Infrastructure Security | json | LOW | Ensure Unencrypted Memcached Instances (TCP:11211) is not exposed to private hosts more than 32 for Google Compute Firewall | AC_GCP_0174 | AC_GCP_0174 |
 
 
 ### google_dns_managed_zone
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | HIGH | Ensure that RSASHA1 is not used for the zone-signing and key-signing keys in Cloud DNS DNSSEC. | accurics.gcp.EKM.108 |
-| Network Security | gcp | HIGH | Ensure that DNSSEC is enabled for Cloud DNS. | accurics.gcp.NS.107 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | gcp | HIGH | Ensure that RSASHA1 is not used for the zone-signing and key-signing keys in Cloud DNS DNSSEC. | accurics.gcp.EKM.108 | AC_GCP_0013 |
+| Infrastructure Security | gcp | LOW | Ensure that DNSSEC is enabled for Cloud DNS. | accurics.gcp.NS.107 | AC_GCP_0014 |
 
 
 ### google_compute_disk
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | MEDIUM | Ensure VM disks for critical VMs are encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.131 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Data Protection | gcp | MEDIUM | Ensure VM disks for critical VMs are encrypted with Customer Supplied Encryption Keys (CSEK) . | accurics.gcp.EKM.131 | AC_GCP_0229 |
 
 
 ### google_project_iam_member
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.137 |
-| Identity & Access Management | gcp | MEDIUM | Ensure that Service Account has no Admin privileges. | accurics.gcp.IAM.138 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | HIGH | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.137 | AC_GCP_0006 |
+| Identity and Access Management | gcp | HIGH | Ensure that Service Account has no Admin privileges. | accurics.gcp.IAM.138 | AC_GCP_0005 |
 
 
 ### google_storage_bucket_iam_member
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | HIGH | Ensure that Cloud Storage bucket is not anonymously or publicly Accessible. | accurics.gcp.IAM.120 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | HIGH | Ensure that Cloud Storage bucket is not anonymously or publicly Accessible. | accurics.gcp.IAM.120 | AC_GCP_0238 |
 
 
 ### google_compute_ssl_policy
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | MEDIUM | Ensure no HTTPS or SSL proxy load balancers permit SSL policies with weak cipher suites. | accurics.gcp.EKM.134 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | gcp | MEDIUM | Ensure no HTTPS or SSL proxy load balancers permit SSL policies with weak cipher suites. | accurics.gcp.EKM.134 | AC_GCP_0034 |
 
 
 ### google_storage_bucket
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Logging | gcp | HIGH | Ensure that logging is enabled for Cloud storage buckets. | accurics.gcp.LOG.147 |
-| Logging | gcp | HIGH | Ensure that object versioning is enabled on log-buckets. | accurics.gcp.LOG.146 |
-| Identity & Access Management | gcp | MEDIUM | Ensure that Cloud Storage buckets have uniform bucket-level access enabled. | accurics.gcp.IAM.122 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Logging and Monitoring | gcp | HIGH | Ensure that logging is enabled for Cloud storage buckets. | accurics.gcp.LOG.147 | AC_GCP_0233 |
+| Logging and Monitoring | gcp | HIGH | Ensure that object versioning is enabled on log-buckets. | accurics.gcp.LOG.146 | AC_GCP_0241 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that Cloud Storage buckets have uniform bucket-level access enabled. | accurics.gcp.IAM.122 | AC_GCP_0234 |
 
 
 ### google_kms_crypto_key
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption & Key Management | gcp | MEDIUM | Ensure Encryption keys are rotated within a period of 90 days. | accurics.gcp.EKM.139 |
-| Encryption & Key Management | gcp | HIGH | Ensure Encryption keys are rotated within a period of 365 days. | accurics.gcp.EKM.007 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | gcp | MEDIUM | Ensure Encryption keys are rotated within a period of 90 days. | accurics.gcp.EKM.139 | AC_GCP_0011 |
+| Security Best Practices | gcp | HIGH | Ensure Encryption keys are rotated within a period of 365 days. | accurics.gcp.EKM.007 | AC_GCP_0012 |
 
 
 ### google_project_iam_binding
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | gcp | MEDIUM | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.136 |
-| Identity and Access Management | gcp | HIGH | Ensure that corporate login credentials are used instead of Gmail accounts. | accurics.gcp.IAM.150 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | gcp | HIGH | Ensure that IAM users are not assigned the Service Account User or Service Account Token Creator roles at project level. | accurics.gcp.IAM.136 | AC_GCP_0007 |
+| Identity and Access Management | gcp | MEDIUM | Ensure that corporate login credentials are used instead of Gmail accounts. | accurics.gcp.IAM.150 | AC_GCP_0008 |
 
 

--- a/docs/policies/github.md
+++ b/docs/policies/github.md
@@ -1,19 +1,19 @@
 
 ### github_repository
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity & Access Management | github | MEDIUM | Repository is Not Private. | accurics.github.IAM.1 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | github | MEDIUM | Repository is Not Private. | accurics.github.IAM.1 | AC_GITHUB_0002 |
 
 
 ### github_repository_webhook
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | github | MEDIUM | Insecure SSL is used for repository webhook. | accurics.github.EKM.2 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Encryption and Key Management | github | MEDIUM | Insecure SSL is used for repository webhook. | accurics.github.EKM.2 | AC_GITHUB_0003 |
 
 
 ### github_organization_webhook
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Encryption and Key Management | github | MEDIUM | Insecure SSL is used for organization webhook. | accurics.github.EKM.1 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Encryption and Key Management | github | MEDIUM | Insecure SSL is used for organization webhook. | accurics.github.EKM.1 | AC_GITHUB_0001 |
 
 

--- a/docs/policies/k8s.md
+++ b/docs/policies/k8s.md
@@ -1,117 +1,75 @@
 
+### kubernetes_endpoint_slice
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | LOW | Ensure endpoint slice is not created or updated with loopback addresses as this acts as an attack vector for exploiting CVE-2021-25737 by an authorized user | AC_K8S_0113 | AC_K8S_0113 |
+
+
 ### kubernetes_service
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | MEDIUM | Restrict the use of externalIPs | AC-K8-NS-SE-M-0188 |
-| Network Security | json | MEDIUM | Ensure that the Tiller Service (Helm v2) is deleted | AC-K8-NS-SE-M-0185 |
-| Network Security | json | LOW | Nodeport service can expose the worker nodes as they have public interface | AC-K8-NS-SV-L-0132 |
-| Network Security | json | MEDIUM | Vulnerable to CVE-2020-8554 | AC-K8-NS-SE-M-0188 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | LOW | Ensure the use of selector is enforced for Kubernetes Ingress or LoadBalancer service | AC_K8S_0114 | AC_K8S_0114 |
+| Infrastructure Security | json | MEDIUM | Restrict the use of externalIPs | AC-K8-NS-SE-M-0188 | AC_K8S_0112 |
+| Infrastructure Security | json | MEDIUM | Ensure that the Tiller Service (Helm v2) is deleted | AC-K8-NS-SE-M-0185 | AC_K8S_0110 |
+| Infrastructure Security | json | LOW | Nodeport service can expose the worker nodes as they have public interface | AC-K8-NS-SV-L-0132 | AC_K8S_0111 |
+| Infrastructure Security | json | MEDIUM | Vulnerable to CVE-2020-8554 | AC-K8-NS-SE-M-0188 | AC_K8S_0112 |
 
 
 ### kubernetes_ingress
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | HIGH | TLS disabled can affect the confidentiality of the data in transit | AC-K8-NS-IN-H-0020 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | json | MEDIUM | TLS disabled can affect the confidentiality of the data in transit | AC-K8-NS-IN-H-0020 | AC_K8S_0002 |
 
 
 ### kubernetes_pod
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Network Security | json | MEDIUM | Containers Should Not Share the Host Network Namespace | AC-K8-NS-PO-M-0164 |
-| Network Security | json | MEDIUM | Image without digest affects the integrity principle of image security | AC-K8-NS-PO-M-0133 |
-| Identity and Access Management | json | HIGH | Minimize Admission of Root Containers | AC-K8-IA-PO-H-0168 |
-| Operational Efficiency | json | Medium | CPU Request Not Set in config file. | AC-K8-OE-PK-M-0155 |
-| Operational Efficiency | json | MEDIUM | Default Namespace Should Not be Used | AC-K8-OE-PO-M-0166 |
-| Network Security | json | HIGH | Do Not Use CAP_SYS_ADMIN Linux Capability | AC-K8-NS-PO-H-0170 |
-| Operational Efficiency | json | Medium | Memory Limits Not Set in config file. | AC-K8-OE-PK-M-0158 |
-| Data Security | json | MEDIUM | Ensure That Tiller (Helm V2) Is Not Deployed | AC-K8-DS-PO-M-0177 |
-| Operational Efficiency | json | LOW | No readiness probe will affect automatic recovery in case of unexpected errors | AC-K8-OE-PO-L-0130 |
-| Identity and Access Management | json | MEDIUM | Default seccomp profile not enabled will make the container to make non-essential system calls | AC-K8-IA-PO-M-0141 |
-| Identity and Access Management | json | MEDIUM | Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions | AC-K8-IA-PO-M-0140 |
-| Network Security | json | HIGH | Prefer using secrets as files over secrets as environment variables | AC-K8-NS-PO-H-0117 |
-| Network Security | json | MEDIUM | Containers Should Not Share Host IPC Namespace | AC-K8-NS-PO-M-0163 |
-| Network Security | json | MEDIUM | Apply Security Context to Your Pods and Containers | AC-K8-NS-PO-M-0122 |
-| Data Security | json | MEDIUM | Ensure Kubernetes Dashboard Is Not Deployed | AC-K8-DS-PO-M-0176 |
-| Identity and Access Management | json | HIGH | Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem | AC-K8-IA-PO-H-0138 |
-| Identity and Access Management | json | MEDIUM | Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host | AC-K8-IA-PO-M-0143 |
-| Identity and Access Management | json | HIGH | Allowing the pod to make system level calls provide access to host/node sensitive information | AC-K8-IA-PO-H-0137 |
-| Operational Efficiency | json | MEDIUM | AlwaysPullImages plugin is not set | AC-K8-OE-PK-M-0034 |
-| Identity and Access Management | json | MEDIUM | Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s | AC-K8-IA-PO-M-0139 |
-| Identity and Access Management | json | MEDIUM | AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats | AC-K8-IA-PO-M-0135 |
-| Identity and Access Management | json | MEDIUM | Containers Should Not Share Host Process ID Namespace | AC-K8-IA-PO-M-0162 |
-| Network Security | json | MEDIUM | Containers Should Run as a High UID to Avoid Host Conflict | AC-K8-NS-PO-M-0182 |
-| Identity and Access Management | json | MEDIUM | Minimize the admission of containers with the NET_RAW capability | AC-K8-IA-PS-M-0112 |
-| Operational Efficiency | json | LOW | No liveness probe will ensure there is no recovery in case of unexpected errors | AC-K8-OE-PO-L-0129 |
-| Operational Efficiency | json | LOW | No tag or container image with :Latest tag makes difficult to rollback and track | AC-K8-OE-PO-L-0134 |
-| Operational Efficiency | json | Medium | Memory Request Not Set in config file. | AC-K8-OE-PK-M-0157 |
-| Cloud Assets Management | json | HIGH | Containers Should Not Run with AllowPrivilegeEscalation | AC-K8-CA-PO-H-0165 |
-| Identity and Access Management | json | HIGH | Minimize the admission of privileged containers | AC-K8-IA-PO-H-0106 |
-| Operational Efficiency | json | Medium | CPU Limits Not Set in config file. | AC-K8-OE-PK-M-0156 |
-| Network Security | json | MEDIUM | Restrict Mounting Docker Socket in a Container | AC-K8-NS-PO-M-0171 |
-| Identity and Access Management | json | MEDIUM | Ensure that Service Account Tokens are only mounted where necessary | AC-K8-IA-PO-M-0105 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.120 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.116 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.117 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.106 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.110 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.111 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.107 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.112 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.108 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.109 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.105 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.113 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.118 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.114 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.115 |
-| Identity and Access Management | kubernetes | MEDIUM | Container does not have resource limitations defined | accurics.kubernetes.IAM.119 |
-| Data Security | json | MEDIUM | Vulnerable to CVE-2020-8555 (affected version of kube-controller-manager: v1.18.0, v1.17.0 - v1.17.4, v1.16.0 - v1.16.8,< v1.15.11 | AC-K8-DS-PO-M-0143 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.64 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.72 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.68 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.69 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.65 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.58 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.62 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.63 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.59 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.60 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.61 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.57 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.70 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.66 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.67 |
-| Encryption and Key Management | kubernetes | HIGH | Container uses secrets in environment variables | accurics.kubernetes.EKM.71 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.81 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.78 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.74 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.75 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.79 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.80 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.87 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.86 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.73 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.85 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.84 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.88 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.83 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.76 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.77 |
-| Identity and Access Management | kubernetes | MEDIUM | Pod has extra capabilities allowed | accurics.kubernetes.IAM.82 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Configuration and Vulnerability Analysis | json | HIGH | CVE-2021-25742: Ingress-nginx with custom snippets allows retrieval of ingress-nginx serviceaccount token and secrets across all namespaces. | AC_K8S_0051 | AC_K8S_0051 |
+| Infrastructure Security | json | MEDIUM | Containers Should Not Share the Host Network Namespace | AC-K8-NS-PO-M-0164 | AC_K8S_0084 |
+| Infrastructure Security | json | MEDIUM | Image without digest affects the integrity principle of image security | AC-K8-NS-PO-M-0133 | AC_K8S_0069 |
+| Identity and Access Management | json | HIGH | Minimize Admission of Root Containers | AC-K8-IA-PO-H-0168 | AC_K8S_0087 |
+| Configuration and Vulnerability Analysis | json | HIGH | CVE-2021-25742: Ingress-nginx with custom snippets with a version that does not support mitigation and allows retrieval of ingress-nginx serviceaccount token and secrets across all namespaces. | AC_K8S_0050 | AC_K8S_0050 |
+| Security Best Practices | json | Medium | CPU Request Not Set in config file. | AC-K8-OE-PK-M-0155 | AC_K8S_0097 |
+| Security Best Practices | json | HIGH | Default Namespace Should Not be Used | AC-K8-OE-PO-M-0166 | AC_K8S_0086 |
+| Infrastructure Security | json | MEDIUM | Do Not Use CAP_SYS_ADMIN Linux Capability | AC-K8-NS-PO-H-0170 | AC_K8S_0075 |
+| Security Best Practices | json | Medium | Memory Limits Not Set in config file. | AC-K8-OE-PK-M-0158 | AC_K8S_0100 |
+| Data Protection | json | MEDIUM | Ensure That Tiller (Helm V2) Is Not Deployed | AC-K8-DS-PO-M-0177 | AC_K8S_0071 |
+| Security Best Practices | json | LOW | No readiness probe will affect automatic recovery in case of unexpected errors | AC-K8-OE-PO-L-0130 | AC_K8S_0072 |
+| Identity and Access Management | json | MEDIUM | Default seccomp profile not enabled will make the container to make non-essential system calls | AC-K8-IA-PO-M-0141 | AC_K8S_0080 |
+| Identity and Access Management | json | MEDIUM | Container images with readOnlyRootFileSystem set as false mounts the container root file system with write permissions | AC-K8-IA-PO-M-0140 | AC_K8S_0078 |
+| Infrastructure Security | json | HIGH | Prefer using secrets as files over secrets as environment variables | AC-K8-NS-PO-H-0117 | AC_K8S_0051 |
+| Infrastructure Security | json | MEDIUM | Containers Should Not Share Host IPC Namespace | AC-K8-NS-PO-M-0163 | AC_K8S_0083 |
+| Infrastructure Security | json | MEDIUM | Apply Security Context to Your Pods and Containers | AC-K8-NS-PO-M-0122 | AC_K8S_0064 |
+| Data Protection | json | MEDIUM | Ensure Kubernetes Dashboard Is Not Deployed | AC-K8-DS-PO-M-0176 | AC_K8S_0067 |
+| Identity and Access Management | json | HIGH | Allowing hostPaths to mount to Pod arise the probability of getting access to the node's filesystem | AC-K8-IA-PO-H-0138 | AC_K8S_0076 |
+| Identity and Access Management | json | MEDIUM | Some volume types mount the host file system paths to the pod or container, thus increasing the chance of escaping the container to access the host | AC-K8-IA-PO-M-0143 | AC_K8S_0081 |
+| Identity and Access Management | json | MEDIUM | Allowing the pod to make system level calls provide access to host/node sensitive information | AC-K8-IA-PO-H-0137 | AC_K8S_0074 |
+| Data Protection | json | MEDIUM | Vulnerable to CVE-2020-8555 (affected version of kube-controller-manager: v1.18.0, v1.17.0 - v1.17.4, v1.16.0 - v1.16.8, and v1.15.11 | AC-K8-DS-PO-M-0143 | AC_K8S_0130 |
+| Compliance Validation | json | MEDIUM | AlwaysPullImages plugin is not set | AC-K8-OE-PK-M-0034 | AC_K8S_0021 |
+| Identity and Access Management | json | MEDIUM | Unmasking the procMount will allow more information than is necessary to the program running in the containers spawned by k8s | AC-K8-IA-PO-M-0139 | AC_K8S_0077 |
+| Identity and Access Management | json | MEDIUM | AppArmor profile not set to default or custom profile will make the container vulnerable to kernel level threats | AC-K8-IA-PO-M-0135 | AC_K8S_0073 |
+| Identity and Access Management | json | MEDIUM | Containers Should Not Share Host Process ID Namespace | AC-K8-IA-PO-M-0162 | AC_K8S_0082 |
+| Infrastructure Security | json | MEDIUM | Containers Should Run as a High UID to Avoid Host Conflict | AC-K8-NS-PO-M-0182 | AC_K8S_0079 |
+| Identity and Access Management | json | MEDIUM | Minimize the admission of containers with the NET_RAW capability | AC-K8-IA-PS-M-0112 | AC_K8S_0048 |
+| Security Best Practices | json | LOW | No liveness probe will ensure there is no recovery in case of unexpected errors | AC-K8-OE-PO-L-0129 | AC_K8S_0070 |
+| Security Best Practices | json | LOW | No tag or container image with :Latest tag makes difficult to rollback and track | AC-K8-OE-PO-L-0134 | AC_K8S_0068 |
+| Security Best Practices | json | Medium | Memory Request Not Set in config file. | AC-K8-OE-PK-M-0157 | AC_K8S_0099 |
+| Compliance Validation | json | HIGH | Containers Should Not Run with AllowPrivilegeEscalation | AC-K8-CA-PO-H-0165 | AC_K8S_0085 |
+| Identity and Access Management | json | HIGH | Minimize the admission of privileged containers | AC-K8-IA-PO-H-0106 | AC_K8S_0046 |
+| Security Best Practices | json | Medium | CPU Limits Not Set in config file. | AC-K8-OE-PK-M-0156 | AC_K8S_0098 |
+| Infrastructure Security | json | MEDIUM | Restrict Mounting Docker Socket in a Container | AC-K8-NS-PO-M-0171 | AC_K8S_0088 |
+| Identity and Access Management | json | MEDIUM | Ensure that Service Account Tokens are only mounted where necessary | AC-K8-IA-PO-M-0105 | AC_K8S_0045 |
 
 
 ### kubernetes_role
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Identity and Access Management | json | HIGH | Ensure that default service accounts are not actively used | AC-K8-IA-RO-H-0104 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Identity and Access Management | json | HIGH | Ensure that default service accounts are not actively used in Kubernetes Role | AC-K8-IA-RO-H-0104 | AC_K8S_0113 |
 
 
 ### kubernetes_namespace
-| Category | Resource | Severity | Description | Reference ID |
-| -------- | -------- | -------- | ----------- | ------------ |
-| Operational Efficiency | kubernetes | LOW | The default namespace should not be used | accurics.kubernetes.OPS.462 |
-| Operational Efficiency | kubernetes | LOW | The default namespace should not be used | accurics.kubernetes.OPS.460 |
-| Operational Efficiency | kubernetes | LOW | The default namespace should not be used | accurics.kubernetes.OPS.461 |
-| Operational Efficiency | json | LOW | No owner for namespace affects the operations | AC-K8-OE-NS-L-0128 |
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Security Best Practices | json | LOW | No owner for namespace affects the operations | AC-K8-OE-NS-L-0128 | AC_K8S_0013 |
 
 


### PR DESCRIPTION
- I noticed a deprecation warning of `Deprecation warning : Use 'id' (AC_AWS_0058) instead of 'reference_id' (AWS.RDS.DataSecurity.High.0414)` and wanted to fix it in my config file, but then noticed that those ID's (`AC_AWS_0058`) aren't documented anywhere other than within the json of each rule. So I figured I would propose adding those ID's to the docs.
- I now see that maybe this repo isn't even the source of truth for the docs anymore? But the https://github.com/accurics/runterrascan.io repo doesn't seem to have any automation to rebuild these, or does it? Anyway, I'm happy to add this if possible but would appreciate guidance if I'm doing it in the wrong place.
- And this also fixes a bug in `docs/policies/document_policies.py` where it crashed when trying to iterate over files in `pkg/policies/opa/rego` when it was expecting to iterate over directories.