### PR TITLE
Add backward compatible implementation of AC_AWS_0214

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_s3_bucket/s3Versioning.rego
+++ b/pkg/policies/opa/rego/aws/aws_s3_bucket/s3Versioning.rego
@@ -8,7 +8,8 @@ package accurics
 checkBucketVersioning(bucket) {
     object.get(bucket.config, "versioning", "undefined") != [[], null, "undefined"][_]
 
-    bucket.config.versioning[_] != true
+    versioning := bucket.config.versioning[_]
+    not versioning.enabled == true
 }
 
 checkBucketVersioning(bucket) {


### PR DESCRIPTION
Add a backward compatible implementation of AC_AWS_0214, which also
works for provider versions before 4.0.0.

It was tested based on the example in #1172 and returns the following result

Scan Summary -

        File/Folder         :   main.tf
        IaC Type            :   terraform
        Scanned At          :   2022-02-27 15:01:56.298085 +0000 UTC
        Policies Validated  :   14
        Violated Policies   :   0
        Low                 :   0
        Medium              :   0
        High                :   0

Resolves #1172