### PR TITLE
Adds: dir scan errors in human readable output format

### DIFF
--- a/pkg/iac-providers/arm/v1/load-dir.go
+++ b/pkg/iac-providers/arm/v1/load-dir.go
@@ -33,9 +33,7 @@ import (
 )
 
 const (
-	iacSearchError string = "error while searching for iac files"
-	strRootDir     string = "root dir"
-	iacFile               = "IAC file"
+	iacFile = "IAC file"
 )
 
 // LoadIacDir loads all ARM template files in the current directory.
@@ -53,7 +51,7 @@ func (a *ARMV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("ARM files not found in the directory %s", a.absRootDir)
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, a.absRootDir), zap.Error(err))
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, a.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "arm", Directory: a.absRootDir, ErrMessage: errMsg})
 	}
 
@@ -155,6 +153,7 @@ func (a *ARMV1) extractParameterValues(params map[string]interface{}) error {
 	return nil
 }
 
+// Name returns name of the provider
 func (a *ARMV1) Name() string {
 	return "arm"
 }

--- a/pkg/iac-providers/arm/v1/load-dir.go
+++ b/pkg/iac-providers/arm/v1/load-dir.go
@@ -51,7 +51,6 @@ func (a *ARMV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("ARM files not found in the directory %s", a.absRootDir)
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, a.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "arm", Directory: a.absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/arm/v1/load-dir.go
+++ b/pkg/iac-providers/arm/v1/load-dir.go
@@ -32,7 +32,11 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const iacFile = "IAC file"
+const (
+	iacSearchError string = "error while searching for iac files"
+	strRootDir     string = "root dir"
+	iacFile               = "IAC file"
+)
 
 // LoadIacDir loads all ARM template files in the current directory.
 func (a *ARMV1) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
@@ -45,6 +49,12 @@ func (a *ARMV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 	if err != nil {
 		zap.S().Debug("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "arm", Directory: absRootDir, ErrMessage: err.Error()})
+	}
+
+	if len(fileMap) == 0 {
+		errMsg := fmt.Sprintf("ARM files not found in the directory %s", a.absRootDir)
+		zap.S().Debug(iacSearchError, zap.String(strRootDir, a.absRootDir), zap.Error(err))
+		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "arm", Directory: a.absRootDir, ErrMessage: errMsg})
 	}
 
 	for fileDir, files := range fileMap {
@@ -143,4 +153,8 @@ func (a *ARMV1) extractParameterValues(params map[string]interface{}) error {
 		a.templateParameters[key] = value.Value
 	}
 	return nil
+}
+
+func (a *ARMV1) Name() string {
+	return "arm"
 }

--- a/pkg/iac-providers/cft/v1/load-dir.go
+++ b/pkg/iac-providers/cft/v1/load-dir.go
@@ -28,30 +28,25 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const (
-	iacSearchError string = "error while searching for iac files"
-	strRootDir     string = "root dir"
-)
-
 // LoadIacDir loads all CFT template files in the current directory.
 func (a *CFTV1) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	a.absRootDir = absRootDir
 
 	allResourcesConfig := make(map[string][]output.ResourceConfig)
 
-	fileMap, err := utils.FindFilesBySuffix(absRootDir, CFTFileExtensions())
+	cftFileMap, err := utils.FindFilesBySuffix(absRootDir, CFTFileExtensions())
 	if err != nil {
 		zap.S().Debug("error while searching for iac files", zap.String("root dir", absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "cft", Directory: absRootDir, ErrMessage: err.Error()})
 	}
 
-	if len(fileMap) == 0 {
-		errMsg := fmt.Sprintf("CFT files not found in the directory %s", a.absRootDir)
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, a.absRootDir), zap.Error(err))
+	if len(cftFileMap) == 0 {
+		errMsg := fmt.Sprintf("cft files not found in the directory %s", a.absRootDir)
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, a.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "cft", Directory: a.absRootDir, ErrMessage: errMsg})
 	}
 
