### PR TITLE
Add Policy AC_GCP_0296 - Service Attachment with ACCEPT_AUTOMATIC

### DIFF
--- a/docs/policies/gcp.md
+++ b/docs/policies/gcp.md
@@ -24,6 +24,10 @@
 | -------- | -------- | -------- | ----------- | ------------ | -- |
 | Identity and Access Management | gcp | HIGH | Ensure oslogin is enabled for a Project | accurics.gcp.IAM.127 | AC_GCP_0291 |
 
+### google_compute_service_attachment
+| Category | Resource | Severity | Description | Reference ID | ID |
+| -------- | -------- | -------- | ----------- | ------------ | -- |
+| Infrastructure Security | gcp | MEDIUM | Service Attachment with connection_preference ACCEPT_AUTOMATIC allow any project to connect. | accurics.gcp.NS.134 | AC_GCP_0296 |
 
 ### google_compute_subnetwork
 | Category | Resource | Severity | Description | Reference ID | ID |

--- a/pkg/policies/opa/rego/gcp/google_compute_service_attachment/accurics.gcp.NS.134.json
+++ b/pkg/policies/opa/rego/gcp/google_compute_service_attachment/accurics.gcp.NS.134.json
@@ -1,0 +1,13 @@
+{
+    "name": "serviceAttachmentAcceptAutomatic",
+    "file": "serviceAttachmentAcceptAutomatic.rego",
+    "policy_type": "gcp",
+    "resource_type": "google_compute_service_attachment",
+    "template_args": null,
+    "severity": "MEDIUM",
+    "description": "Service Attachment with connection_preference ACCEPT_AUTOMATIC allow any project to connect.",
+    "reference_id": "accurics.gcp.NS.134",
+    "category": "Infrastructure Security",
+    "version": 2,
+    "id": "AC_GCP_0296"
+}

--- a/pkg/policies/opa/rego/gcp/google_compute_service_attachment/serviceAttachmentAcceptAutomatic.rego
+++ b/pkg/policies/opa/rego/gcp/google_compute_service_attachment/serviceAttachmentAcceptAutomatic.rego
@@ -1,0 +1,6 @@
+package accurics
+
+serviceAttachmentAcceptAutomatic[saconf.id] {
+  saconf := input.google_compute_service_attachment[_]
+  saconf.config.connection_preference == "ACCEPT_AUTOMATIC"
+}


### PR DESCRIPTION
GCP service attachments provide a way to share a single service
cross project and VPC boundaries. Since all examples show for ease
of use the connection preference `ACCEPT_AUTOMATIC` it's easy to
go to production with working but insecure setups.
Use `ACCEPT_MANUAL` and define the projects you would like to
allow to connect with a private service connect is the safe way.