### PR TITLE
typo: Change "desitnation" to "destination".

### DIFF
--- a/pkg/downloader/getter.go
+++ b/pkg/downloader/getter.go
@@ -31,7 +31,7 @@ import (
 var (
 	ErrEmptyURLType      = fmt.Errorf("empty remote url and type")
 	ErrEmptyURLDest      = fmt.Errorf("remote url or destination dir path cannot be empty")
-	ErrEmptyURLTypeDest  = fmt.Errorf("empty remote url or type or desitnation dir path")
+	ErrEmptyURLTypeDest  = fmt.Errorf("empty remote url or type or destination dir path")
 	ErrInvalidRemoteType = fmt.Errorf("supplied remote type is not supported")
 )
 

--- a/test/e2e/scan/scan_remote_test.go
+++ b/test/e2e/scan/scan_remote_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Scan Command using remote types", func() {
 	})
 
 	Context("remote type is supplied, but remote URL is not", func() {
-		errString := "empty remote url or type or desitnation dir path"
+		errString := "empty remote url or type or destination dir path"
 
 		When("remote type is git", func() {
 			It("should error out and exit with status code 1", func() {


### PR DESCRIPTION
# Summary

This pull request fixes a typo where "destination" was spelled "desitnation".