### PR TITLE
#1158 Fix check for sqs without encryption

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_sqs_queue/sqsSseDisabled.rego
+++ b/pkg/policies/opa/rego/aws/aws_sqs_queue/sqsSseDisabled.rego
@@ -3,4 +3,5 @@ package accurics
 {{.prefix}}sqsSseDisabled[sqs.id] {
   sqs := input.aws_sqs_queue[_]
   object.get(sqs.config, "kms_master_key_id", "undefined") == ["undefined", null, ""][_]
+  object.get(sqs.config, "sqs_managed_sse_enabled", false) == [false , null, ""][_]
 }


### PR DESCRIPTION
According to [that](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue#server-side-encryption-sse), with _sqs_managed_sse_enabled_ sse can be enabled as well.

Fixes #1158 