### PR TITLE
terraform iac provider should proceed with static analysis when rootMod is not `nil`

### DIFF
--- a/pkg/iac-providers/terraform/commons/load-dir.go
+++ b/pkg/iac-providers/terraform/commons/load-dir.go
@@ -140,12 +140,20 @@ func (t TerraformDirectoryLoader) loadDirRecursive(dirList []string) (output.All
 
 		// load current config directory
 		rootMod, diags := t.parser.LoadConfigDir(dir)
-		if diags.HasErrors() {
+		if rootMod == nil && diags.HasErrors() {
 			// log a debug message and continue with other directories
 			errMessage := fmt.Sprintf("failed to load terraform config dir '%s'. error from terraform:\n%+v\n", dir, getErrorMessagesFromDiagnostics(diags))
 			zap.S().Debug(errMessage)
 			t.addError(errMessage, dir)
 			continue
+		}
+
+		// rootMod can be considered for static analysis
+		if rootMod != nil && diags.HasErrors() {
+			// log a debug message and continue with analysis of the root mod.
+			errMessage := fmt.Sprintf("diagnostic errors while loading terraform config dir '%s'. error from terraform:\n%+v\n", dir, getErrorMessagesFromDiagnostics(diags))
+			zap.S().Debug(errMessage)
+			t.addError(errMessage, dir)
 		}
 
 		// get unified config for the current directory
@@ -257,11 +265,19 @@ func (t TerraformDirectoryLoader) loadDirNonRecursive() (output.AllResourceConfi
 
 	// load current config directory
 	rootMod, diags := t.parser.LoadConfigDir(t.absRootDir)
-	if diags.HasErrors() {
+	if rootMod == nil && diags.HasErrors() {
 		// log a debug message and continue with other directories
 		errMessage := fmt.Sprintf("failed to load terraform config dir '%s'. error from terraform:\n%+v\n", t.absRootDir, getErrorMessagesFromDiagnostics(diags))
 		zap.S().Debug(errMessage)
 		return nil, multierror.Append(t.errIacLoadDirs, results.DirScanErr{IacType: "terraform", Directory: t.absRootDir, ErrMessage: errMessage})
+	}
+
+	// rootMod can be considered for static analysis
+	if rootMod != nil && diags.HasErrors() {
+		// log a debug message and continue with analysis of the root mod.
+		errMessage := fmt.Sprintf("diagnostic errors while loading terraform config dir '%s'. error from terraform:\n%+v\n", t.absRootDir, getErrorMessagesFromDiagnostics(diags))
+		zap.S().Debug(errMessage)
+		t.addError(errMessage, t.absRootDir)
 	}
 
 	// get unified config for the current directory

--- a/pkg/iac-providers/terraform/v12/load-dir_test.go
+++ b/pkg/iac-providers/terraform/v12/load-dir_test.go
@@ -37,14 +37,14 @@ func TestLoadIacDir(t *testing.T) {
 	destroyProvisionersDir := filepath.Join(testDataDir, "destroy-provisioners")
 	destroyProvisionersMainFile := filepath.Join(destroyProvisionersDir, "main.tf")
 
-	testErrorString1 := fmt.Sprintf(`failed to load terraform config dir '%s'. error from terraform:
+	testErrorString1 := fmt.Sprintf(`diagnostic errors while loading terraform config dir '%s'. error from terraform:
 %s:1,21-2,1: Invalid block definition; A block definition must have block content delimited by "{" and "}", starting on the same line as the block header.
 %s:1,1-5: Unsupported block type; Blocks of type "some" are not expected here.
 `, testDataDir, emptyTfFilePath, emptyTfFilePath)
 
 	multipleProvidersDir := filepath.Join(testDataDir, "multiple-required-providers")
 
-	testErrorString2 := fmt.Sprintf(`failed to load terraform config dir '%s'. error from terraform:
+	testErrorString2 := fmt.Sprintf(`diagnostic errors while loading terraform config dir '%s'. error from terraform:
 %s:2,3-21: Duplicate required providers configuration; A module may have only one required providers configuration. The required providers were previously configured at %s:2,3-21.
 `, multipleProvidersDir, filepath.Join(multipleProvidersDir, "b.tf"), filepath.Join(multipleProvidersDir, "a.tf"))
 
@@ -52,7 +52,7 @@ func TestLoadIacDir(t *testing.T) {
 <nil>: Failed to read module directory; Module directory %s does not exist or cannot be read.
 `, filepath.Join(testDataDir, "invalid-moduleconfigs", "cloudfront", "sub-cloudfront"))
 
-	errStringDestroyProvisioners := fmt.Sprintf(`failed to load terraform config dir '%s'. error from terraform:
+	errStringDestroyProvisioners := fmt.Sprintf(`diagnostic errors while loading terraform config dir '%s'. error from terraform:
 %s:8,12-22: Invalid reference from destroy provisioner; Destroy-time provisioners and their connection configurations may only reference attributes of the related resource, via 'self', 'count.index', or 'each.key'.
 
 References to other resources during the destroy phase can cause dependency cycles and interact poorly with create_before_destroy.

--- a/pkg/iac-providers/terraform/v14/load-dir_test.go
+++ b/pkg/iac-providers/terraform/v14/load-dir_test.go
@@ -34,7 +34,7 @@ import (
 func TestLoadIacDir(t *testing.T) {
 	var nilMultiErr *multierror.Error = nil
 
-	testErrorMessage := fmt.Sprintf(`failed to load terraform config dir '%s'. error from terraform:
+	testErrorMessage := fmt.Sprintf(`diagnostic errors while loading terraform config dir '%s'. error from terraform:
 %s:1,21-2,1: Invalid block definition; A block definition must have block content delimited by "{" and "}", starting on the same line as the block header.
 %s:1,1-5: Unsupported block type; Blocks of type "some" are not expected here.
 `, testDataDir, emptyTfFilePath, emptyTfFilePath)

--- a/pkg/iac-providers/terraform/v15/load-dir_test.go
+++ b/pkg/iac-providers/terraform/v15/load-dir_test.go
@@ -34,7 +34,7 @@ import (
 func TestLoadIacDir(t *testing.T) {
 	var nilMultiErr *multierror.Error = nil
 
-	testErrorMessage := fmt.Sprintf(`failed to load terraform config dir '%s'. error from terraform:
+	testErrorMessage := fmt.Sprintf(`diagnostic errors while loading terraform config dir '%s'. error from terraform:
 %s:1,21-2,1: Invalid block definition; A block definition must have block content delimited by "{" and "}", starting on the same line as the block header.
 %s:1,1-5: Unsupported block type; Blocks of type "some" are not expected here.
 `, testDataDir, emptyTfFilePath, emptyTfFilePath)


### PR DESCRIPTION
fixes #1182 
fixes #1176 