### PR TITLE
[Feature]Option to provide temp directory path for download

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,6 +153,7 @@ You should see a total of 9 violations, which are detailed in the output.
 
 Now that you understand how to run Terrascan, you can explore various options available. The [usage page](usage/usage.md) covers the options in detail. For more information, see [Related resources](#related_resources).
 
+If you do not want terrascan to use `os.TempDir()` for downloading/cloning of remote repository, terraform module or template files you can specify the directory to use by setting `TERRRASCAN_CUSTOM_TEMP_DIR` environment variable.
 # Related resources
 
 * The [usage guide](usage/usage.md) explains general usage, how to scan other types of IaC (such as: Kubernetes, Helm, and Kustomize), List of other IaC providers (e.g. Kubernetes, Helm, etc.), instructions to limit the scan to specific directories or files, and generating the output in different formats.

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/accurics/terrascan/pkg/downloader"
@@ -190,7 +189,7 @@ func (s *ScanOptions) initColor() {
 func (s *ScanOptions) Run() error {
 
 	// temp dir to download the remote repo
-	tempDir := filepath.Join(os.TempDir(), utils.GenRandomString(6))
+	tempDir := utils.GenerateTempDir()
 	defer os.RemoveAll(tempDir)
 
 	// download remote repository

--- a/pkg/http-server/remote-repo.go
+++ b/pkg/http-server/remote-repo.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/accurics/terrascan/pkg/config"
@@ -120,7 +119,7 @@ func (s *scanRemoteRepoReq) ScanRemoteRepo(iacType, iacVersion string, cloudType
 	)
 
 	// temp destination directory to download remote repo
-	tempDir := filepath.Join(os.TempDir(), utils.GenRandomString(6))
+	tempDir := utils.GenerateTempDir()
 	defer os.RemoveAll(tempDir)
 
 	// download remote repository

--- a/pkg/mapper/iac-providers/arm/functions/linked-template.go
+++ b/pkg/mapper/iac-providers/arm/functions/linked-template.go
@@ -13,7 +13,7 @@ import (
 
 // ResolveLinkedTemplate downloads temlate for the given uri and returns its path
 func ResolveLinkedTemplate(uri string) ([]byte, error) {
-	tempDir := filepath.Join(os.TempDir(), utils.GenRandomString(6))
+	tempDir := utils.GenerateTempDir()
 	defer os.RemoveAll(tempDir)
 	path, err := downloadTemplate(uri, tempDir)
 	if err != nil {

--- a/pkg/mapper/iac-providers/cft/functions/s3-download.go
+++ b/pkg/mapper/iac-providers/cft/functions/s3-download.go
@@ -136,7 +136,7 @@ func downloadPrivateTemplate(url *url.URL, s3c *S3Client) ([]byte, error) {
 }
 
 func downloadPublicTemplate(uri string) ([]byte, error) {
-	dst := filepath.Join(os.TempDir(), utils.GenRandomString(6))
+	dst := utils.GenerateTempDir()
 	defer os.RemoveAll(dst)
 	parts := strings.Split(uri, "/")
 	path := filepath.Join(dst, parts[len(parts)-1])

--- a/pkg/utils/dir.go
+++ b/pkg/utils/dir.go
@@ -24,6 +24,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// customTempDir env variable if set all the repository/module/template
+// download will happen in the provided directory
+const customTempDir = "TERRRASCAN_CUSTOM_TEMP_DIR"
+
 // GetHomeDir returns the home directory path
 func GetHomeDir() (terrascanDir string) {
 	zap.S().Debug("looking up for the home directory path")
@@ -39,7 +43,12 @@ func GetHomeDir() (terrascanDir string) {
 
 // GenerateTempDir generates a temporary directory
 func GenerateTempDir() string {
-	return filepath.Join(os.TempDir(), GenRandomString(6))
+	// if env variable custom temp directory is set will be used for download/clone.
+	tempDir := os.Getenv(customTempDir)
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+	return filepath.Join(tempDir, GenRandomString(6))
 }
 
 // IsDirExists checks wether the provided directory exists or not

--- a/test/e2e/scan/scan_remote_test.go
+++ b/test/e2e/scan/scan_remote_test.go
@@ -17,6 +17,9 @@
 package scan_test
 
 import (
+	"os"
+	"path/filepath"
+
 	scanUtils "github.com/accurics/terrascan/test/e2e/scan"
 	"github.com/accurics/terrascan/test/helper"
 	. "github.com/onsi/ginkgo"
@@ -224,6 +227,30 @@ var _ = Describe("Scan Command using remote types", func() {
 					session = helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
 					Eventually(session, scanUtils.RemoteScanTimeout).Should(gexec.Exit(helper.ExitCodeOne))
 				})
+			})
+		})
+	})
+	Context("when scan is run using custom temp directory with env variable", func() {
+		When("remote type is git", func() {
+			remoteURL := "github.com/accurics/KaiMonkey/terraform/aws"
+			tmpDir, err := filepath.Abs(filepath.Join(iacRootRelPath, "temp_dir"))
+			Expect(err).NotTo(HaveOccurred())
+			JustBeforeEach(func() {
+				err = os.Setenv("TERRRASCAN_CUSTOM_TEMP_DIR", tmpDir)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			JustAfterEach(func() {
+				err := os.Unsetenv("TERRRASCAN_CUSTOM_TEMP_DIR")
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should download the resource in provided custom temp dir and generate scan results", func() {
+				scanArgs := []string{scanUtils.ScanCommand, "-o", "json", "-r", "git", "--remote-url", remoteURL}
+				session = helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				// exit code is 5 because iac files in directory has violations
+				// and directory scan errors
+				Eventually(session, scanUtils.RemoteScanTimeout).Should(gexec.Exit(helper.ExitCodeFive))
+				helper.ContainsDirScanErrorSubString(session, tmpDir)
 			})
 		})
 	})


### PR DESCRIPTION
Changes to read environment variable `TERRRASCAN_CUSTOM_TEMP_DIR` to specify a temporary directory to download repository, terraform modules, and cft/arm templates.