### PR TITLE
file out writer implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=accurics_terrascan&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=accurics_terrascan)
 [![AUR package](https://repology.org/badge/version-for-repo/aur/terrascan.svg)](https://repology.org/project/terrascan/versions)
 [![codecov](https://codecov.io/gh/accurics/terrascan/branch/master/graph/badge.svg)](https://codecov.io/gh/accurics/terrascan)
-[![Documentation Status](https://readthedocs.com/projects/accurics-terrascan/badge/?version=latest)](https://docs.accurics.com/projects/accurics-terrascan/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.com/projects/accurics-terrascan/badge/?version=latest)](https://runterrascan.io/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
 ## Introduction

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -6,7 +6,7 @@ Validating Webhook as well, that'll use the terrascan server as its backend.
 In server mode, terrascan will act both as an API server for
 performing remote scans of IAC, as well as a validating admission
 webhook for a Kubernetes cluster. Further details can be found in
-the [main documentation](https://docs.accurics.com/projects/accurics-terrascan/en/latest/).
+the [main documentation](https://runterrascan.io/).
 
 ## Usage
 ### Set up TLS certificates
@@ -25,7 +25,7 @@ will be named `terrascan` and hosted in `terrascan` namespace. You'll have to ma
 
 ### Terrascan configuration file
 This chart will look for a [terrascan configuration
-file](https://docs.accurics.com/projects/accurics-terrascan/en/latest/usage/#config-file)
+file](https://runterrascan.io/docs/usage/config_options/)
 at `data/config.toml`. If that file exists before running `helm
 install`, it's contents will be loaded into a configMap and provided
 to the terrascan server.

--- a/deploy/kustomize/README.md
+++ b/deploy/kustomize/README.md
@@ -1,26 +1,26 @@
-## INSTALLING TERRASCAN IN A KUBERNETES CLUSTER USING KUSTOMIZE
+## Installing terrascan in a Kubernetes cluster using Kustomize
 
 This guide will help you install terrascan server inside your kubernetes cluster.
 We have covered the following use cases in the sections below.
 
-  - #####[Deploying Terrascan Server](deploying-terrascan-server)
+  - [Deploying Terrascan Server](#deploying-terrascan-server)  
     Terrascan operating in http server mode.
 
-  - ####[Deploying Terrascan Server in TLS Mode](deploying-terrascan-server-in-tls-mode)
+  - [Deploying Terrascan Server in TLS Mode](#deploying-terrascan-server-in-tls-mode)  
     Terrascan operating in https server mode. This deployment is also a foundation for the terrascan webhook setup.
 
-  - ####[Deploying Terrascan Server for Remote Repository Scan](deploying-terrascan-server-for-remote-repository-scan)
+  - [Deploying Terrascan Server for Remote Repository Scan](#deploying-terrascan-server-for-private-remote-repository-scan)  
     Terrascan in https server mode installed with ssh capabilities, to scan ***private*** remote repositories. For remote
     scanning public repos, deploying `Terrascan Server in TLS Mode` is sufficient.
     This deployment can be handy for use-cases like an argocd pre-sync hook that sends remote repository scan requests to the server.
 
-  - ####[Setting Up Terrascan Webhook](setting-up-terrascan-webhook)
+  - [Setting Up Terrascan Webhook](#setting-up-terrascan-webhook)  
     A Kubernetes Validating Webhook, that safeguards your cluster by denying the creation of kubernetes resources that
     can cause potential security violations.
 
-  - ####[Clean Up](clean-up)
+  - [Clean Up](#clean-up)
 
-###PRE-REQUISITE
+### Pre-requisite
 1. Make sure you have required access on the kubernetes cluster to create and update the following resources:
 
   - Secrets
@@ -63,7 +63,7 @@ terrascan server. The string replacement will be required in the following files
   kubectl create namespace terrascan
   ```
 
-###Deploying Terrascan Server
+### Deploying Terrascan Server
 
 Deploy terrascan in server mode operating in plain HTTP mode.
 
@@ -78,7 +78,7 @@ Deploy terrascan in server mode operating in plain HTTP mode.
     kustomize build server/ | kubectl apply -f -
     ```
 
-###Deploying Terrascan Server in TLS Mode
+### Deploying Terrascan Server in TLS Mode
 
 Deploy terrascan in server mode operating in HTTPS mode.
 
@@ -126,7 +126,7 @@ Deploy terrascan in server mode operating in HTTPS mode.
     kustomize build server-tls/ | kubectl apply -f -
     ```
 
-###Deploying Terrascan Server For Private Remote Repository Scan
+### Deploying Terrascan Server For Private Remote Repository Scan
 
 For scanning ***Private*** remote IaC file repositories, Terrascan must be provided with the required SSH keys to connect and clone the
 repository locally to scan it. The following steps will help in setting up for that.
@@ -170,7 +170,7 @@ repository locally to scan it. The following steps will help in setting up for t
    kustomize build server-remote-repo-scan/ | kubectl apply -f -
     ```
 
-###Setting Up Terrascan Webhook
+### Setting Up Terrascan Webhook
 If you want to setup a Validating Webhook that scans your incoming kubernetes resources using terrascan,
 follow the steps below.
 
@@ -245,7 +245,7 @@ follow the steps below.
     kubectl apply -f webhook/validating-webhook.yaml
     ```
 
-###Clean Up
+### Clean Up
 
   Deleting the namespace that you used, will delete all the resources itself.
   ```bash

--- a/docs/integrations/argocd-integration.md
+++ b/docs/integrations/argocd-integration.md
@@ -328,7 +328,7 @@ Host github.com
 
 After making changes to the webhook deployment file, apply this yaml in your cluster.
 
-You can also run terrascan admission controller server outside cluster, for more information and instructions on configuring terrascan as an admission controller webhook, see https://docs.accurics.com/projects/accurics-terrascan/en/latest/integrations/admission-controller-webhooks-usage.
+You can also run terrascan admission controller server outside cluster, for more information and instructions on configuring terrascan as an admission controller webhook, see https://runterrascan.io/docs/integrations/k8s/.
 
 #### Step 2: Create a Dockerfile
 

--- a/docs/usage/command_line_mode.md
+++ b/docs/usage/command_line_mode.md
@@ -34,13 +34,13 @@ Available Commands:
   version     Shows the Terrascan version you are currently using.
 
 Flags:
-  -c, --config-path string   config file path
-  -h, --help                 help for terrascan
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -h, --help                    help for terrascan
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.
 ```
@@ -291,9 +291,9 @@ aws_ecr_repository:
 | ----------- | ----------- |------------|
 | -c | Use this to specify config file settings | Format supported is `*.TOML` |
 | -l | Use this to specify what log settings | debug, **info**, warn, error, panic, fatal  |
+| --log-output-dir | Use this to specify the directory path for writing scan logs and output files along with console output. In case the directory could not be resolved, the scan logs and results will be printed on console only. |
 | -x | Use this to specify the log file format | **console**, json |
 | -o | Use this to specify the scan output type | **human**, json, yaml, xml, junit-xml, sarif, github-sarif |
-| --output-dir | Use this to over-write the directory path for writing scan logs and output files, default directory is user's HOME directory. If the provided directory path doesn't exist, Terrascan will try to create the path. On failure to make the directory, it will fall back to default. In case the HOME directory could not be resolved, the scan logs and results will be printed on console only. |
 | --temp-dir | Use this to specify temporary directory path to download remote repository,module and templates |
 
 
@@ -337,10 +337,10 @@ Flags:
   -v, --verbose                             will show violations with details (applicable for default output)
 
 Global Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates
 ```

--- a/docs/usage/command_line_mode.md
+++ b/docs/usage/command_line_mode.md
@@ -21,7 +21,7 @@ $ terrascan
 Terrascan
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
-For more information, please visit https://docs.accurics.com
+For more information, please visit https://runterrascan.io/
 
 Usage:
   terrascan [command]
@@ -39,6 +39,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.
@@ -292,6 +293,7 @@ aws_ecr_repository:
 | -l | Use this to specify what log settings | debug, **info**, warn, error, panic, fatal  |
 | -x | Use this to specify the log file format | **console**, json |
 | -o | Use this to specify the scan output type | **human**, json, yaml, xml, junit-xml, sarif, github-sarif |
+| --output-dir | Use this to over-write the directory path for writing scan logs and output files, default directory is user's HOME directory. If the provided directory path doesn't exist, Terrascan will try to create the path. On failure to make the directory, it will fall back to default. In case the HOME directory could not be resolved, the scan logs and results will be printed on console only. |
 | --temp-dir | Use this to specify temporary directory path to download remote repository,module and templates |
 
 
@@ -339,5 +341,6 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 ```

--- a/go.mod
+++ b/go.mod
@@ -55,13 +55,13 @@ require (
 	github.com/zclconf/go-cty v1.9.1
 	go.uber.org/zap v1.16.0
 	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d
-	golang.org/x/tools v0.1.8 // indirect
+	golang.org/x/tools v0.1.11-0.20220316014157-77aa08bb151a // indirect
 	google.golang.org/api v0.34.0
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	helm.sh/helm/v3 v3.6.1
-	honnef.co/go/tools v0.2.2 // indirect
+	honnef.co/go/tools v0.3.1 // indirect
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v10.0.0+incompatible
@@ -175,9 +175,10 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.6.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect
-	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/mod v0.5.1 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1510,6 +1510,8 @@ golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1521,7 +1523,10 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e h1:qyrTQ++p1afMkO4DPEeLGq/3oTsdlvdH4vqZUBWzUKM=
+golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1549,6 +1554,8 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1836,6 +1843,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
 golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.11-0.20220316014157-77aa08bb151a h1:ofrrl6c6NG5/IOSx/R1cyiQxxjqlur0h/TvbUhkH0II=
+golang.org/x/tools v0.1.11-0.20220316014157-77aa08bb151a/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -2029,6 +2038,8 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.2.2 h1:MNh1AVMyVX23VUHE2O27jm6lNj3vjO5DexS4A1xvnzk=
 honnef.co/go/tools v0.2.2/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
+honnef.co/go/tools v0.3.1 h1:1kJlrWJLkaGXgcaeosRXViwviqjI7nkBvU2+sZW0AYc=
+honnef.co/go/tools v0.3.1/go.mod h1:vlRD9XErLMGT+mDuofSr0mMMquscM/1nQqtRSsh6m70=
 k8s.io/api v0.19.0 h1:XyrFIJqTYZJ2DU7FBE/bSPz7b1HvbVBuBf07oeo6eTc=
 k8s.io/api v0.19.0/go.mod h1:I1K45XlvTrDjmj5LoM5LuP/KYrhWbjUKT/SoPG0qTjw=
 k8s.io/apiextensions-apiserver v0.21.0 h1:Nd4uBuweg6ImzbxkC1W7xUNZcCV/8Vt10iTdTIVF3hw=

--- a/pkg/cli/output_writer.go
+++ b/pkg/cli/output_writer.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/accurics/terrascan/pkg/termcolor"
+	"go.uber.org/zap"
 )
 
 // NewOutputWriter gets a new io.Writer based on os.Stdout.
@@ -16,4 +18,34 @@ func NewOutputWriter(useColors bool) io.Writer {
 		return termcolor.NewColorizedWriter(os.Stdout)
 	}
 	return os.Stdout
+}
+
+// NewFileWriter gets a new io.Writer based on file output.
+func NewFileWriter(dir string, outputType string) (io.Writer, func() error) {
+
+	// if no directory resolved
+	if dir == "" {
+		return nil, nil
+	}
+
+	fileName := "scan-result.txt"
+
+	// decide the file extension/type
+	switch outputType {
+	case "json":
+		fileName = "scan-result.json"
+	case "yaml":
+		fileName = "scan-result.yaml"
+	case "xml", "junit-xml":
+		fileName = "scan-result.xml"
+	}
+
+	filePath := filepath.Join(dir, fileName)
+	f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		zap.S().Warn("unable to open file: %s, error:%w", filePath, err)
+		return nil, nil
+	}
+
+	return f, f.Close
 }

--- a/pkg/cli/output_writer.go
+++ b/pkg/cli/output_writer.go
@@ -20,7 +20,8 @@ func NewOutputWriter(useColors bool) io.Writer {
 	return os.Stdout
 }
 
-// NewFileWriter gets a new io.Writer based on file output.
+// NewFileWriter gets a new io.Writer based on file output and closing function.
+// It returns `nil nil` if the value of dir is empty or if the file can't be opened
 func NewFileWriter(dir string, outputType string) (io.Writer, func() error) {
 
 	// if no directory resolved
@@ -38,6 +39,8 @@ func NewFileWriter(dir string, outputType string) (io.Writer, func() error) {
 		fileName = "scan-result.yaml"
 	case "xml", "junit-xml":
 		fileName = "scan-result.xml"
+	case "sarif", "github-sarif":
+		fileName = "scan-result.sarif"
 	}
 
 	filePath := filepath.Join(dir, fileName)

--- a/pkg/cli/register.go
+++ b/pkg/cli/register.go
@@ -42,30 +42,25 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&OutputType, "output", "o", "human", "output type (human, json, yaml, xml, junit-xml, sarif, github-sarif)")
 	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config-path", "c", "", "config file path")
 	rootCmd.PersistentFlags().StringVarP(&CustomTempDir, "temp-dir", "", "", "temporary directory path to download remote repository,module and templates")
-	rootCmd.PersistentFlags().StringVarP(&OutputDir, "output-dir", "", "", "directory path to over-write the default logs and output files ( default directory is user home directory)")
+	rootCmd.PersistentFlags().StringVarP(&LogOutputDir, "log-output-dir", "", "", "directory path to write the log and output files")
 
 	//Added init here in case flag parsing failed we should log which flag was incorrect.
-	logging.Init(LogType, LogLevel, OutputDir)
+	logging.Init(LogType, LogLevel, LogOutputDir)
 
 	// Function to execute before processing commands
 	cobra.OnInitialize(func() {
 		// validate OutputDir
-		// make sure the OutputDir Exist, on failure setting OutputDir to user's HOME as default location
-		if OutputDir != "" {
-			err := os.MkdirAll(OutputDir, 0755)
+		// make sure the OutputDir Exist, on failure set OutputDir to user's HOME as default location
+		if LogOutputDir != "" {
+			err := os.MkdirAll(LogOutputDir, 0755)
 			if err != nil {
-				zap.S().Warnf("failed to resolve the output directory: %s, writing results to user's HOME", OutputDir)
-				OutputDir = ""
+				zap.S().Warnf("failed to resolve the log output directory: %s", LogOutputDir)
+				LogOutputDir = ""
 			}
 		}
-		if OutputDir == "" {
-			OutputDir = utils.GetHomeDir()
-		}
-		if OutputDir == "" {
-			zap.S().Warn("failed to resolve the user's HOME directory, skipped writing logs/results to file")
-		}
+
 		// Set up the logger
-		logging.Init(LogType, LogLevel, OutputDir)
+		logging.Init(LogType, LogLevel, LogOutputDir)
 
 		if len(ConfigFile) == 0 {
 			ConfigFile = os.Getenv(config.ConfigEnvvarName)

--- a/pkg/cli/register.go
+++ b/pkg/cli/register.go
@@ -42,7 +42,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&OutputType, "output", "o", "human", "output type (human, json, yaml, xml, junit-xml, sarif, github-sarif)")
 	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config-path", "c", "", "config file path")
 	rootCmd.PersistentFlags().StringVarP(&CustomTempDir, "temp-dir", "", "", "temporary directory path to download remote repository,module and templates")
-	rootCmd.PersistentFlags().StringVarP(&OutputDir, "output-dir", "", "", "directory path to over-write the default logs and output files ( default directory is user's home directory)")
+	rootCmd.PersistentFlags().StringVarP(&OutputDir, "output-dir", "", "", "directory path to over-write the default logs and output files ( default directory is user home directory)")
 
 	//Added init here in case flag parsing failed we should log which flag was incorrect.
 	logging.Init(LogType, LogLevel, OutputDir)

--- a/pkg/cli/register.go
+++ b/pkg/cli/register.go
@@ -49,8 +49,7 @@ func Execute() {
 
 	// Function to execute before processing commands
 	cobra.OnInitialize(func() {
-		// validate OutputDir
-		// make sure the OutputDir Exist, on failure set OutputDir to user's HOME as default location
+		// making sure the LogOutputDir Exist
 		if LogOutputDir != "" {
 			err := os.MkdirAll(LogOutputDir, 0755)
 			if err != nil {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -36,8 +36,8 @@ var (
 	// CustomTempDir Temporary directory path to download remote repository,module and templates
 	CustomTempDir string
 
-	// OutputDir Directory to write scan logs and result files
-	OutputDir string
+	// LogOutputDir Directory to write scan logs and result files
+	LogOutputDir string
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -46,6 +46,6 @@ var rootCmd = &cobra.Command{
 	Long: `Terrascan
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
-For more information, please visit https://docs.accurics.com
+For more information, please visit https://runterrascan.io/
 `,
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -35,6 +35,9 @@ var (
 
 	// CustomTempDir Temporary directory path to download remote repository,module and templates
 	CustomTempDir string
+
+	// OutputDir Directory to write scan logs and result files
+	OutputDir string
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -118,8 +118,8 @@ type ScanOptions struct {
 	// repoRef lets us specify the branch of the repository being scanned
 	repoRef string
 
-	// outputDir lets us specify the directory to write scan result and log files
-	outputDir string
+	// logOutputDir lets us specify the directory to write scan result and log files
+	logOutputDir string
 }
 
 // NewScanOptions returns a new pointer to ScanOptions
@@ -262,7 +262,7 @@ func (s ScanOptions) writeResults(results runtime.Output) error {
 	outputWriter := NewOutputWriter(s.UseColors)
 	writers = append(writers, outputWriter)
 
-	fileWriter, closeFile := NewFileWriter(s.outputDir, s.outputType)
+	fileWriter, closeFile := NewFileWriter(s.logOutputDir, s.outputType)
 	if fileWriter != nil {
 		writers = append(writers, fileWriter)
 		defer closeFile()

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -51,7 +51,7 @@ func scan(cmd *cobra.Command, args []string) error {
 	zap.S().Debug("running terrascan in cli mode")
 	scanOptions.configFile = ConfigFile
 	scanOptions.outputType = OutputType
-	scanOptions.outputDir = OutputDir
+	scanOptions.outputDir = LogOutputDir
 	return scanOptions.Scan()
 }
 

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -51,7 +51,7 @@ func scan(cmd *cobra.Command, args []string) error {
 	zap.S().Debug("running terrascan in cli mode")
 	scanOptions.configFile = ConfigFile
 	scanOptions.outputType = OutputType
-	scanOptions.outputDir = LogOutputDir
+	scanOptions.logOutputDir = LogOutputDir
 	return scanOptions.Scan()
 }
 

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -51,6 +51,7 @@ func scan(cmd *cobra.Command, args []string) error {
 	zap.S().Debug("running terrascan in cli mode")
 	scanOptions.configFile = ConfigFile
 	scanOptions.outputType = OutputType
+	scanOptions.outputDir = OutputDir
 	return scanOptions.Scan()
 }
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -17,9 +17,13 @@
 package logging
 
 import (
+	"path/filepath"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+const LogFileName = "terrascan.log"
 
 var globalLogger *zap.SugaredLogger
 
@@ -44,7 +48,7 @@ func getLoggerLevel(lvl string) zapcore.Level {
 }
 
 // Init initializes global custom zap logger
-func Init(encoding, level string) {
+func Init(encoding, level, logDir string) {
 
 	// select encoding level
 	encodingLevel := zapcore.LowercaseColorLevelEncoder
@@ -53,7 +57,7 @@ func Init(encoding, level string) {
 	}
 
 	// get logger
-	logger := GetLogger(level, encoding, encodingLevel)
+	logger := GetLogger(level, encoding, logDir, encodingLevel)
 
 	// set global Logger as well
 	globalLogger = logger.Sugar()
@@ -63,7 +67,7 @@ func Init(encoding, level string) {
 }
 
 // GetLogger creates a customer zap logger
-func GetLogger(logLevel, encoding string, encodingLevel func(zapcore.Level, zapcore.PrimitiveArrayEncoder)) *zap.Logger {
+func GetLogger(logLevel, encoding, logDir string, encodingLevel func(zapcore.Level, zapcore.PrimitiveArrayEncoder)) *zap.Logger {
 
 	// build zap config
 	zapConfig := zap.Config{
@@ -79,6 +83,10 @@ func GetLogger(logLevel, encoding string, encodingLevel func(zapcore.Level, zapc
 			EncodeTime:   zapcore.ISO8601TimeEncoder,
 			EncodeCaller: zapcore.ShortCallerEncoder,
 		},
+	}
+
+	if logDir != "" {
+		zapConfig.OutputPaths = append(zapConfig.OutputPaths, filepath.Join(logDir, LogFileName))
 	}
 
 	// create zap logger

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const LogFileName = "terrascan.log"
+const logFileName = "terrascan.log"
 
 var globalLogger *zap.SugaredLogger
 
@@ -86,7 +86,7 @@ func GetLogger(logLevel, encoding, logDir string, encodingLevel func(zapcore.Lev
 	}
 
 	if logDir != "" {
-		zapConfig.OutputPaths = append(zapConfig.OutputPaths, filepath.Join(logDir, LogFileName))
+		zapConfig.OutputPaths = append(zapConfig.OutputPaths, filepath.Join(logDir, logFileName))
 	}
 
 	// create zap logger

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -66,23 +66,26 @@ func TestGetLogger(t *testing.T) {
 		logLevel      string
 		encoding      string
 		encodingLevel func(zapcore.Level, zapcore.PrimitiveArrayEncoder)
+		logDir        string
 	}{
 		{
 			name:          "check debug log level",
 			logLevel:      "debug",
 			encoding:      "json",
 			encodingLevel: zapcore.LowercaseLevelEncoder,
+			logDir:        "",
 		},
 		{
 			name:          "check log level",
 			logLevel:      "panic",
 			encoding:      "console",
 			encodingLevel: zapcore.LowercaseLevelEncoder,
+			logDir:        "",
 		},
 	}
 
 	for _, tt := range table {
-		got := GetLogger(tt.logLevel, tt.encoding, tt.encodingLevel)
+		got := GetLogger(tt.logLevel, tt.encoding, tt.logDir, tt.encodingLevel)
 		if ce := got.Check(getLoggerLevel(tt.logLevel), "testing"); ce == nil {
 			t.Errorf("unexpected error")
 		}
@@ -91,7 +94,7 @@ func TestGetLogger(t *testing.T) {
 
 func TestGetDefaultLogger(t *testing.T) {
 	t.Run("json encoding", func(t *testing.T) {
-		Init("json", "info")
+		Init("json", "info", "")
 		got := GetDefaultLogger()
 		want := globalLogger
 		if !reflect.DeepEqual(got, want) {
@@ -99,7 +102,7 @@ func TestGetDefaultLogger(t *testing.T) {
 		}
 	})
 	t.Run("console encoding", func(t *testing.T) {
-		Init("console", "info")
+		Init("console", "info", "")
 		got := GetDefaultLogger()
 		want := globalLogger
 		if !reflect.DeepEqual(got, want) {

--- a/pkg/termcolor/writer_test.go
+++ b/pkg/termcolor/writer_test.go
@@ -1,6 +1,7 @@
 package termcolor
 
 import (
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -34,14 +35,14 @@ func buildStore() *results.ViolationStore {
 func init() {
 	res := buildStore()
 
-	w := NewColorizedWriter(&jsonData)
+	w := []io.Writer{NewColorizedWriter(&jsonData)}
 
 	err := writer.Write("json", res, w)
 	if err != nil {
 		panic(err)
 	}
 
-	w = NewColorizedWriter(&yamlData)
+	w = []io.Writer{NewColorizedWriter(&yamlData)}
 
 	err = writer.Write("yaml", res, w)
 	if err != nil {
@@ -77,7 +78,8 @@ func TestYAMLSeverityIsColorized(t *testing.T) {
 
 	res := buildStore()
 	yw := &strings.Builder{}
-	w := NewColorizedWriter(yw)
+
+	w := []io.Writer{NewColorizedWriter(yw)}
 
 	// HIGH, MEDIUM, LOW
 	testSeverity := func(sev string) {
@@ -143,7 +145,7 @@ func TestJSONSeverityIsColorized(t *testing.T) {
 
 	res := buildStore()
 	yw := &strings.Builder{}
-	w := NewColorizedWriter(yw)
+	w := []io.Writer{NewColorizedWriter(yw)}
 
 	// HIGH, MEDIUM, LOW
 	testSeverity := func(sev string) {

--- a/pkg/writer/github_sarif.go
+++ b/pkg/writer/github_sarif.go
@@ -29,6 +29,6 @@ func init() {
 }
 
 // GithubSarifWriter writes sarif formatted violation results report that are well suited for github codescanning alerts display
-func GithubSarifWriter(data interface{}, writer io.Writer) error {
-	return writeSarif(data, writer, true)
+func GithubSarifWriter(data interface{}, writers []io.Writer) error {
+	return writeSarif(data, writers, true)
 }

--- a/pkg/writer/github_sarif_test.go
+++ b/pkg/writer/github_sarif_test.go
@@ -3,10 +3,12 @@ package writer
 import (
 	"bytes"
 	"fmt"
-	"github.com/accurics/terrascan/pkg/utils"
-	"github.com/accurics/terrascan/pkg/version"
+	"io"
 	"strings"
 	"testing"
+
+	"github.com/accurics/terrascan/pkg/utils"
+	"github.com/accurics/terrascan/pkg/version"
 )
 
 const violationTemplateForGH = `{
@@ -86,11 +88,12 @@ func TestGithubSarifWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			if err := GithubSarifWriter(tt.input, writer); (err != nil) != tt.expectedError {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			if err := GithubSarifWriter(tt.input, w); (err != nil) != tt.expectedError {
 				t.Errorf("HumanReadbleWriter() error = gotErr: %v, wantErr: %v", err, tt.expectedError)
 			}
-			outputBytes := writer.Bytes()
+			outputBytes := bf.Bytes()
 			gotOutput := string(bytes.TrimSpace(outputBytes))
 
 			if equal, _ := utils.AreEqualJSON(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)); !equal {

--- a/pkg/writer/human_readable.go
+++ b/pkg/writer/human_readable.go
@@ -88,7 +88,7 @@ func init() {
 }
 
 // HumanReadbleWriter display scan summary in human readable format
-func HumanReadbleWriter(data interface{}, writer io.Writer) error {
+func HumanReadbleWriter(data interface{}, writers []io.Writer) error {
 	tmpl, err := template.New("Report").Funcs(template.FuncMap{
 		"defaultViolations":      defaultViolations,
 		"detailedViolations":     detailedViolations,
@@ -105,11 +105,14 @@ func HumanReadbleWriter(data interface{}, writer io.Writer) error {
 	buffer := bytes.Buffer{}
 	tmpl.Execute(&buffer, data)
 
-	_, err = writer.Write(buffer.Bytes())
-	if err != nil {
-		return err
+	for _, writer := range writers {
+		_, err = writer.Write(buffer.Bytes())
+		if err != nil {
+			return err
+		}
+		writer.Write([]byte{'\n'})
 	}
-	writer.Write([]byte{'\n'})
+
 	return nil
 }
 

--- a/pkg/writer/human_readable_test.go
+++ b/pkg/writer/human_readable_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
@@ -305,11 +306,12 @@ func TestHumanReadbleWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			if err := HumanReadbleWriter(tt.input, writer); (err != nil) != tt.expectedError {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			if err := HumanReadbleWriter(tt.input, w); (err != nil) != tt.expectedError {
 				t.Errorf("HumanReadbleWriter() error = gotErr: %v, wantErr: %v", err, tt.expectedError)
 			}
-			outputBytes := writer.Bytes()
+			outputBytes := bf.Bytes()
 			gotOutput := string(bytes.TrimSpace(outputBytes))
 			if !strings.EqualFold(gotOutput, strings.TrimSpace(tt.expectedOutput)) {
 				t.Errorf("HumanReadbleWriter() = got: %v, want: %v", gotOutput, tt.expectedOutput)

--- a/pkg/writer/json.go
+++ b/pkg/writer/json.go
@@ -30,9 +30,11 @@ func init() {
 }
 
 // JSONWriter prints data in JSON format
-func JSONWriter(data interface{}, writer io.Writer) error {
+func JSONWriter(data interface{}, writers []io.Writer) error {
 	j, _ := json.MarshalIndent(data, "", "  ")
-	writer.Write(j)
-	writer.Write([]byte{'\n'})
+	for _, writer := range writers {
+		writer.Write(j)
+		writer.Write([]byte{'\n'})
+	}
 	return nil
 }

--- a/pkg/writer/json_test.go
+++ b/pkg/writer/json_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
@@ -124,9 +125,10 @@ func TestJSONWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			JSONWriter(tt.input, writer)
-			if gotOutput := writer.String(); !strings.EqualFold(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)) {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			JSONWriter(tt.input, w)
+			if gotOutput := bf.String(); !strings.EqualFold(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)) {
 				t.Errorf("JSONWriter() = got: %v, want: %v", gotOutput, tt.expectedOutput)
 			}
 		})

--- a/pkg/writer/junit_xml.go
+++ b/pkg/writer/junit_xml.go
@@ -118,7 +118,7 @@ func init() {
 }
 
 // JUnitXMLWriter writes scan summary in junit xml format
-func JUnitXMLWriter(data interface{}, writer io.Writer) error {
+func JUnitXMLWriter(data interface{}, writers []io.Writer) error {
 	output, ok := data.(policy.EngineOutput)
 	if !ok {
 		return fmt.Errorf("incorrect input for JunitXML writer, supported type is policy.EngineOutput")
@@ -126,7 +126,7 @@ func JUnitXMLWriter(data interface{}, writer io.Writer) error {
 
 	junitXMLOutput := convert(output)
 
-	return XMLWriter(junitXMLOutput, writer)
+	return XMLWriter(junitXMLOutput, writers)
 }
 
 // convert is helper func to convert engine output to JUnitTestSuites

--- a/pkg/writer/junit_xml_test.go
+++ b/pkg/writer/junit_xml_test.go
@@ -19,6 +19,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -131,12 +132,13 @@ func TestJUnitXMLWriter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			if err := JUnitXMLWriter(tt.args.data, writer); (err != nil) != tt.wantErr {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			if err := JUnitXMLWriter(tt.args.data, w); (err != nil) != tt.wantErr {
 				t.Errorf("JUnitXMLWriter() got error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			if gotWriter := writer.String(); !strings.EqualFold(strings.TrimSpace(gotWriter), strings.TrimSpace(tt.wantWriter)) {
+			if gotWriter := bf.String(); !strings.EqualFold(strings.TrimSpace(gotWriter), strings.TrimSpace(tt.wantWriter)) {
 				t.Errorf("JUnitXMLWriter() got = %v, want = %v", gotWriter, tt.wantWriter)
 			}
 		})

--- a/pkg/writer/register.go
+++ b/pkg/writer/register.go
@@ -24,9 +24,9 @@ import (
 type supportedFormat string
 
 // writerMap stores mapping of supported writer formats with respective functions
-var writerMap = make(map[supportedFormat](func(interface{}, io.Writer) error))
+var writerMap = make(map[supportedFormat](func(interface{}, []io.Writer) error))
 
 // RegisterWriter registers a writer for terrascan
-func RegisterWriter(format supportedFormat, writerFunc func(interface{}, io.Writer) error) {
+func RegisterWriter(format supportedFormat, writerFunc func(interface{}, []io.Writer) error) {
 	writerMap[format] = writerFunc
 }

--- a/pkg/writer/sarif.go
+++ b/pkg/writer/sarif.go
@@ -17,15 +17,16 @@
 package writer
 
 import (
+	"io"
+	"path/filepath"
+	"strings"
+
 	"github.com/accurics/terrascan/pkg/policy"
 	"github.com/accurics/terrascan/pkg/utils"
 	"github.com/accurics/terrascan/pkg/version"
 	"github.com/go-errors/errors"
 	"github.com/owenrumney/go-sarif/sarif"
 	"go.uber.org/zap"
-	"io"
-	"path/filepath"
-	"strings"
 )
 
 const (
@@ -37,11 +38,11 @@ func init() {
 }
 
 // SarifWriter writes sarif formatted violation results report
-func SarifWriter(data interface{}, writer io.Writer) error {
-	return writeSarif(data, writer, false)
+func SarifWriter(data interface{}, writers []io.Writer) error {
+	return writeSarif(data, writers, false)
 }
 
-func writeSarif(data interface{}, writer io.Writer, forGithub bool) error {
+func writeSarif(data interface{}, writers []io.Writer, forGithub bool) error {
 	outputData := data.(policy.EngineOutput)
 	report, err := sarif.New(sarif.Version210)
 	if err != nil {
@@ -103,7 +104,8 @@ func writeSarif(data interface{}, writer io.Writer, forGithub bool) error {
 	}
 
 	// print the report to anything that implements `io.Writer`
-	return report.PrettyWrite(writer)
+	// Sarif already writes the result in a file hence we are ignoring the file output writer
+	return report.PrettyWrite(writers[0])
 }
 
 func getSarifLevel(severity string) string {

--- a/pkg/writer/sarif.go
+++ b/pkg/writer/sarif.go
@@ -103,9 +103,14 @@ func writeSarif(data interface{}, writers []io.Writer, forGithub bool) error {
 			WithLocation(location)
 	}
 
-	// print the report to anything that implements `io.Writer`
-	// Sarif already writes the result in a file hence we are ignoring the file output writer
-	return report.PrettyWrite(writers[0])
+	for _, writer := range writers {
+		// print the report to anything that implements `io.Writer`
+		err = report.PrettyWrite(writer)
+		if err != nil {
+			zap.S().Warnf("failed to write result, error :%w", err)
+		}
+	}
+	return nil
 }
 
 func getSarifLevel(severity string) string {

--- a/pkg/writer/sarif_test.go
+++ b/pkg/writer/sarif_test.go
@@ -3,6 +3,7 @@ package writer
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -153,11 +154,12 @@ func TestSarifWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			if err := SarifWriter(tt.input, writer); (err != nil) != tt.expectedError {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			if err := SarifWriter(tt.input, w); (err != nil) != tt.expectedError {
 				t.Errorf("HumanReadbleWriter() error = gotErr: %v, wantErr: %v", err, tt.expectedError)
 			}
-			outputBytes := writer.Bytes()
+			outputBytes := bf.Bytes()
 			gotOutput := string(bytes.TrimSpace(outputBytes))
 
 			if equal, _ := utils.AreEqualJSON(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)); !equal {

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -28,7 +28,7 @@ var (
 )
 
 // Write method writes in the given format using the respective writer func
-func Write(format string, data interface{}, writer io.Writer) error {
+func Write(format string, data interface{}, writers []io.Writer) error {
 
 	writerFunc, present := writerMap[supportedFormat(format)]
 	if !present {
@@ -36,5 +36,5 @@ func Write(format string, data interface{}, writer io.Writer) error {
 		return errNotSupported
 	}
 
-	return writerFunc(data, writer)
+	return writerFunc(data, writers)
 }

--- a/pkg/writer/writer_test.go
+++ b/pkg/writer/writer_test.go
@@ -2,18 +2,23 @@ package writer
 
 import (
 	"bytes"
+	"io"
 	"testing"
 )
 
 func TestWriteWithNonRegisteredWriter(t *testing.T) {
-	err := Write("test", nil, &bytes.Buffer{})
+	var bf bytes.Buffer
+	w := []io.Writer{&bf}
+	err := Write("test", nil, w)
 	if err != errNotSupported {
 		t.Errorf("Expected error = %v but got %v", errNotSupported, err)
 	}
 }
 
 func TestWriteWithRegisteredWriter(t *testing.T) {
-	err := Write("json", nil, &bytes.Buffer{})
+	var bf bytes.Buffer
+	w := []io.Writer{&bf}
+	err := Write("json", nil, w)
 	if err != nil {
 		t.Errorf("Unexpected error for json writer = %v", err)
 	}

--- a/pkg/writer/xml.go
+++ b/pkg/writer/xml.go
@@ -32,13 +32,15 @@ func init() {
 }
 
 // XMLWriter prints data in XML format
-func XMLWriter(data interface{}, writer io.Writer) error {
+func XMLWriter(data interface{}, writers []io.Writer) error {
 	j, err := xml.MarshalIndent(data, "", "  ")
 	if err != nil {
 		zap.S().Errorf("failed to write XML output. error: '%v'", err)
 		return err
 	}
-	writer.Write(j)
-	writer.Write([]byte{'\n'})
+	for _, writer := range writers {
+		writer.Write(j)
+		writer.Write([]byte{'\n'})
+	}
 	return nil
 }

--- a/pkg/writer/xml_test.go
+++ b/pkg/writer/xml_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
@@ -40,9 +41,10 @@ func TestXMLWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			XMLWriter(tt.input, writer)
-			if gotOutput := writer.String(); !strings.EqualFold(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)) {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			XMLWriter(tt.input, w)
+			if gotOutput := bf.String(); !strings.EqualFold(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)) {
 				t.Errorf("XMLWriter() = got: %v, want: %v", gotOutput, tt.expectedOutput)
 			}
 		})

--- a/pkg/writer/yaml.go
+++ b/pkg/writer/yaml.go
@@ -31,9 +31,11 @@ func init() {
 }
 
 // YAMLWriter prints data in YAML format
-func YAMLWriter(data interface{}, writer io.Writer) error {
+func YAMLWriter(data interface{}, writers []io.Writer) error {
 	j, _ := yaml.Marshal(data)
-	writer.Write(j)
-	writer.Write([]byte{'\n'})
+	for _, writer := range writers {
+		writer.Write(j)
+		writer.Write([]byte{'\n'})
+	}
 	return nil
 }

--- a/pkg/writer/yaml_test.go
+++ b/pkg/writer/yaml_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
@@ -183,9 +184,10 @@ func TestYAMLWriter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &bytes.Buffer{}
-			YAMLWriter(tt.input, writer)
-			if gotOutput := writer.String(); !strings.EqualFold(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)) {
+			var bf bytes.Buffer
+			w := []io.Writer{&bf}
+			YAMLWriter(tt.input, w)
+			if gotOutput := bf.String(); !strings.EqualFold(strings.TrimSpace(gotOutput), strings.TrimSpace(tt.expectedOutput)) {
 				t.Errorf("YAMLWriter() = got: %v, want: %v", gotOutput, tt.expectedOutput)
 			}
 		})

--- a/test/e2e/help/golden/help_command.txt
+++ b/test/e2e/help/golden/help_command.txt
@@ -19,7 +19,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_command.txt
+++ b/test/e2e/help/golden/help_command.txt
@@ -1,7 +1,7 @@
 Terrascan
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
-For more information, please visit https://docs.accurics.com
+For more information, please visit https://runterrascan.io/
 
 Usage:
   terrascan [command]

--- a/test/e2e/help/golden/help_command.txt
+++ b/test/e2e/help/golden/help_command.txt
@@ -14,12 +14,12 @@ Available Commands:
   version     Terrascan version
 
 Flags:
-  -c, --config-path string   config file path
-  -h, --help                 help for terrascan
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -h, --help                    help for terrascan
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_command.txt
+++ b/test/e2e/help/golden/help_command.txt
@@ -19,6 +19,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_flag.txt
+++ b/test/e2e/help/golden/help_flag.txt
@@ -17,6 +17,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_flag.txt
+++ b/test/e2e/help/golden/help_flag.txt
@@ -13,11 +13,12 @@ Available Commands:
   version     Terrascan version
 
 Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -h, --help                    help for terrascan
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_flag.txt
+++ b/test/e2e/help/golden/help_flag.txt
@@ -1,7 +1,7 @@
 Terrascan
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
-For more information, please visit https://docs.accurics.com
+For more information, please visit https://runterrascan.io/
 
 Usage:
   terrascan [command]
@@ -17,7 +17,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_flag.txt
+++ b/test/e2e/help/golden/help_flag.txt
@@ -14,7 +14,6 @@ Available Commands:
 
 Flags:
   -c, --config-path string      config file path
-  -h, --help                    help for terrascan
   -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
       --log-output-dir string   directory path to write the log and output files
   -x, --log-type string         log output type (console, json) (default "console")

--- a/test/e2e/help/golden/help_init.txt
+++ b/test/e2e/help/golden/help_init.txt
@@ -13,5 +13,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_init.txt
+++ b/test/e2e/help/golden/help_init.txt
@@ -13,4 +13,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_init.txt
+++ b/test/e2e/help/golden/help_init.txt
@@ -9,9 +9,9 @@ Flags:
   -h, --help   help for init
 
 Global Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_scan.txt
+++ b/test/e2e/help/golden/help_scan.txt
@@ -37,4 +37,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_scan.txt
+++ b/test/e2e/help/golden/help_scan.txt
@@ -33,9 +33,9 @@ Flags:
       --webhook-url string        webhook URL where Terrascan will send JSON scan report and normalized IaC JSON
 
 Global Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_scan.txt
+++ b/test/e2e/help/golden/help_scan.txt
@@ -37,5 +37,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_server.txt
+++ b/test/e2e/help/golden/help_server.txt
@@ -12,9 +12,9 @@ Flags:
   -p, --port string        server port (default "9010")
 
 Global Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_server.txt
+++ b/test/e2e/help/golden/help_server.txt
@@ -16,4 +16,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_server.txt
+++ b/test/e2e/help/golden/help_server.txt
@@ -16,5 +16,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_unsupported_command.txt
+++ b/test/e2e/help/golden/help_unsupported_command.txt
@@ -10,11 +10,12 @@ Available Commands:
   version     Terrascan version
 
 Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -h, --help                    help for terrascan
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_unsupported_command.txt
+++ b/test/e2e/help/golden/help_unsupported_command.txt
@@ -14,6 +14,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_unsupported_command.txt
+++ b/test/e2e/help/golden/help_unsupported_command.txt
@@ -14,7 +14,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/help_unsupported_command.txt
+++ b/test/e2e/help/golden/help_unsupported_command.txt
@@ -11,7 +11,6 @@ Available Commands:
 
 Flags:
   -c, --config-path string      config file path
-  -h, --help                    help for terrascan
   -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
       --log-output-dir string   directory path to write the log and output files
   -x, --log-type string         log output type (console, json) (default "console")

--- a/test/e2e/help/golden/help_version.txt
+++ b/test/e2e/help/golden/help_version.txt
@@ -13,5 +13,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_version.txt
+++ b/test/e2e/help/golden/help_version.txt
@@ -13,4 +13,5 @@ Global Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/help_version.txt
+++ b/test/e2e/help/golden/help_version.txt
@@ -9,9 +9,9 @@ Flags:
   -h, --help   help for version
 
 Global Flags:
-  -c, --config-path string   config file path
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates

--- a/test/e2e/help/golden/no_command.txt
+++ b/test/e2e/help/golden/no_command.txt
@@ -19,7 +19,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/no_command.txt
+++ b/test/e2e/help/golden/no_command.txt
@@ -1,7 +1,7 @@
 Terrascan
 
 Detect compliance and security violations across Infrastructure as Code to mitigate risk before provisioning cloud native infrastructure.
-For more information, please visit https://docs.accurics.com
+For more information, please visit https://runterrascan.io/
 
 Usage:
   terrascan [command]

--- a/test/e2e/help/golden/no_command.txt
+++ b/test/e2e/help/golden/no_command.txt
@@ -14,12 +14,12 @@ Available Commands:
   version     Terrascan version
 
 Flags:
-  -c, --config-path string   config file path
-  -h, --help                 help for terrascan
-  -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
-  -x, --log-type string      log output type (console, json) (default "console")
-  -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
-      --output-dir string    directory path to over-write the default logs and output files ( default directory is user home directory)
-      --temp-dir string      temporary directory path to download remote repository,module and templates
+  -c, --config-path string      config file path
+  -h, --help                    help for terrascan
+  -l, --log-level string        log level (debug, info, warn, error, panic, fatal) (default "info")
+      --log-output-dir string   directory path to write the log and output files
+  -x, --log-type string         log output type (console, json) (default "console")
+  -o, --output string           output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --temp-dir string         temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/help/golden/no_command.txt
+++ b/test/e2e/help/golden/no_command.txt
@@ -19,6 +19,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml, junit-xml, sarif, github-sarif) (default "human")
+      --output-dir string    directory path to over-write the default logs and output files ( default directory is user's home directory)
       --temp-dir string      temporary directory path to download remote repository,module and templates
 
 Use "terrascan [command] --help" for more information about a command.

--- a/test/e2e/scan/scan_test.go
+++ b/test/e2e/scan/scan_test.go
@@ -376,4 +376,98 @@ var _ = Describe("Scan", func() {
 			})
 		})
 	})
+	Describe("terrascan scan, write logs and results in file", func() {
+		Context("terrascan scan command is run with --log-output-dir flag", func() {
+			It("should scan and use the directory path to write the logs and result", func() {
+				logOutputdir := "/tmp/terrascan"
+				logFile := filepath.Join(logOutputdir, "terrascan.log")
+				resultFile := filepath.Join(logOutputdir, "scan-result.txt")
+
+				iacDir, err1 := filepath.Abs(filepath.Join(awsIacRelPath, "aws_ami_violation"))
+				Expect(err1).NotTo(HaveOccurred())
+				scanArgs := []string{"scan", "-d", iacDir, "--log-output-dir", logOutputdir}
+				session := helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				Eventually(session, 3).Should(gexec.Exit(helper.ExitCodeFive))
+				_, err := os.Stat(logFile)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = os.Stat(resultFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				// clean up
+				os.RemoveAll(logOutputdir)
+			})
+			It("should scan and use the directory path to write the logs and result in json file", func() {
+				logOutputdir := "/tmp/terrascan"
+				logFile := filepath.Join(logOutputdir, "terrascan.log")
+				resultFile := filepath.Join(logOutputdir, "scan-result.json")
+
+				iacDir, err1 := filepath.Abs(filepath.Join(awsIacRelPath, "aws_ami_violation"))
+				Expect(err1).NotTo(HaveOccurred())
+				scanArgs := []string{"scan", "-d", iacDir, "--log-output-dir", logOutputdir, "-o", "json"}
+				session := helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				Eventually(session, 3).Should(gexec.Exit(helper.ExitCodeFive))
+				_, err := os.Stat(logFile)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = os.Stat(resultFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				// clean up
+				os.RemoveAll(logOutputdir)
+			})
+			It("should scan and use the directory path to write the logs and result in yaml file", func() {
+				logOutputdir := "/tmp/terrascan"
+				logFile := filepath.Join(logOutputdir, "terrascan.log")
+				resultFile := filepath.Join(logOutputdir, "scan-result.yaml")
+
+				iacDir, err1 := filepath.Abs(filepath.Join(awsIacRelPath, "aws_ami_violation"))
+				Expect(err1).NotTo(HaveOccurred())
+				scanArgs := []string{"scan", "-d", iacDir, "--log-output-dir", logOutputdir, "-o", "yaml"}
+				session := helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				Eventually(session, 3).Should(gexec.Exit(helper.ExitCodeFive))
+				_, err := os.Stat(logFile)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = os.Stat(resultFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				// clean up
+				os.RemoveAll(logOutputdir)
+			})
+			It("should scan and use the directory path to write the logs and result in xml file", func() {
+				logOutputdir := "/tmp/terrascan"
+				logFile := filepath.Join(logOutputdir, "terrascan.log")
+				resultFile := filepath.Join(logOutputdir, "scan-result.xml")
+
+				iacDir, err1 := filepath.Abs(filepath.Join(awsIacRelPath, "aws_ami_violation"))
+				Expect(err1).NotTo(HaveOccurred())
+				scanArgs := []string{"scan", "-d", iacDir, "--log-output-dir", logOutputdir, "-o", "xml"}
+				session := helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				Eventually(session, 3).Should(gexec.Exit(helper.ExitCodeFive))
+				_, err := os.Stat(logFile)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = os.Stat(resultFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				// clean up
+				os.RemoveAll(logOutputdir)
+			})
+			It("should scan and use the directory path to write the logs and result in sarif file", func() {
+				logOutputdir := "/tmp/terrascan"
+				logFile := filepath.Join(logOutputdir, "terrascan.log")
+				resultFile := filepath.Join(logOutputdir, "scan-result.sarif")
+
+				iacDir, err1 := filepath.Abs(filepath.Join(awsIacRelPath, "aws_ami_violation"))
+				Expect(err1).NotTo(HaveOccurred())
+				scanArgs := []string{"scan", "-d", iacDir, "--log-output-dir", logOutputdir, "-o", "sarif"}
+				session := helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				Eventually(session, 3).Should(gexec.Exit(helper.ExitCodeFive))
+				_, err := os.Stat(logFile)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = os.Stat(resultFile)
+				Expect(err).NotTo(HaveOccurred())
+
+				// clean up
+				os.RemoveAll(logOutputdir)
+			})
+		})
+	})
 })


### PR DESCRIPTION
1. We can use `--log-output-dir` flag if we want to write the log and scan results in files
2. The log file will get appended while the scan output will be overwritten.
3. The format of the scan output file will be in sync with `-o` flag input
4. For now we will support output writing for every format except sarif (as sarif already writes the result to a file and this will require considering the file locations field in the sarif output)