### PR TITLE
Feature/best effort cft file load

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.9.1
+	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d
 	golang.org/x/tools v0.1.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.9.1
-	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d
 	golang.org/x/tools v0.1.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/owenrumney/go-sarif v1.0.12
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
+	github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522 // indirect
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/owenrumney/go-sarif v1.0.12
 	github.com/pelletier/go-toml v1.9.3
 	github.com/pkg/errors v0.9.1
-	github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522 // indirect
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -144,8 +144,9 @@ func (a *CFTV1) extractTemplate(file string, data *[]byte) (*cloudformation.Temp
 }
 
 const (
-	awsTemplateFormatVersion = "AWSTemplateFormatVersion"
-	resources                = "Resources"
+	awsTemplateFormatVersion       = "AWSTemplateFormatVersion"
+	awsTemplateFormatVersionString = "2010-09-09"
+	resources                      = "Resources"
 )
 
 type cftResource struct {
@@ -163,11 +164,22 @@ func preParse(sanitized []byte) ([]cftResource, error) {
 		return nil, err
 	}
 
-	resourceMap := jsonMap[resources].(map[string]interface{})
+	var resourceMap map[string]interface{}
+	if jsonMap[resources] != nil {
+		resourceMap = jsonMap[resources].(map[string]interface{})
+	} else {
+		resourceMap = jsonMap
+	}
+
 	for key := range resourceMap {
 		var resourceInfo cftResource
 
-		resourceInfo.AWSTemplateFormatVersion = jsonMap[awsTemplateFormatVersion].(string)
+		if jsonMap[awsTemplateFormatVersion] != nil {
+			resourceInfo.AWSTemplateFormatVersion = jsonMap[awsTemplateFormatVersion].(string)
+		} else {
+			resourceInfo.AWSTemplateFormatVersion = awsTemplateFormatVersionString
+		}
+
 		resourceInfo.Resources = make(map[string]interface{}, 1)
 		resourceInfo.Resources[key] = resourceMap[key]
 

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -126,7 +126,10 @@ func (a *CFTV1) extractTemplate(file string, data *[]byte) (*cloudformation.Temp
 		}
 
 		resourceData, err := json.Marshal(preParsedList[i])
-		dirErr := results.DirScanErr{IacType: "cft", Directory: a.absRootDir, ErrMessage: err.Error()}
+		var dirErr results.DirScanErr
+		if err != nil {
+			dirErr = results.DirScanErr{IacType: "cft", Directory: a.absRootDir, ErrMessage: err.Error()}
+		}
 
 		if err != nil {
 			zap.S().Debug("failed to marshal json for resource", zap.String("resource", resourceName), zap.Error(err))

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -91,9 +91,18 @@ func (a *CFTV1) getConfig(absFilePath string, fileData *[]byte, parameters *map[
 
 func (a *CFTV1) extractTemplate(file string, data *[]byte) (*cloudformation.Template, error) {
 	var multiErr multierror.Error
-
 	fileExt := a.getFileType(file, data)
-	isYaml := fileExt == YAMLExtension || fileExt == YAMLExtension2
+	var isYaml bool
+
+	switch fileExt {
+	case YAMLExtension, YAMLExtension2:
+		isYaml = true
+	case JSONExtension:
+		isYaml = false
+	default:
+		zap.S().Debug("unknown extension found", zap.String("extension", fileExt))
+		return nil, fmt.Errorf("unsupported extension for file %s", file)
+	}
 
 	zap.S().Debug("sanitizing cft template file", zap.String("file", file))
 	sanitized, err := a.sanitizeCftTemplate(*data, isYaml)

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -30,7 +30,7 @@ import (
 	"github.com/accurics/terrascan/pkg/results"
 	"github.com/awslabs/goformation/v5"
 	"github.com/awslabs/goformation/v5/cloudformation"
-	"go.uber.org/multierr"
+	multierr "github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 )
 

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -121,6 +121,7 @@ type cftResource struct {
 
 func (a *CFTV1) cleanTemplate(resourceMap map[string]interface{}, version, absFilePath string) (*cloudformation.Template, error) {
 	var onetemplate cloudformation.Template
+	onetemplate.Resources = make(cloudformation.Resources, len(resourceMap))
 
 	for resourceName := range resourceMap {
 		var resourceInfo cftResource

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -31,7 +31,7 @@ import (
 	"github.com/accurics/terrascan/pkg/results"
 	"github.com/awslabs/goformation/v5"
 	"github.com/awslabs/goformation/v5/cloudformation"
-	"go.uber.org/multierr"
+	multierr "github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 )
 

--- a/pkg/iac-providers/cft/v1/load-file.go
+++ b/pkg/iac-providers/cft/v1/load-file.go
@@ -158,8 +158,8 @@ func (a *CFTV1) extractTemplate(file string, data *[]byte) (*cloudformation.Temp
 }
 
 const (
-	AWSTemplateFormatVersion = "AWSTemplateFormatVersion"
-	Resources                = "Resources"
+	awsTemplateFormatVersion = "AWSTemplateFormatVersion"
+	resources                = "Resources"
 )
 
 type cftResource struct {
@@ -177,10 +177,10 @@ func getResourcesList(sanitized []byte) ([]cftResource, error) {
 		return nil, err
 	}
 
-	resourceMap := jsonMap[Resources].(map[string]interface{})
+	resourceMap := jsonMap[resources].(map[string]interface{})
 	for key := range resourceMap {
 		var resourceInfo cftResource
-		resourceInfo.AWSTemplateFormatVersion = jsonMap[AWSTemplateFormatVersion].(string)
+		resourceInfo.AWSTemplateFormatVersion = jsonMap[awsTemplateFormatVersion].(string)
 		resourceInfo.Resources = make(map[string]interface{}, 1)
 		resourceInfo.Resources[key] = resourceMap[key]
 

--- a/pkg/iac-providers/cft/v1/load-file_test.go
+++ b/pkg/iac-providers/cft/v1/load-file_test.go
@@ -32,10 +32,37 @@ func TestLoadIacFile(t *testing.T) {
 	invalidFile, _ := filepath.Abs(path.Join(testDataDir, "deploy.yaml"))
 	validFile, _ := filepath.Abs(path.Join(testDataDir, "templates", "s3", "deploy.template"))
 	nestedFile, _ := filepath.Abs(path.Join(testDataDir, "templates", "s3", "nested.template"))
+	partialWrongFile, _ := filepath.Abs(path.Join(testDataDir, "someResourcesIncorrectCftTemplate.yml"))
 
 	testErrString1 := fmt.Sprintf("unsupported extension for file %s", testFile)
 	testErrString2 := "unable to read file nonexistent.txt"
 	testErrString3 := "invalid YAML template: yaml: line 27: did not find expected alphabetic or numeric character"
+
+	validFileConfig := make(map[string][]output.ResourceConfig, 2)
+	validFileConfig["aws_s3_bucket_policy"] = []output.ResourceConfig{{
+		ID: "aws_s3_bucket_policy.BucketPolicy",
+	}}
+	validFileConfig["aws_s3_bucket"] = []output.ResourceConfig{{
+		ID: "aws_s3_bucket.S3Bucket",
+	}}
+
+	nestedFileConfig := make(map[string][]output.ResourceConfig, 2)
+	nestedFileConfig["aws_cloudformation_stack"] = []output.ResourceConfig{{
+		ID: "aws_cloudformation_stack.myStackWithParams",
+	}}
+	nestedFileConfig["aws_s3_bucket"] = []output.ResourceConfig{{
+		ID: "aws_s3_bucket.S3Bucket",
+	}}
+
+	partialWrongConfig := make(map[string][]output.ResourceConfig, 3)
+	partialWrongConfig["aws_cognito_user_pool"] = []output.ResourceConfig{{
+		ID: "aws_cognito_user_pool.goodpool",
+	}}
+	partialWrongConfig["aws_kinesis_stream"] = []output.ResourceConfig{{
+		ID: "aws_kinesis_stream.riverstream",
+	}, {
+		ID: "aws_kinesis_stream.livestream",
+	}}
 
 	table := []struct {
 		wantErr  error
@@ -69,29 +96,77 @@ func TestLoadIacFile(t *testing.T) {
 			typeOnly: false,
 		}, {
 			wantErr:  nil,
-			want:     output.AllResourceConfigs{},
+			want:     validFileConfig,
 			cftv1:    CFTV1{},
-			name:     "invalid file",
+			name:     "valid file",
 			filePath: validFile,
 			typeOnly: false,
 		}, {
 			wantErr:  nil,
-			want:     output.AllResourceConfigs{},
+			want:     nestedFileConfig,
 			cftv1:    CFTV1{},
 			name:     "nested file",
 			filePath: nestedFile,
+			typeOnly: false,
+		},
+		{
+			wantErr:  nil,
+			want:     partialWrongConfig,
+			cftv1:    CFTV1{},
+			name:     "partially wrong cft file",
+			filePath: partialWrongFile,
 			typeOnly: false,
 		},
 	}
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			_, gotErr := tt.cftv1.LoadIacFile(tt.filePath, tt.options)
+			gotResponse, gotErr := tt.cftv1.LoadIacFile(tt.filePath, tt.options)
+
 			if !reflect.DeepEqual(gotErr, tt.wantErr) {
 				t.Errorf("unexpected error; gotErr: '%+v', wantErr: '%+v'", gotErr, tt.wantErr)
-			} else if tt.typeOnly && (reflect.TypeOf(gotErr)) != reflect.TypeOf(tt.wantErr) {
+			}
+
+			if tt.typeOnly && (reflect.TypeOf(gotErr)) != reflect.TypeOf(tt.wantErr) {
 				t.Errorf("unexpected error; gotErr: '%v', wantErr: '%v'", reflect.TypeOf(gotErr), reflect.TypeOf(tt.wantErr))
+			}
+
+			if err := verifyResponseObject(tt.want, gotResponse); err != nil {
+				t.Error(err)
 			}
 		})
 	}
+}
+
+func verifyResponseObject(want, got output.AllResourceConfigs) error {
+	if len(got) == 0 && len(want) == 0 {
+		return nil
+	}
+
+	if len(want) != len(got) {
+		return fmt.Errorf("incorrect response object array length; got: '%d', want: '%d'", len(got), len(want))
+	}
+
+	for wantKey := range want {
+
+		if _, ok := got[wantKey]; !ok {
+			return fmt.Errorf("wanted resource object not found in response object")
+		}
+
+		for wantIndex := range want[wantKey] {
+
+			flag := false
+			for gotIndex := range got[wantKey] {
+				if got[wantKey][gotIndex].ID == want[wantKey][gotIndex].ID {
+					flag = true
+				}
+			}
+			if !flag {
+				return fmt.Errorf("resource ID mismatch for key: '%s' at index: '%d'", wantKey, wantIndex)
+			}
+
+		}
+	}
+
+	return nil
 }

--- a/pkg/iac-providers/cft/v1/load-file_test.go
+++ b/pkg/iac-providers/cft/v1/load-file_test.go
@@ -157,7 +157,7 @@ func verifyResponseObject(want, got output.AllResourceConfigs) error {
 
 			flag := false
 			for gotIndex := range got[wantKey] {
-				if got[wantKey][gotIndex].ID == want[wantKey][gotIndex].ID {
+				if got[wantKey][gotIndex].ID == want[wantKey][wantIndex].ID {
 					flag = true
 				}
 			}

--- a/pkg/iac-providers/cft/v1/sanitize-cft-template.go
+++ b/pkg/iac-providers/cft/v1/sanitize-cft-template.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (a *CFTV1) sanitizeCftTemplate(data []byte, isYAML bool) (map[string]interface{}, string, error) {
+func (a *CFTV1) sanitizeCftTemplate(data []byte, isYAML bool) (map[string]interface{}, error) {
 	var (
 		intrinsified []byte
 		err          error
@@ -39,13 +39,13 @@ func (a *CFTV1) sanitizeCftTemplate(data []byte, isYAML bool) (map[string]interf
 		// Process all AWS CloudFormation intrinsic functions (e.g. Fn::Join)
 		intrinsified, err = intrinsics.ProcessYAML(data, nil)
 		if err != nil {
-			return nil, "", fmt.Errorf("error while resolving intrinsic functions, error %w", err)
+			return nil, fmt.Errorf("error while resolving intrinsic functions, error %w", err)
 		}
 	} else {
 		// Process all AWS CloudFormation intrinsic functions (e.g. Fn::Join)
 		intrinsified, err = intrinsics.ProcessJSON(data, nil)
 		if err != nil {
-			return nil, "", fmt.Errorf("error while resolving intrinsic functions, error %w", err)
+			return nil, fmt.Errorf("error while resolving intrinsic functions, error %w", err)
 		}
 	}
 
@@ -53,7 +53,7 @@ func (a *CFTV1) sanitizeCftTemplate(data []byte, isYAML bool) (map[string]interf
 
 	err = json.Unmarshal(intrinsified, &templateFileMap)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	// sanitize Parameters
@@ -80,22 +80,10 @@ func (a *CFTV1) sanitizeCftTemplate(data []byte, isYAML bool) (map[string]interf
 					delete(rMap, rName)
 				}
 			}
-
-			if templateFileMap["AWSTemplateFormatVersion"] == nil {
-				return rMap, "2010-09-09", nil
-			}
-
-			version, ok := templateFileMap["AWSTemplateFormatVersion"].(string)
-			if !ok {
-				return rMap, "2010-09-09", nil
-			}
-
-			return rMap, version, nil
 		}
-		return nil, "", nil
 	}
 
-	return nil, "", nil
+	return templateFileMap, nil
 }
 
 func inspectAndSanitizeParameters(p interface{}) {

--- a/pkg/iac-providers/cft/v1/sanitize-cft-template_test.go
+++ b/pkg/iac-providers/cft/v1/sanitize-cft-template_test.go
@@ -66,15 +66,10 @@ func TestCFTV1_sanitizeCftTemplate(t *testing.T) {
 				t.Error("CFTV1.sanitizeCftTemplate() got no error, expected parsing error")
 			}
 
-			got, err := a.sanitizeCftTemplate(data, tt.args.isYAML)
+			_, _, err = a.sanitizeCftTemplate(data, tt.args.isYAML)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CFTV1.sanitizeCftTemplate() error = %v, wantErr %v", err, tt.wantErr)
 				return
-			}
-
-			_, err = goformation.ParseJSON(got)
-			if err != nil {
-				t.Error("CFTV1.sanitizeCftTemplate() got error, expected no error")
 			}
 		})
 	}

--- a/pkg/iac-providers/cft/v1/sanitize-cft-template_test.go
+++ b/pkg/iac-providers/cft/v1/sanitize-cft-template_test.go
@@ -66,11 +66,24 @@ func TestCFTV1_sanitizeCftTemplate(t *testing.T) {
 				t.Error("CFTV1.sanitizeCftTemplate() got no error, expected parsing error")
 			}
 
-			_, _, err = a.sanitizeCftTemplate(data, tt.args.isYAML)
+			resMap, version, err := a.sanitizeCftTemplate(data, tt.args.isYAML)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CFTV1.sanitizeCftTemplate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
+			resMap["AWSTemplateFormatVersion"] = version
+			resData, err := json.Marshal(resMap)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resourseMap marshalling error error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			_, err = goformation.ParseJSON(resData)
+			if err != nil {
+				t.Error("CFTV1.sanitizeCftTemplate() got error, expected no error")
+			}
+
 		})
 	}
 }

--- a/pkg/iac-providers/cft/v1/sanitize-cft-template_test.go
+++ b/pkg/iac-providers/cft/v1/sanitize-cft-template_test.go
@@ -66,14 +66,13 @@ func TestCFTV1_sanitizeCftTemplate(t *testing.T) {
 				t.Error("CFTV1.sanitizeCftTemplate() got no error, expected parsing error")
 			}
 
-			resMap, version, err := a.sanitizeCftTemplate(data, tt.args.isYAML)
+			templateMap, err := a.sanitizeCftTemplate(data, tt.args.isYAML)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CFTV1.sanitizeCftTemplate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
-			resMap["AWSTemplateFormatVersion"] = version
-			resData, err := json.Marshal(resMap)
+			resData, err := json.Marshal(templateMap)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("resourseMap marshalling error error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -83,7 +82,6 @@ func TestCFTV1_sanitizeCftTemplate(t *testing.T) {
 			if err != nil {
 				t.Error("CFTV1.sanitizeCftTemplate() got error, expected no error")
 			}
-
 		})
 	}
 }

--- a/pkg/iac-providers/cft/v1/testdata/someResourcesIncorrectCftTemplate.yml
+++ b/pkg/iac-providers/cft/v1/testdata/someResourcesIncorrectCftTemplate.yml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  deadpool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      Name: dead
+  goodpool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: good
+  riverstream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: river
+      RetentionPeriodHours: 168
+      ShardCount: 3
+  livestream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: live
+      RetentionPeriodHours: 50
+      ShardCount: 1

--- a/pkg/iac-providers/cft/v1/types.go
+++ b/pkg/iac-providers/cft/v1/types.go
@@ -50,3 +50,8 @@ const (
 func CFTFileExtensions() []string {
 	return []string{YAMLExtension, YAMLExtension2, JSONExtension, TemplateExtension, TXTExtension}
 }
+
+type cftResource struct {
+	AWSTemplateFormatVersion string                 `json:"AWSTemplateFormatVersion"`
+	Resources                map[string]interface{} `json:"Resources"`
+}


### PR DESCRIPTION
enhancement in best effort CFT file processing
only violating resources in a CFT file will be skipped with error logs, configuration will be generated for the rest of the file

changes:
- convert yaml files into json post sanitizatio
- read resulting json of resources into `map[string]interface{}`
- convert them into individual json resource objects
- parse resource objects one by one, log and continue on error