-	for fileDir, files := range fileMap {
+	for fileDir, files := range cftFileMap {
 		for i := range files {
 			file := filepath.Join(fileDir, *files[i])
 
@@ -72,6 +67,7 @@ func (a *CFTV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 	return allResourcesConfig, a.errIacLoadDirs
 }
 
-func (a *CFTV1) Name() string {
+// Name returns name of the provider
+func (*CFTV1) Name() string {
 	return "cft"
 }

--- a/pkg/iac-providers/cft/v1/load-dir.go
+++ b/pkg/iac-providers/cft/v1/load-dir.go
@@ -42,7 +42,6 @@ func (a *CFTV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 
 	if len(cftFileMap) == 0 {
 		errMsg := fmt.Sprintf("cft files not found in the directory %s", a.absRootDir)
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, a.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(a.errIacLoadDirs, results.DirScanErr{IacType: "cft", Directory: a.absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/docker/v1/load-dir.go
+++ b/pkg/iac-providers/docker/v1/load-dir.go
@@ -43,7 +43,6 @@ func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}
 
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("Dockerfile not found in the directory %s", dc.absRootDir)
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, dc.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(dc.errIacLoadDirs, results.DirScanErr{IacType: "docker", Directory: dc.absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/docker/v1/load-dir.go
+++ b/pkg/iac-providers/docker/v1/load-dir.go
@@ -27,6 +27,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	iacSearchError string = "error while searching for iac files"
+	strRootDir     string = "root dir"
+)
+
 // LoadIacDir loads the docker file specified in given folder.
 func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	// set the root directory being scanned
@@ -42,7 +47,9 @@ func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}
 	}
 
 	if len(fileMap) == 0 {
-		zap.S().Warnf("directory '%s' has no files named Dockerfile. Use -f flag if Dockerfiles follow a different naming convention.", absRootDir)
+		errMsg := fmt.Sprintf("Dockerfile not found in the directory %s", dc.absRootDir)
+		zap.S().Debug(iacSearchError, zap.String(strRootDir, dc.absRootDir), zap.Error(err))
+		return allResourcesConfig, multierror.Append(dc.errIacLoadDirs, results.DirScanErr{IacType: "Docker", Directory: dc.absRootDir, ErrMessage: errMsg})
 	}
 
 	for fileDir, files := range fileMap {
@@ -64,4 +71,8 @@ func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}
 
 	return allResourcesConfig, dc.errIacLoadDirs
 
+}
+
+func (dc *DockerV1) Name() string {
+	return "docker"
 }

--- a/pkg/iac-providers/docker/v1/load-dir.go
+++ b/pkg/iac-providers/docker/v1/load-dir.go
@@ -27,11 +27,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	iacSearchError string = "error while searching for iac files"
-	strRootDir     string = "root dir"
-)
-
 // LoadIacDir loads the docker file specified in given folder.
 func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	// set the root directory being scanned
@@ -48,8 +43,8 @@ func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}
 
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("Dockerfile not found in the directory %s", dc.absRootDir)
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, dc.absRootDir), zap.Error(err))
-		return allResourcesConfig, multierror.Append(dc.errIacLoadDirs, results.DirScanErr{IacType: "Docker", Directory: dc.absRootDir, ErrMessage: errMsg})
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, dc.absRootDir), zap.Error(err))
+		return allResourcesConfig, multierror.Append(dc.errIacLoadDirs, results.DirScanErr{IacType: "docker", Directory: dc.absRootDir, ErrMessage: errMsg})
 	}
 
 	for fileDir, files := range fileMap {
@@ -73,6 +68,7 @@ func (dc *DockerV1) LoadIacDir(absRootDir string, options map[string]interface{}
 
 }
 
+// Name returns name of the provider
 func (dc *DockerV1) Name() string {
 	return "docker"
 }

--- a/pkg/iac-providers/helm/v3/load-dir.go
+++ b/pkg/iac-providers/helm/v3/load-dir.go
@@ -55,7 +55,6 @@ func (h *HelmV3) LoadIacDir(absRootDir string, options map[string]interface{}) (
 
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("no helm charts found in directory %s", absRootDir)
-		zap.S().Debug(zap.String("root dir", absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(h.errIacLoadDirs, results.DirScanErr{IacType: "helm", Directory: absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/helm/v3/load-dir.go
+++ b/pkg/iac-providers/helm/v3/load-dir.go
@@ -309,3 +309,7 @@ func (h *HelmV3) getHelmTemplateExtensions() []string {
 func (h *HelmV3) getHelmChartFilenames() []string {
 	return []string{"Chart.yaml"}
 }
+
+func (h *HelmV3) Name() string {
+	return "helm"
+}

--- a/pkg/iac-providers/helm/v3/load-dir.go
+++ b/pkg/iac-providers/helm/v3/load-dir.go
@@ -310,6 +310,7 @@ func (h *HelmV3) getHelmChartFilenames() []string {
 	return []string{"Chart.yaml"}
 }
 
+// Name returns name of the provider
 func (h *HelmV3) Name() string {
 	return "helm"
 }

--- a/pkg/iac-providers/interface.go
+++ b/pkg/iac-providers/interface.go
@@ -25,4 +25,5 @@ import (
 type IacProvider interface {
 	LoadIacFile(string, map[string]interface{}) (output.AllResourceConfigs, error)
 	LoadIacDir(string, map[string]interface{}) (output.AllResourceConfigs, error)
+	Name() string
 }

--- a/pkg/iac-providers/kubernetes/v1/load-dir.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir.go
@@ -29,11 +29,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const (
-	iacSearchError string = "error while searching for iac files"
-	strRootDir     string = "root dir"
-)
-
 func (*K8sV1) getFileType(file string) string {
 	if strings.HasSuffix(file, YAMLExtension) {
 		return YAMLExtension
@@ -59,7 +54,7 @@ func (k *K8sV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 	}
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("kubernetes files not found in the directory %s", k.absRootDir)
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, k.absRootDir), zap.Error(err))
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, k.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(k.errIacLoadDirs, results.DirScanErr{IacType: "k8s", Directory: k.absRootDir, ErrMessage: errMsg})
 	}
 
@@ -84,6 +79,7 @@ func (k *K8sV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 	return allResourcesConfig, k.errIacLoadDirs
 }
 
-func (k *K8sV1) Name() string {
+// Name returns name of the provider
+func (*K8sV1) Name() string {
 	return kubernetesTypeNameShort
 }

--- a/pkg/iac-providers/kubernetes/v1/load-dir.go
+++ b/pkg/iac-providers/kubernetes/v1/load-dir.go
@@ -54,7 +54,6 @@ func (k *K8sV1) LoadIacDir(absRootDir string, options map[string]interface{}) (o
 	}
 	if len(fileMap) == 0 {
 		errMsg := fmt.Sprintf("kubernetes files not found in the directory %s", k.absRootDir)
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, k.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(k.errIacLoadDirs, results.DirScanErr{IacType: "k8s", Directory: k.absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/kubernetes/v1/types.go
+++ b/pkg/iac-providers/kubernetes/v1/types.go
@@ -39,8 +39,9 @@ const (
 	// UnknownExtension unknown
 	UnknownExtension = "unknown"
 
-	kubernetesTypeName = "kubernetes"
-	defaultNamespace   = "default"
+	kubernetesTypeName      = "kubernetes"
+	defaultNamespace        = "default"
+	kubernetesTypeNameShort = "k8s"
 )
 
 // K8sFileExtensions returns the valid extensions for k8s (yaml, yml, json)

--- a/pkg/iac-providers/kustomize/commons/load-dir.go
+++ b/pkg/iac-providers/kustomize/commons/load-dir.go
@@ -35,8 +35,6 @@ import (
 
 const (
 	kustomizedirectory string = "kustomization"
-	iacSearchError     string = "error while searching for iac files"
-	strRootDir         string = "root dir"
 )
 
 var (
@@ -62,19 +60,19 @@ func (t KustomizeDirectoryLoader) LoadIacDir() (output.AllResourceConfigs, error
 
 	files, err := utils.FindFilesBySuffixInDir(t.absRootDir, KustomizeFileNames())
 	if err != nil {
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, t.absRootDir), zap.Error(err))
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, t.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "kustomize", Directory: t.absRootDir, ErrMessage: err.Error()})
 	}
 
 	if len(files) == 0 {
 		errMsg := fmt.Sprintf("kustomization.y(a)ml file not found in the directory %s", t.absRootDir)
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, t.absRootDir), zap.Error(err))
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, t.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "kustomize", Directory: t.absRootDir, ErrMessage: errMsg})
 	}
 
 	if len(files) > 1 {
 		errMsg := fmt.Sprintf("multiple kustomization.y(a)ml found in the directory %s", t.absRootDir)
-		zap.S().Debug(iacSearchError, zap.String(strRootDir, t.absRootDir), zap.Error(err))
+		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, t.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "kustomize", Directory: t.absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/kustomize/commons/load-dir.go
+++ b/pkg/iac-providers/kustomize/commons/load-dir.go
@@ -60,19 +60,16 @@ func (t KustomizeDirectoryLoader) LoadIacDir() (output.AllResourceConfigs, error
 
 	files, err := utils.FindFilesBySuffixInDir(t.absRootDir, KustomizeFileNames())
 	if err != nil {
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, t.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "kustomize", Directory: t.absRootDir, ErrMessage: err.Error()})
 	}
 
 	if len(files) == 0 {
 		errMsg := fmt.Sprintf("kustomization.y(a)ml file not found in the directory %s", t.absRootDir)
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, t.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "kustomize", Directory: t.absRootDir, ErrMessage: errMsg})
 	}
 
 	if len(files) > 1 {
 		errMsg := fmt.Sprintf("multiple kustomization.y(a)ml found in the directory %s", t.absRootDir)
-		zap.S().Debug(output.IacSearchError, zap.String(output.StrRootDir, t.absRootDir), zap.Error(err))
 		return allResourcesConfig, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "kustomize", Directory: t.absRootDir, ErrMessage: errMsg})
 	}
 

--- a/pkg/iac-providers/kustomize/v2/load-dir.go
+++ b/pkg/iac-providers/kustomize/v2/load-dir.go
@@ -30,6 +30,7 @@ func (k *KustomizeV2) LoadIacDir(absRootDir string, options map[string]interface
 	return commons.NewKustomizeDirectoryLoader(absRootDir, options, true, versionSuffix).LoadIacDir()
 }
 
-func (a *KustomizeV2) Name() string {
+// Name returns name of the provider
+func (k *KustomizeV2) Name() string {
 	return "kustomize"
 }

--- a/pkg/iac-providers/kustomize/v2/load-dir.go
+++ b/pkg/iac-providers/kustomize/v2/load-dir.go
@@ -29,3 +29,7 @@ const (
 func (k *KustomizeV2) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	return commons.NewKustomizeDirectoryLoader(absRootDir, options, true, versionSuffix).LoadIacDir()
 }
+
+func (a *KustomizeV2) Name() string {
+	return "kustomize"
+}

--- a/pkg/iac-providers/kustomize/v3/load-dir.go
+++ b/pkg/iac-providers/kustomize/v3/load-dir.go
@@ -30,6 +30,7 @@ func (k *KustomizeV3) LoadIacDir(absRootDir string, options map[string]interface
 	return commons.NewKustomizeDirectoryLoader(absRootDir, options, true, versionSuffix).LoadIacDir()
 }
 
-func (a *KustomizeV3) Name() string {
+// Name returns name of the provider
+func (k *KustomizeV3) Name() string {
 	return "kustomize"
 }

--- a/pkg/iac-providers/kustomize/v3/load-dir.go
+++ b/pkg/iac-providers/kustomize/v3/load-dir.go
@@ -29,3 +29,7 @@ const (
 func (k *KustomizeV3) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	return commons.NewKustomizeDirectoryLoader(absRootDir, options, true, versionSuffix).LoadIacDir()
 }
+
+func (a *KustomizeV3) Name() string {
+	return "kustomize"
+}

--- a/pkg/iac-providers/kustomize/v4/load-dir.go
+++ b/pkg/iac-providers/kustomize/v4/load-dir.go
@@ -30,6 +30,7 @@ func (k *KustomizeV4) LoadIacDir(absRootDir string, options map[string]interface
 	return commons.NewKustomizeDirectoryLoader(absRootDir, options, false, versionSuffix).LoadIacDir()
 }
 
-func (a *KustomizeV4) Name() string {
+// Name returns name of the provider
+func (k *KustomizeV4) Name() string {
 	return "kustomize"
 }

--- a/pkg/iac-providers/kustomize/v4/load-dir.go
+++ b/pkg/iac-providers/kustomize/v4/load-dir.go
@@ -29,3 +29,7 @@ const (
 func (k *KustomizeV4) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	return commons.NewKustomizeDirectoryLoader(absRootDir, options, false, versionSuffix).LoadIacDir()
 }
+
+func (a *KustomizeV4) Name() string {
+	return "kustomize"
+}

--- a/pkg/iac-providers/output/types.go
+++ b/pkg/iac-providers/output/types.go
@@ -50,13 +50,6 @@ type ContainerDetails struct {
 	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
 }
 
-const (
-	// IacSearchError common error when files are not found.
-	IacSearchError string = "error while searching for iac files"
-	// StrRootDir root directory details when files are not found.
-	StrRootDir string = "root dir"
-)
-
 // SkipRule struct will hold the skipped rule and any comment for the skipped rule
 type SkipRule struct {
 	Rule    string `json:"rule"`

--- a/pkg/iac-providers/output/types.go
+++ b/pkg/iac-providers/output/types.go
@@ -50,6 +50,13 @@ type ContainerDetails struct {
 	Vulnerabilities []Vulnerability `json:"vulnerabilities"`
 }
 
+const (
+	// IacSearchError common error when files are not found.
+	IacSearchError string = "error while searching for iac files"
+	// StrRootDir root directory details when files are not found.
+	StrRootDir string = "root dir"
+)
+
 // SkipRule struct will hold the skipped rule and any comment for the skipped rule
 type SkipRule struct {
 	Rule    string `json:"rule"`

--- a/pkg/iac-providers/terraform/v12/load-dir.go
+++ b/pkg/iac-providers/terraform/v12/load-dir.go
@@ -30,6 +30,7 @@ func (*TfV12) LoadIacDir(absRootDir string, options map[string]interface{}) (all
 	return commons.NewTerraformDirectoryLoader(absRootDir, options).LoadIacDir()
 }
 
+// Name returns name of the provider
 func (*TfV12) Name() string {
 	return "terraform"
 }

--- a/pkg/iac-providers/terraform/v12/load-dir.go
+++ b/pkg/iac-providers/terraform/v12/load-dir.go
@@ -29,3 +29,7 @@ func (*TfV12) LoadIacDir(absRootDir string, options map[string]interface{}) (all
 	zap.S().Warn("There may be a few breaking changes while working with terraform v0.12 files. For further information, refer to https://github.com/accurics/terrascan/releases/v1.3.0")
 	return commons.NewTerraformDirectoryLoader(absRootDir, options).LoadIacDir()
 }
+
+func (*TfV12) Name() string {
+	return "terraform"
+}

--- a/pkg/iac-providers/terraform/v14/load-dir.go
+++ b/pkg/iac-providers/terraform/v14/load-dir.go
@@ -29,6 +29,7 @@ func (tfv14 *TfV14) LoadIacDir(absRootDir string, options map[string]interface{}
 	return commons.NewTerraformDirectoryLoader(absRootDir, options).LoadIacDir()
 }
 
+// Name returns name of the provider
 func (*TfV14) Name() string {
 	return "terraform"
 }

--- a/pkg/iac-providers/terraform/v14/load-dir.go
+++ b/pkg/iac-providers/terraform/v14/load-dir.go
@@ -28,3 +28,7 @@ import (
 func (tfv14 *TfV14) LoadIacDir(absRootDir string, options map[string]interface{}) (allResourcesConfig output.AllResourceConfigs, err error) {
 	return commons.NewTerraformDirectoryLoader(absRootDir, options).LoadIacDir()
 }
+
+func (*TfV14) Name() string {
+	return "terraform"
+}

--- a/pkg/iac-providers/terraform/v15/load-dir.go
+++ b/pkg/iac-providers/terraform/v15/load-dir.go
@@ -30,6 +30,7 @@ func (*TfV15) LoadIacDir(absRootDir string, options map[string]interface{}) (all
 	return commons.NewTerraformDirectoryLoader(absRootDir, options).LoadIacDir()
 }
 
+// Name returns name of the provider
 func (*TfV15) Name() string {
 	return "terraform"
 }

--- a/pkg/iac-providers/terraform/v15/load-dir.go
+++ b/pkg/iac-providers/terraform/v15/load-dir.go
@@ -29,3 +29,7 @@ func (*TfV15) LoadIacDir(absRootDir string, options map[string]interface{}) (all
 
 	return commons.NewTerraformDirectoryLoader(absRootDir, options).LoadIacDir()
 }
+
+func (*TfV15) Name() string {
+	return "terraform"
+}

--- a/pkg/iac-providers/tfplan/v1/load-dir.go
+++ b/pkg/iac-providers/tfplan/v1/load-dir.go
@@ -31,3 +31,7 @@ var (
 func (k *TFPlan) LoadIacDir(absRootDir string, options map[string]interface{}) (output.AllResourceConfigs, error) {
 	return output.AllResourceConfigs{}, errIacDirNotSupport
 }
+
+func (*TFPlan) Name() string {
+	return "tfplan"
+}

--- a/pkg/iac-providers/tfplan/v1/load-dir.go
+++ b/pkg/iac-providers/tfplan/v1/load-dir.go
@@ -32,6 +32,7 @@ func (k *TFPlan) LoadIacDir(absRootDir string, options map[string]interface{}) (
 	return output.AllResourceConfigs{}, errIacDirNotSupport
 }
 
+// Name returns name of the provider
 func (*TFPlan) Name() string {
 	return "tfplan"
 }

--- a/pkg/results/types.go
+++ b/pkg/results/types.go
@@ -51,12 +51,13 @@ type PassedRule struct {
 
 // ViolationStore Storage area for violation data
 type ViolationStore struct {
-	DirScanErrors     []DirScanErr     `json:"scan_errors,omitempty" yaml:"scan_errors,omitempty" xml:"scan_errors>scan_error,omitempty"`
-	PassedRules       []*PassedRule    `json:"passed_rules,omitempty" yaml:"passed_rules,omitempty" xml:"passed_rules>passed_rule,omitempty"`
-	Violations        []*Violation     `json:"violations" yaml:"violations" xml:"violations>violation"`
-	SkippedViolations []*Violation     `json:"skipped_violations" yaml:"skipped_violations" xml:"skipped_violations>violation"`
-	Vulnerabilities   []*Vulnerability `json:"vulnerabilities,omitempty" yaml:"vulnerabilities,omitempty"`
-	Summary           ScanSummary      `json:"scan_summary" yaml:"scan_summary" xml:"scan_summary"`
+	DirScanErrors      []DirScanErr     `json:"scan_errors,omitempty" yaml:"scan_errors,omitempty" xml:"scan_errors>scan_error,omitempty"`
+	IacTypesIdentified []string         `json:"iac_types_identified,omitempty" yaml:"iac_types_identified,omitempty"`
+	PassedRules        []*PassedRule    `json:"passed_rules,omitempty" yaml:"passed_rules,omitempty" xml:"passed_rules>passed_rule,omitempty"`
+	Violations         []*Violation     `json:"violations" yaml:"violations" xml:"violations>violation"`
+	SkippedViolations  []*Violation     `json:"skipped_violations" yaml:"skipped_violations" xml:"skipped_violations>violation"`
+	Vulnerabilities    []*Vulnerability `json:"vulnerabilities,omitempty" yaml:"vulnerabilities,omitempty"`
+	Summary            ScanSummary      `json:"scan_summary" yaml:"scan_summary" xml:"scan_summary"`
 }
 
 // ScanSummary will hold the default scan summary data

--- a/pkg/results/types.go
+++ b/pkg/results/types.go
@@ -51,13 +51,12 @@ type PassedRule struct {
 
 // ViolationStore Storage area for violation data
 type ViolationStore struct {
-	DirScanErrors      []DirScanErr     `json:"scan_errors,omitempty" yaml:"scan_errors,omitempty" xml:"scan_errors>scan_error,omitempty"`
-	IacTypesIdentified []string         `json:"iac_types_identified,omitempty" yaml:"iac_types_identified,omitempty"`
-	PassedRules        []*PassedRule    `json:"passed_rules,omitempty" yaml:"passed_rules,omitempty" xml:"passed_rules>passed_rule,omitempty"`
-	Violations         []*Violation     `json:"violations" yaml:"violations" xml:"violations>violation"`
-	SkippedViolations  []*Violation     `json:"skipped_violations" yaml:"skipped_violations" xml:"skipped_violations>violation"`
-	Vulnerabilities    []*Vulnerability `json:"vulnerabilities,omitempty" yaml:"vulnerabilities,omitempty"`
-	Summary            ScanSummary      `json:"scan_summary" yaml:"scan_summary" xml:"scan_summary"`
+	DirScanErrors     []DirScanErr     `json:"scan_errors,omitempty" yaml:"scan_errors,omitempty" xml:"scan_errors>scan_error,omitempty"`
+	PassedRules       []*PassedRule    `json:"passed_rules,omitempty" yaml:"passed_rules,omitempty" xml:"passed_rules>passed_rule,omitempty"`
+	Violations        []*Violation     `json:"violations" yaml:"violations" xml:"violations>violation"`
+	SkippedViolations []*Violation     `json:"skipped_violations" yaml:"skipped_violations" xml:"skipped_violations>violation"`
+	Vulnerabilities   []*Vulnerability `json:"vulnerabilities,omitempty" yaml:"vulnerabilities,omitempty"`
+	Summary           ScanSummary      `json:"scan_summary" yaml:"scan_summary" xml:"scan_summary"`
 }
 
 // ScanSummary will hold the default scan summary data

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/accurics/terrascan/pkg/notifications/webhook"
 	"github.com/accurics/terrascan/pkg/policy/opa"
@@ -243,7 +244,7 @@ func (e *Executor) Execute(configOnly, configWithError bool) (results Output, er
 	if configWithError {
 		results.Violations.ViolationStore = res.NewViolationStore()
 		if e.iacType == "all" {
-			results.Violations.ViolationStore.IacTypesIdentified = iacTypes
+			results.Violations.ViolationStore.Summary.IacType = strings.Join(iacTypes, ",")
 		}
 		if err := merr.ErrorOrNil(); err != nil {
 			sort.Sort(merr)
@@ -284,7 +285,7 @@ func (e *Executor) Execute(configOnly, configWithError bool) (results Output, er
 	}
 
 	if e.iacType == "all" {
-		results.Violations.ViolationStore.IacTypesIdentified = iacTypes
+		results.Violations.ViolationStore.Summary.IacType = strings.Join(iacTypes, ",")
 	}
 
 	// send notifications, if configured

--- a/pkg/runtime/executor_test.go
+++ b/pkg/runtime/executor_test.go
@@ -70,6 +70,10 @@ func (m MockIacProvider) LoadIacFile(file string, options map[string]interface{}
 	return m.output, m.err
 }
 
+func (m MockIacProvider) Name() string {
+	return "mock-iac"
+}
+
 // mock policy engine
 type MockPolicyEngine struct {
 	err error

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -35,6 +35,7 @@ type engineEvalResult struct {
 
 // dirScanResp represents a directory scan response
 type dirScanResp struct {
-	err error
-	rc  output.AllResourceConfigs
+	err     error
+	rc      output.AllResourceConfigs
+	iacType string
 }

--- a/pkg/writer/human_readable.go
+++ b/pkg/writer/human_readable.go
@@ -27,6 +27,10 @@ import (
 )
 
 const (
+	oneLineCommonFormat = "%-20v:\t%s\n\t"
+)
+
+const (
 	humanReadbleFormat supportedFormat = "human"
 
 	defaultTemplate string = `
@@ -37,10 +41,6 @@ Scan Errors -
 	-----------------------------------------------------------------------
 	{{end}}
 {{end}}	
-{{if (gt (len .ViolationStore.IacTypesIdentified) 0) }}
-IaC Types Identified - 
-	{{iacTypesIdentified .ViolationStore.IacTypesIdentified | printf "%s"}}
-{{end}}
 {{if (gt (len .ViolationStore.PassedRules) 0) }}
 Passed Rules - 
     {{range $index, $element := .ViolationStore.PassedRules}}
@@ -96,7 +96,6 @@ func HumanReadbleWriter(data interface{}, writer io.Writer) error {
 		"passedRules":            passedRules,
 		"defaultVulnerabilities": defaultVulnerabilities,
 		"dirScanErrors":          dirScanErrors,
-		"iacTypesIdentified":     iacTypesIdentified,
 	}).Parse(defaultTemplate)
 	if err != nil {
 		zap.S().Errorf("failed to write human readable output. error: '%v'", err)
@@ -157,11 +156,11 @@ func detailedViolations(v results.Violation) string {
 
 func scanSummary(s results.ScanSummary) string {
 
-	out := fmt.Sprintf("%-20v:\t%s\n\t",
+	out := fmt.Sprintf(oneLineCommonFormat,
 		"File/Folder", s.ResourcePath)
 
 	if s.Branch != "" {
-		out += fmt.Sprintf("%-20v:\t%s\n\t", "Branch", s.Branch)
+		out += fmt.Sprintf(oneLineCommonFormat, "Branch", s.Branch)
 	}
 
 	out += fmt.Sprintf("%-20v:\t%s\n\t%-20v:\t%s\n\t%-20v:\t%d\n\t%-20v:\t%d\n\t%-20v:\t%d\n\t%-20v:\t%d\n\t%-20v:\t%d\n\t",
@@ -216,9 +215,4 @@ func dirScanErrors(d results.DirScanErr) string {
 		"Directory", d.Directory,
 		"Error Message", d.ErrMessage)
 	return out
-}
-
-func iacTypesIdentified(iacs []string) string {
-	return fmt.Sprintf("%-20v:\t%s\n\t",
-		"IaC's", iacs)
 }

--- a/pkg/writer/human_readable.go
+++ b/pkg/writer/human_readable.go
@@ -30,6 +30,13 @@ const (
 	humanReadbleFormat supportedFormat = "human"
 
 	defaultTemplate string = `
+{{if (gt (len .ViolationStore.DirScanErrors) 0)}}	
+Scan Errors - 
+{{range $index, $element := .ViolationStore.DirScanErrors}}
+	{{dirScanErrors $element | printf "%s"}}
+	-----------------------------------------------------------------------
+	{{end}}
+{{end}}	
 {{if (gt (len .ViolationStore.PassedRules) 0) }}
 Passed Rules - 
     {{range $index, $element := .ViolationStore.PassedRules}}
@@ -84,6 +91,7 @@ func HumanReadbleWriter(data interface{}, writer io.Writer) error {
 		"scanSummary":            scanSummary,
 		"passedRules":            passedRules,
 		"defaultVulnerabilities": defaultVulnerabilities,
+		"dirScanErrors":          dirScanErrors,
 	}).Parse(defaultTemplate)
 	if err != nil {
 		zap.S().Errorf("failed to write human readable output. error: '%v'", err)
@@ -194,5 +202,13 @@ func defaultVulnerabilities(v results.Vulnerability) string {
 		"Line", v.LineNumber,
 		"Primary URL", v.PrimaryURL,
 		"Primary URL", v.Severity)
+	return out
+}
+
+func dirScanErrors(d results.DirScanErr) string {
+	out := fmt.Sprintf("%-20v:\t%s\n\t%-20v:\t%s\n\t%-20v:\t%s\n\t",
+		"IaC Type", d.IacType,
+		"Directory", d.Directory,
+		"Error Message", d.ErrMessage)
 	return out
 }

--- a/pkg/writer/human_readable.go
+++ b/pkg/writer/human_readable.go
@@ -37,6 +37,10 @@ Scan Errors -
 	-----------------------------------------------------------------------
 	{{end}}
 {{end}}	
+{{if (gt (len .ViolationStore.IacTypesIdentified) 0) }}
+IaC Types Identified - 
+	{{iacTypesIdentified .ViolationStore.IacTypesIdentified | printf "%s"}}
+{{end}}
 {{if (gt (len .ViolationStore.PassedRules) 0) }}
 Passed Rules - 
     {{range $index, $element := .ViolationStore.PassedRules}}
@@ -92,6 +96,7 @@ func HumanReadbleWriter(data interface{}, writer io.Writer) error {
 		"passedRules":            passedRules,
 		"defaultVulnerabilities": defaultVulnerabilities,
 		"dirScanErrors":          dirScanErrors,
+		"iacTypesIdentified":     iacTypesIdentified,
 	}).Parse(defaultTemplate)
 	if err != nil {
 		zap.S().Errorf("failed to write human readable output. error: '%v'", err)
@@ -211,4 +216,9 @@ func dirScanErrors(d results.DirScanErr) string {
 		"Directory", d.Directory,
 		"Error Message", d.ErrMessage)
 	return out
+}
+
+func iacTypesIdentified(iacs []string) string {
+	return fmt.Sprintf("%-20v:\t%s\n\t",
+		"IaC's", iacs)
 }

--- a/pkg/writer/human_readable_test.go
+++ b/pkg/writer/human_readable_test.go
@@ -62,6 +62,12 @@ var (
 			Summary: summaryWithNoViolations,
 		},
 	}
+	outputWithIacTypes = policy.EngineOutput{
+		ViolationStore: &results.ViolationStore{
+			IacTypesIdentified: []string{"k8s"},
+			Summary:            summaryWithNoViolations,
+		},
+	}
 	vulnerabilitiesInputHumanReadable = policy.EngineOutput{
 		ViolationStore: &results.ViolationStore{
 			Vulnerabilities: []*results.Vulnerability{
@@ -176,6 +182,21 @@ Scan Summary -
 	Medium              :	0
 	High                :	1`
 
+	expectedOutputWithIaCTypes = `IaC Types Identified - 
+	IaC's               :	[k8s]
+	
+
+
+Scan Summary -
+
+	File/Folder         :	test
+	IaC Type            :	terraform
+	Scanned At          :	2020-12-12 11:21:29.902796 +0000 UTC
+	Policies Validated  :	566
+	Violated Policies   :	1
+	Low                 :	0
+	Medium              :	0
+	High                :	1`
 	expectedOutputWithDirScanError = `Scan Errors - 
 
 	IaC Type            :	kustomize
@@ -191,6 +212,7 @@ Scan Summary -
 	-----------------------------------------------------------------------
 	
 	
+
 
 Passed Rules - 
     
@@ -300,6 +322,11 @@ func TestHumanReadbleWriter(t *testing.T) {
 			name:           "Human Readable Writer: with directory scan error",
 			input:          outputWithDirScanErrors,
 			expectedOutput: expectedOutputWithDirScanError,
+		},
+		{
+			name:           "Human Readable Writer: with iac types identified",
+			input:          outputWithIacTypes,
+			expectedOutput: expectedOutputWithIaCTypes,
 		},
 	}
 

--- a/pkg/writer/human_readable_test.go
+++ b/pkg/writer/human_readable_test.go
@@ -62,12 +62,6 @@ var (
 			Summary: summaryWithNoViolations,
 		},
 	}
-	outputWithIacTypes = policy.EngineOutput{
-		ViolationStore: &results.ViolationStore{
-			IacTypesIdentified: []string{"k8s"},
-			Summary:            summaryWithNoViolations,
-		},
-	}
 	vulnerabilitiesInputHumanReadable = policy.EngineOutput{
 		ViolationStore: &results.ViolationStore{
 			Vulnerabilities: []*results.Vulnerability{
@@ -182,21 +176,6 @@ Scan Summary -
 	Medium              :	0
 	High                :	1`
 
-	expectedOutputWithIaCTypes = `IaC Types Identified - 
-	IaC's               :	[k8s]
-	
-
-
-Scan Summary -
-
-	File/Folder         :	test
-	IaC Type            :	terraform
-	Scanned At          :	2020-12-12 11:21:29.902796 +0000 UTC
-	Policies Validated  :	566
-	Violated Policies   :	1
-	Low                 :	0
-	Medium              :	0
-	High                :	1`
 	expectedOutputWithDirScanError = `Scan Errors - 
 
 	IaC Type            :	kustomize
@@ -212,7 +191,6 @@ Scan Summary -
 	-----------------------------------------------------------------------
 	
 	
-
 
 Passed Rules - 
     
@@ -322,11 +300,6 @@ func TestHumanReadbleWriter(t *testing.T) {
 			name:           "Human Readable Writer: with directory scan error",
 			input:          outputWithDirScanErrors,
 			expectedOutput: expectedOutputWithDirScanError,
-		},
-		{
-			name:           "Human Readable Writer: with iac types identified",
-			input:          outputWithIacTypes,
-			expectedOutput: expectedOutputWithIaCTypes,
 		},
 	}
 

--- a/pkg/writer/human_readable_test.go
+++ b/pkg/writer/human_readable_test.go
@@ -36,6 +36,32 @@ var (
 			Summary: summaryWithNoViolations,
 		},
 	}
+	outputWithDirScanErrors = policy.EngineOutput{
+		ViolationStore: &results.ViolationStore{
+			DirScanErrors: []results.DirScanErr{
+				{
+					IacType:    "kustomize",
+					Directory:  "test/e2e/test_data/iac/aws/aws_db_instance_violation",
+					ErrMessage: "kustomization.y(a)ml file not found in the directory test/e2e/test_data/iac/aws/aws_db_instance_violation",
+				},
+				{
+					IacType:    "helm",
+					Directory:  "test/e2e/test_data/iac/aws/aws_db_instance_violation",
+					ErrMessage: "no helm charts found in directory test/e2e/test_data/iac/aws/aws_db_instance_violation",
+				},
+			},
+			PassedRules: []*results.PassedRule{
+				{
+					RuleName:    "s3EnforceUserACL",
+					Description: "S3 bucket Access is allowed to all AWS Account Users.",
+					RuleID:      "AWS.S3Bucket.DS.High.1043",
+					Severity:    "HIGH",
+					Category:    "S3",
+				},
+			},
+			Summary: summaryWithNoViolations,
+		},
+	}
 	vulnerabilitiesInputHumanReadable = policy.EngineOutput{
 		ViolationStore: &results.ViolationStore{
 			Vulnerabilities: []*results.Vulnerability{
@@ -150,6 +176,44 @@ Scan Summary -
 	Medium              :	0
 	High                :	1`
 
+	expectedOutputWithDirScanError = `Scan Errors - 
+
+	IaC Type            :	kustomize
+	Directory           :	test/e2e/test_data/iac/aws/aws_db_instance_violation
+	Error Message       :	kustomization.y(a)ml file not found in the directory test/e2e/test_data/iac/aws/aws_db_instance_violation
+	
+	-----------------------------------------------------------------------
+	
+	IaC Type            :	helm
+	Directory           :	test/e2e/test_data/iac/aws/aws_db_instance_violation
+	Error Message       :	no helm charts found in directory test/e2e/test_data/iac/aws/aws_db_instance_violation
+	
+	-----------------------------------------------------------------------
+	
+	
+
+Passed Rules - 
+    
+	Rule ID        :	AWS.S3Bucket.DS.High.1043
+	Rule Name      :	s3EnforceUserACL
+	Description    :	S3 bucket Access is allowed to all AWS Account Users.
+	Severity       :	HIGH
+	Category       :	S3
+	
+	-----------------------------------------------------------------------
+	
+
+Scan Summary -
+
+	File/Folder         :	test
+	IaC Type            :	terraform
+	Scanned At          :	2020-12-12 11:21:29.902796 +0000 UTC
+	Policies Validated  :	566
+	Violated Policies   :	1
+	Low                 :	0
+	Medium              :	0
+	High                :	1`
+
 	vulnerabilityScanOutputHumanReadable = `Vulnerabilities Details - 
     
 	Description         :	GNU Bash. Bash is the GNU Project's shell
@@ -231,6 +295,11 @@ func TestHumanReadbleWriter(t *testing.T) {
 				},
 			},
 			expectedOutput: expectedOutput4,
+		},
+		{
+			name:           "Human Readable Writer: with directory scan error",
+			input:          outputWithDirScanErrors,
+			expectedOutput: expectedOutputWithDirScanError,
 		},
 	}
 

--- a/test/e2e/scan/golden/terraform_scans/aws/aws_ami_violations/aws_ami_violation_json_all.txt
+++ b/test/e2e/scan/golden/terraform_scans/aws/aws_ami_violations/aws_ami_violation_json_all.txt
@@ -2,6 +2,26 @@
   "results": {
     "scan_errors": [
       {
+        "iac_type": "arm",
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "ARM files not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+      },
+      {
+        "iac_type": "cft",
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "CFT files not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+      },
+      {
+        "iac_type": "Docker",
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "Dockerfile not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+      },
+      {
+        "iac_type": "k8s",
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "kubernetes files not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+      },
+      {
         "iac_type": "kustomize",
         "directory": "/Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
         "errMsg": "kustomization.y(a)ml file not found in the directory /Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
@@ -11,6 +31,9 @@
         "directory": "/Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
         "errMsg": "no helm charts found in directory /Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
       }
+    ],
+    "iac_types_identified": [
+      "terraform"
     ],
     "violations": [
       {

--- a/test/e2e/scan/golden/terraform_scans/aws/aws_ami_violations/aws_ami_violation_json_all.txt
+++ b/test/e2e/scan/golden/terraform_scans/aws/aws_ami_violations/aws_ami_violation_json_all.txt
@@ -7,14 +7,14 @@
         "errMsg": "ARM files not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
       },
       {
-        "iac_type": "cft",
-        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
-        "errMsg": "CFT files not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
-      },
-      {
-        "iac_type": "Docker",
+        "iac_type": "docker",
         "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
         "errMsg": "Dockerfile not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+      },
+      {
+        "iac_type": "cft",
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "cft files not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
       },
       {
         "iac_type": "k8s",
@@ -23,17 +23,14 @@
       },
       {
         "iac_type": "kustomize",
-        "directory": "/Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
-        "errMsg": "kustomization.y(a)ml file not found in the directory /Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "kustomization.y(a)ml file not found in the directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
       },
       {
         "iac_type": "helm",
-        "directory": "/Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
-        "errMsg": "no helm charts found in directory /Users/pankajpatil/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
+        "directory": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+        "errMsg": "no helm charts found in directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation"
       }
-    ],
-    "iac_types_identified": [
-      "terraform"
     ],
     "violations": [
       {
@@ -52,9 +49,9 @@
     ],
     "skipped_violations": null,
     "scan_summary": {
-      "file/folder": "/Users/apple/go/src/github.com/patilpankaj212/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
-      "iac_type": "all",
-      "scanned_at": "2021-03-02 15:45:55.603722 +0000 UTC",
+      "file/folder": "/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation",
+      "iac_type": "terraform",
+      "scanned_at": "2022-03-25 06:40:14.665143 +0000 UTC",
       "policies_validated": 8,
       "violated_policies": 1,
       "low": 0,

--- a/test/e2e/scan/scan_test.go
+++ b/test/e2e/scan/scan_test.go
@@ -101,6 +101,17 @@ var _ = Describe("Scan", func() {
 						helper.ContainsDirScanErrorSubString(session, errString2)
 					})
 				})
+				Context("iac loading errors would be displayed in the output, output type is human readable", func() {
+					It("scan the directory and display results", func() {
+						scanArgs := []string{scanUtils.ScanCommand, "-p", policyRootRelPath}
+						// these errors would come from terraform, helm, and kustomize iac providers
+						errString1 := "kustomization.y(a)ml file not found in the directory"
+						errString2 := "no helm charts found in directory"
+						session = helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+						helper.ContainsDirScanErrorSubString(session, errString1)
+						helper.ContainsDirScanErrorSubString(session, errString2)
+					})
+				})
 				When("iac type is terraform and --non-recursive flag is used", func() {
 					It("should error out if no terraform files are present in working directory", func() {
 						scanArgs := []string{scanUtils.ScanCommand, "-i", "terraform", "--non-recursive"}


### PR DESCRIPTION
Now human-readable(default) out format will also include the scan errors.

Example of output with errors.

```		
Scan Errors - 

	IaC Type            :	arm
	Directory           :	/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	Error Message       :	ARM files not found in the directory /terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	
	-----------------------------------------------------------------------
	
	IaC Type            :	docker
	Directory           :	/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	Error Message       :	Dockerfile not found in the directory /terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	
	-----------------------------------------------------------------------
	
	IaC Type            :	cft
	Directory           :	/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	Error Message       :	error while loading iac file '/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation/config.yaml', err: failed to find valid Resources key in file: /terrascan/test/e2e/test_data/iac/aws/aws_ami_violation/config.yaml
	
	-----------------------------------------------------------------------
	
	IaC Type            :	kustomize
	Directory           :	/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	Error Message       :	kustomization.y(a)ml file not found in the directory /terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	
	-----------------------------------------------------------------------
	
	IaC Type            :	helm
	Directory           :	/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	Error Message       :	no helm charts found in directory /Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	
	-----------------------------------------------------------------------
	
	

Violation Details -
    
	Description    :	Enable AWS AMI Encryption
	File           :	main.tf
	Module Name    :	root
	Plan Root      :	./
	Line           :	5
	Severity       :	MEDIUM
	
	-----------------------------------------------------------------------
	
	Description    :	TLS disabled can affect the confidentiality of the data in transit
	File           :	config.yaml
	Line           :	1
	Severity       :	HIGH
	
	-----------------------------------------------------------------------
	

Scan Summary -

	File/Folder         :	/Users/suvarna/go/src/github.com/rchanger/terrascan/test/e2e/test_data/iac/aws/aws_ami_violation
	IaC Type            :	k8s,terraform
	Scanned At          :	2022-03-25 06:53:32.16055 +0000 UTC
	Policies Validated  :	8
	Violated Policies   :	2
	Low                 :	0
	Medium              :	1
	High                :	1
	