### PR TITLE
support for new flag to define custom temp directory

### DIFF
--- a/docs/usage/command_line_mode.md
+++ b/docs/usage/command_line_mode.md
@@ -39,6 +39,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.
 ```
@@ -291,6 +292,7 @@ aws_ecr_repository:
 | -l | Use this to specify what log settings | debug, **info**, warn, error, panic, fatal  |
 | -x | Use this to specify the log file format | **console**, json |
 | -o | Use this to specify the scan output type | **human**, json, yaml, xml, junit-xml, sarif, github-sarif |
+| --temp-dir | Use this to specify temporary directory path to download remote repository,module and templates |
 
 
 
@@ -337,4 +339,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates
 ```

--- a/pkg/cli/register.go
+++ b/pkg/cli/register.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/accurics/terrascan/pkg/config"
 	"github.com/accurics/terrascan/pkg/logging"
+	"github.com/accurics/terrascan/pkg/utils"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -40,6 +41,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&LogType, "log-type", "x", "console", "log output type (console, json)")
 	rootCmd.PersistentFlags().StringVarP(&OutputType, "output", "o", "human", "output type (human, json, yaml, xml, junit-xml, sarif, github-sarif)")
 	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config-path", "c", "", "config file path")
+	rootCmd.PersistentFlags().StringVarP(&CustomTempDir, "temp-dir", "", "", "temporary directory path to download remote repository,module and templates")
 
 	//Added init here in case flag parsing failed we should log which flag was incorrect.
 	logging.Init(LogType, LogLevel)
@@ -58,6 +60,9 @@ func Execute() {
 		if err := config.LoadGlobalConfig(ConfigFile); err != nil {
 			zap.S().Error("error while loading global config", zap.Error(err))
 			os.Exit(1)
+		}
+		if CustomTempDir != "" {
+			utils.CustomTempDir = CustomTempDir
 		}
 	})
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -32,6 +32,9 @@ var (
 
 	// ConfigFile Config file path
 	ConfigFile string
+
+	// CustomTempDir Temporary directory path to download remote repository,module and templates
+	CustomTempDir string
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/utils/dir.go
+++ b/pkg/utils/dir.go
@@ -28,6 +28,9 @@ import (
 // download will happen in the provided directory
 const customTempDir = "TERRRASCAN_CUSTOM_TEMP_DIR"
 
+// CustomTempDir store the global flag --temp-dir value which will be used to download repository,module and template.
+var CustomTempDir string
+
 // GetHomeDir returns the home directory path
 func GetHomeDir() (terrascanDir string) {
 	zap.S().Debug("looking up for the home directory path")
@@ -45,6 +48,9 @@ func GetHomeDir() (terrascanDir string) {
 func GenerateTempDir() string {
 	// if env variable custom temp directory is set will be used for download/clone.
 	tempDir := os.Getenv(customTempDir)
+	if CustomTempDir != "" {
+		tempDir = CustomTempDir
+	}
 	if tempDir == "" {
 		tempDir = os.TempDir()
 	}

--- a/test/e2e/help/golden/help_command.txt
+++ b/test/e2e/help/golden/help_command.txt
@@ -19,5 +19,6 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_flag.txt
+++ b/test/e2e/help/golden/help_flag.txt
@@ -17,5 +17,6 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_init.txt
+++ b/test/e2e/help/golden/help_init.txt
@@ -13,3 +13,4 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_scan.txt
+++ b/test/e2e/help/golden/help_scan.txt
@@ -37,3 +37,4 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_server.txt
+++ b/test/e2e/help/golden/help_server.txt
@@ -16,3 +16,4 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_unsupported_command.txt
+++ b/test/e2e/help/golden/help_unsupported_command.txt
@@ -14,5 +14,6 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_version.txt
+++ b/test/e2e/help/golden/help_version.txt
@@ -13,3 +13,4 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/no_command.txt
+++ b/test/e2e/help/golden/no_command.txt
@@ -19,5 +19,6 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/scan/scan_remote_test.go
+++ b/test/e2e/scan/scan_remote_test.go
@@ -254,4 +254,19 @@ var _ = Describe("Scan Command using remote types", func() {
 			})
 		})
 	})
+	Context("when scan is run on remote dir and using flag --temp-dir to set custom temp dir", func() {
+		When("remote type is git", func() {
+			remoteURL := "github.com/accurics/KaiMonkey/terraform/aws"
+			tmpDir, err := filepath.Abs(filepath.Join(iacRootRelPath, "temp_dir"))
+			Expect(err).NotTo(HaveOccurred())
+			It("should download the resource in provided custom temp dir and generate scan results", func() {
+				scanArgs := []string{scanUtils.ScanCommand, "-o", "json", "-r", "git", "--remote-url", remoteURL, "--temp-dir", tmpDir}
+				session = helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				// exit code is 5 because iac files in directory has violations
+				// and directory scan errors
+				Eventually(session, scanUtils.RemoteScanTimeout).Should(gexec.Exit(helper.ExitCodeFive))
+				helper.ContainsDirScanErrorSubString(session, tmpDir)
+			})
+		})
+	})
 })


### PR DESCRIPTION
Adds a new global flag `--temp-dir` to specify a custom temporary directory for cloning. 